### PR TITLE
Implement JsonSerializable on value classes

### DIFF
--- a/src/DayOfWeek.php
+++ b/src/DayOfWeek.php
@@ -9,7 +9,7 @@ namespace Brick\DateTime;
  *
  * This class is immutable.
  */
-class DayOfWeek
+class DayOfWeek implements \JsonSerializable
 {
     public const MONDAY    = 1;
     public const TUESDAY   = 2;
@@ -237,6 +237,16 @@ class DayOfWeek
     public function minus(int $days) : DayOfWeek
     {
         return $this->plus(- $days);
+    }
+
+    /**
+     * Serializes as a string using {@see DayOfWeek::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -13,7 +13,7 @@ use ArithmeticError;
  *
  * This class is immutable.
  */
-class Duration
+class Duration implements \JsonSerializable
 {
     /**
      * The duration in seconds.
@@ -874,6 +874,16 @@ class Duration
     public function toNanosPart() : int
     {
         return $this->nanos;
+    }
+
+    /**
+     * Serializes as a string using {@see Duration::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -13,7 +13,7 @@ use Brick\DateTime\Field\NanoOfSecond;
  * without any calendar concept of date, time or time zone. It is not very meaningful to humans,
  * but can be converted to a `ZonedDateTime` by providing a time zone.
  */
-class Instant
+class Instant implements \JsonSerializable
 {
     /**
      * The number of seconds since the epoch of 1970-01-01T00:00:00Z.
@@ -452,6 +452,16 @@ class Instant
         }
 
         return $result;
+    }
+
+    /**
+     * Serializes as a string using {@see Instant::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -10,7 +10,7 @@ namespace Brick\DateTime;
  *
  * This class is immutable.
  */
-class Interval
+class Interval implements \JsonSerializable
 {
     /**
      * The start instant, inclusive.
@@ -100,6 +100,16 @@ class Interval
     public function getDuration() : Duration
     {
         return Duration::between($this->start, $this->end);
+    }
+
+    /**
+     * Serializes as a string using {@see Interval::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -15,7 +15,7 @@ use Brick\DateTime\Utility\Math;
  *
  * This class is immutable.
  */
-class LocalDate
+class LocalDate implements \JsonSerializable
 {
     /**
      * The minimum supported year for instances of `LocalDate`, -999,999.
@@ -853,6 +853,16 @@ class LocalDate
         }
 
         return new LocalDate($year, $month, $day);
+    }
+
+    /**
+     * Serializes as a string using {@see LocalDate::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -15,7 +15,7 @@ use Brick\DateTime\Parser\IsoParsers;
  * This object is iterable and countable: the iterator returns all the LocalDate objects contained
  * in the range, while `count()` returns the total number of dates contained in the range.
  */
-class LocalDateRange implements \IteratorAggregate, \Countable
+class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSerializable
 {
     /**
      * The start date, inclusive.
@@ -182,6 +182,16 @@ class LocalDateRange implements \IteratorAggregate, \Countable
     public function count() : int
     {
         return $this->endDate->toEpochDay() - $this->startDate->toEpochDay() + 1;
+    }
+
+    /**
+     * Serializes as a string using {@see LocalDateRange::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -15,7 +15,7 @@ use Brick\DateTime\Utility\Math;
  *
  * This class is immutable.
  */
-class LocalDateTime
+class LocalDateTime implements \JsonSerializable
 {
     /**
      * @var LocalDate
@@ -947,6 +947,16 @@ class LocalDateTime
     public function toDateTimeImmutable() : \DateTimeImmutable
     {
         return \DateTimeImmutable::createFromMutable($this->toDateTime());
+    }
+
+    /**
+     * Serializes as a string using {@see LocalDateTime::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -18,7 +18,7 @@ use Brick\DateTime\Utility\Math;
  *
  * This class is immutable.
  */
-class LocalTime
+class LocalTime implements \JsonSerializable
 {
     public const MONTHS_PER_YEAR    = 12;
     public const DAYS_PER_WEEK      = 7;
@@ -705,6 +705,16 @@ class LocalTime
     public function toDateTimeImmutable() : \DateTimeImmutable
     {
         return \DateTimeImmutable::createFromMutable($this->toDateTime());
+    }
+
+    /**
+     * Serializes as a string using {@see LocalTime::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/Month.php
+++ b/src/Month.php
@@ -7,7 +7,7 @@ namespace Brick\DateTime;
 /**
  * Represents a month-of-year such as January.
  */
-class Month
+class Month implements \JsonSerializable
 {
     public const JANUARY   = 1;
     public const FEBRUARY  = 2;
@@ -261,6 +261,16 @@ class Month
     public function minus(int $months) : Month
     {
         return $this->plus(- $months);
+    }
+
+    /**
+     * Serializes as a string using {@see Month::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/MonthDay.php
+++ b/src/MonthDay.php
@@ -12,7 +12,7 @@ use Brick\DateTime\Parser\IsoParsers;
 /**
  * A month-day in the ISO-8601 calendar system, such as `--12-03`.
  */
-class MonthDay
+class MonthDay implements \JsonSerializable
 {
     /**
      * The month-of-year, from 1 to 12.
@@ -271,6 +271,16 @@ class MonthDay
     public function atYear(int $year) : LocalDate
     {
         return LocalDate::of($year, $this->month, $this->isValidYear($year) ? $this->day : 28);
+    }
+
+    /**
+     * Serializes as a string using {@see MonthDay::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/Period.php
+++ b/src/Period.php
@@ -9,7 +9,7 @@ namespace Brick\DateTime;
  *
  * This class is immutable.
  */
-class Period
+class Period implements \JsonSerializable
 {
     /**
      * @var int
@@ -438,6 +438,16 @@ class Period
             $this->months,
             $this->days
         ));
+    }
+
+    /**
+     * Serializes as a string using {@see Period::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/Year.php
+++ b/src/Year.php
@@ -9,7 +9,7 @@ use Brick\DateTime\Field;
 /**
  * Represents a year in the proleptic calendar.
  */
-class Year
+class Year implements \JsonSerializable
 {
     public const MIN_VALUE = LocalDate::MIN_YEAR;
     public const MAX_VALUE = LocalDate::MAX_YEAR;
@@ -251,6 +251,16 @@ class Year
     public function atMonthDay(MonthDay $monthDay) : LocalDate
     {
         return $monthDay->atYear($this->year);
+    }
+
+    /**
+     * Serializes as a string using {@see Year::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -13,7 +13,7 @@ use Brick\DateTime\Utility\Math;
 /**
  * Represents the combination of a year and a month.
  */
-class YearMonth
+class YearMonth implements \JsonSerializable
 {
     /**
      * The year, from MIN_YEAR to MAX_YEAR.
@@ -362,6 +362,16 @@ class YearMonth
     public function minusMonths(int $months) : YearMonth
     {
         return $this->plusMonths(- $months);
+    }
+
+    /**
+     * Serializes as a string using {@see YearMonth::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/YearMonthRange.php
+++ b/src/YearMonthRange.php
@@ -15,7 +15,7 @@ use Brick\DateTime\Parser\IsoParsers;
  * This object is iterable and countable: the iterator returns all the YearMonth objects contained
  * in the range, while `count()` returns the total number of year-months contained in the range.
  */
-class YearMonthRange implements \IteratorAggregate, \Countable
+class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializable
 {
     /**
      * The start year-month, inclusive.
@@ -178,6 +178,16 @@ class YearMonthRange implements \IteratorAggregate, \Countable
         return 12 * ($this->end->getYear() - $this->start->getYear())
             + ($this->end->getMonth() - $this->start->getMonth())
             + 1;
+    }
+
+    /**
+     * Serializes as a string using {@see YearMonthRange::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -7,7 +7,7 @@ namespace Brick\DateTime;
 /**
  * Represents the combination of a year and a week.
  */
-class YearWeek
+class YearWeek implements \JsonSerializable
 {
     /**
      * The year, from MIN_YEAR to MAX_YEAR.
@@ -328,6 +328,16 @@ class YearWeek
     public function is53WeekYear() : bool
     {
         return Field\WeekOfYear::is53WeekYear($this->year);
+    }
+
+    /**
+     * Serializes as a string using {@see YearWeek::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -15,7 +15,7 @@ use Brick\DateTime\Parser\IsoParsers;
  * A ZonedDateTime can be viewed as a LocalDateTime along with a time zone
  * and targets a specific point in time.
  */
-class ZonedDateTime
+class ZonedDateTime implements \JsonSerializable
 {
     /**
      * The local date-time.
@@ -917,6 +917,16 @@ class ZonedDateTime
     public function toDateTimeImmutable() : \DateTimeImmutable
     {
         return \DateTimeImmutable::createFromMutable($this->toDateTime());
+    }
+
+    /**
+     * Serializes as a string using {@see ZonedDateTime::__toString()}.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
+    {
+        return (string) $this;
     }
 
     /**

--- a/tests/DayOfWeekTest.php
+++ b/tests/DayOfWeekTest.php
@@ -252,6 +252,17 @@ class DayOfWeekTest extends AbstractTestCase
      * @param int    $dayOfWeek    The day-of-week value, from 1 to 7.
      * @param string $expectedName The expected name.
      */
+    public function testJsonSerialize(int $dayOfWeek, string $expectedName)
+    {
+        $this->assertSame(json_encode($expectedName), json_encode(DayOfWeek::of($dayOfWeek)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $dayOfWeek    The day-of-week value, from 1 to 7.
+     * @param string $expectedName The expected name.
+     */
     public function testToString(int $dayOfWeek, string $expectedName)
     {
         $this->assertSame($expectedName, (string) DayOfWeek::of($dayOfWeek));
@@ -272,4 +283,5 @@ class DayOfWeekTest extends AbstractTestCase
             [DayOfWeek::SUNDAY,    'Sunday']
         ];
     }
+
 }

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -1496,6 +1496,18 @@ class DurationTest extends AbstractTestCase
      * @param int    $nanos
      * @param string $expected
      */
+    public function testJsonSerialize(int $seconds, int $nanos, string $expected)
+    {
+        $this->assertSame(json_encode($expected), json_encode(Duration::ofSeconds($seconds, $nanos)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $seconds
+     * @param int    $nanos
+     * @param string $expected
+     */
     public function testToString(int $seconds, int $nanos, string $expected)
     {
         $this->assertSame($expected, (string) Duration::ofSeconds($seconds, $nanos));

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -640,6 +640,18 @@ class InstantTest extends AbstractTestCase
      * @param int    $nano           The nano adjustment to the epoch second.
      * @param string $expectedString The expected string output.
      */
+    public function testJsonSerialize(int $epochSecond, int $nano, string $expectedString)
+    {
+        $this->assertSame(json_encode($expectedString), json_encode(Instant::of($epochSecond, $nano)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $epochSecond    The epoch second to test.
+     * @param int    $nano           The nano adjustment to the epoch second.
+     * @param string $expectedString The expected string output.
+     */
     public function testToString(int $epochSecond, int $nano, string $expectedString)
     {
         $this->assertSame($expectedString, (string) Instant::of($epochSecond, $nano));

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -93,6 +93,16 @@ class IntervalTest extends AbstractTestCase
         $this->assertDurationIs(1, 999444556, $duration);
     }
 
+    public function testJsonSerialize()
+    {
+        $interval = new Interval(
+            Instant::of(1000000000),
+            Instant::of(2000000000)
+        );
+
+        $this->assertSame(json_encode('2001-09-09T01:46:40Z/2033-05-18T03:33:20Z'), json_encode($interval));
+    }
+
     public function testToString()
     {
         $interval = new Interval(

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -202,6 +202,14 @@ class LocalDateRangeTest extends AbstractTestCase
         ];
     }
 
+    public function testJsonSerialize()
+    {
+        $this->assertSame(json_encode('2008-12-31/2011-01-01'), json_encode(LocalDateRange::of(
+            LocalDate::of(2008, 12, 31),
+            LocalDate::of(2011, 1, 1)
+        )));
+    }
+
     public function testToString()
     {
         $this->assertSame('2008-12-31/2011-01-01', (string) LocalDateRange::of(

--- a/tests/LocalDateTest.php
+++ b/tests/LocalDateTest.php
@@ -1270,6 +1270,19 @@ class LocalDateTest extends AbstractTestCase
      * @param int    $day      The day-of-month.
      * @param string $expected The expected result string.
      */
+    public function testJsonSerialize(int $year, int $month, int $day, string $expected)
+    {
+        $this->assertSame(json_encode($expected), json_encode(LocalDate::of($year, $month, $day)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $year     The year.
+     * @param int    $month    The month.
+     * @param int    $day      The day-of-month.
+     * @param string $expected The expected result string.
+     */
     public function testToString(int $year, int $month, int $day, string $expected)
     {
         $this->assertSame($expected, (string) LocalDate::of($year, $month, $day));

--- a/tests/LocalDateTimeTest.php
+++ b/tests/LocalDateTimeTest.php
@@ -1338,4 +1338,45 @@ class LocalDateTimeTest extends AbstractTestCase
             ['2011-07-31T23:59:59.000123456', '2011-07-31T23:59:59.000123+0000'],
         ];
     }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $year     The year.
+     * @param int    $month    The month.
+     * @param int    $day      The day-of-month.
+     * @param string $expected The expected result string.
+     */
+    public function testJsonSerialize(int $year, int $month, int $day, int $hour, int $minute, int $second, int $nano, string $expected)
+    {
+        $this->assertSame(json_encode($expected), json_encode(LocalDateTime::of($year, $month, $day, $hour, $minute, $second, $nano)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $year     The year.
+     * @param int    $month    The month.
+     * @param int    $day      The day-of-month.
+     * @param string $expected The expected result string.
+     */
+    public function testToString(int $year, int $month, int $day, int $hour, int $minute, int $second, int $nano, string $expected)
+    {
+        $this->assertSame($expected, (string) LocalDateTime::of($year, $month, $day, $hour, $minute, $second, $nano));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerToString() : array
+    {
+        return [
+            [999, 1, 2, 1, 2, 0, 0, '0999-01-02T01:02'],
+            [-999, 1, 2, 1, 2, 3, 0, '-0999-01-02T01:02:03'],
+            [1970, 1, 1, 1, 2, 3, 4, '1970-01-01T01:02:03.000000004'],
+            [-1970, 1, 1, 1, 2, 0, 3, '-1970-01-01T01:02:00.000000003'],
+            [1, 2, 3, 12, 34, 56, 789000000, '0001-02-03T12:34:56.789'],
+            [-1, 2, 3, 12, 34, 56, 78900000, '-0001-02-03T12:34:56.0789'],
+        ];
+    }
 }

--- a/tests/LocalTimeTest.php
+++ b/tests/LocalTimeTest.php
@@ -1113,6 +1113,20 @@ class LocalTimeTest extends AbstractTestCase
      * @param int    $n The nanosecond.
      * @param string $r The expected result.
      */
+    public function testJsonSerialize(int $h, int $m, int $s, int $n, string $r)
+    {
+        $this->assertSame(json_encode($r), json_encode(LocalTime::of($h, $m, $s, $n)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $h The hour.
+     * @param int    $m The minute.
+     * @param int    $s The second.
+     * @param int    $n The nanosecond.
+     * @param string $r The expected result.
+     */
     public function testToString(int $h, int $m, int $s, int $n, string $r)
     {
         $this->assertSame($r, (string) LocalTime::of($h, $m, $s, $n));

--- a/tests/MonthDayTest.php
+++ b/tests/MonthDayTest.php
@@ -521,6 +521,18 @@ class MonthDayTest extends AbstractTestCase
      * @param int    $day    The day of the month-day to test.
      * @param string $string The expected result string.
      */
+    public function testJsonSerialize(int $month, int $day, string $string)
+    {
+        $this->assertSame(json_encode($string), json_encode(MonthDay::of($month, $day)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $month  The month of the month-day to test.
+     * @param int    $day    The day of the month-day to test.
+     * @param string $string The expected result string.
+     */
     public function testToString(int $month, int $day, string $string)
     {
         $this->assertSame($string, (string) MonthDay::of($month, $day));

--- a/tests/MonthTest.php
+++ b/tests/MonthTest.php
@@ -316,6 +316,17 @@ class MonthTest extends AbstractTestCase
      * @param int    $month        The month number.
      * @param string $expectedName The expected month name.
      */
+    public function testJsonSerialize(int $month, string $expectedName)
+    {
+        $this->assertSame(json_encode($expectedName), json_encode(Month::of($month)));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $month        The month number.
+     * @param string $expectedName The expected month name.
+     */
     public function testToString(int $month, string $expectedName)
     {
         $this->assertSame($expectedName, (string) Month::of($month));

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -339,7 +339,20 @@ class PeriodTest extends AbstractTestCase
     }
 
     /**
-     * *@dataProvider providerToString
+     * @dataProvider providerToString
+     *
+     * @param int    $years    The number of years in the period.
+     * @param int    $months   The number of months in the period.
+     * @param int    $days     The number of days in the period.
+     * @param string $expected The expected string output.
+     */
+    public function testJsonSerialize(int $years, int $months, int $days, string $expected)
+    {
+        $this->assertSame(json_encode($expected), json_encode(Period::of($years, $months, $days)));
+    }
+
+    /**
+     * @dataProvider providerToString
      *
      * @param int    $years    The number of years in the period.
      * @param int    $months   The number of months in the period.

--- a/tests/YearMonthRangeTest.php
+++ b/tests/YearMonthRangeTest.php
@@ -194,6 +194,14 @@ class YearMonthRangeTest extends AbstractTestCase
         ];
     }
 
+    public function testJsonSerialize()
+    {
+        $this->assertSame(json_encode('2008-12/2011-01'), json_encode(YearMonthRange::of(
+            YearMonth::of(2008, 12),
+            YearMonth::of(2011, 1)
+        )));
+    }
+
     public function testToString()
     {
         $this->assertSame('2008-12/2011-01', (string) YearMonthRange::of(

--- a/tests/YearMonthTest.php
+++ b/tests/YearMonthTest.php
@@ -505,6 +505,11 @@ class YearMonthTest extends AbstractTestCase
         ];
     }
 
+    public function testJsonSerialize()
+    {
+        $this->assertSame(json_encode('2013-09'), json_encode(YearMonth::of(2013, 9)));
+    }
+
     public function testToString()
     {
         $this->assertSame('2013-09', (string) YearMonth::of(2013, 9));

--- a/tests/YearTest.php
+++ b/tests/YearTest.php
@@ -479,6 +479,11 @@ class YearTest extends AbstractTestCase
         ];
     }
 
+    public function testJsonSerialize()
+    {
+        $this->assertSame(json_encode('1987'), json_encode(Year::of(1987)));
+    }
+
     public function testToString()
     {
         $this->assertSame('1987', (string) Year::of(1987));

--- a/tests/YearWeekTest.php
+++ b/tests/YearWeekTest.php
@@ -403,6 +403,19 @@ class YearWeekTest extends AbstractTestCase
      * @param int    $week
      * @param string $expected
      */
+    public function testJsonSerialize(int $year, int $week, string $expected)
+    {
+        $yearWeek = YearWeek::of($year, $week);
+        $this->assertSame(json_encode($expected), json_encode($yearWeek));
+    }
+
+    /**
+     * @dataProvider providerToString
+     *
+     * @param int    $year
+     * @param int    $week
+     * @param string $expected
+     */
     public function testToString(int $year, int $week, string $expected)
     {
         $yearWeek = YearWeek::of($year, $week);

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -827,6 +827,16 @@ class ZonedDateTimeTest extends AbstractTestCase
         ];
     }
 
+    public function testJsonSerialize()
+    {
+        $timeZone = TimeZone::parse('America/Los_Angeles');
+        $localDateTime = '2000-01-20T12:34:56.123456789';
+        $localDateTime = LocalDateTime::parse($localDateTime);
+        $zonedDateTime = ZonedDateTime::of($localDateTime, $timeZone);
+
+        $this->assertSame(json_encode('2000-01-20T12:34:56.123456789-08:00[America/Los_Angeles]'), json_encode($zonedDateTime));
+    }
+
     public function testToString()
     {
         $timeZone = TimeZone::parse('America/Los_Angeles');


### PR DESCRIPTION
Implement the interface `JsonSerializable` on value classes inside `src/`.

The implementation is dead simple: I just reuse the `__toString()` of each class.

The tests are using the `providerToString` providers as well. I am not sure about this ; do I create a new provider for each one instead?

In addition, I added a `testToString` test for `LocalDateTimeTest`.