### PR TITLE
Add LocalDateRange::isIntersect method

### DIFF
--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -178,6 +178,24 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     }
 
     /**
+     * Returns intersection this LocalDateRange with the given date range, exception if ranges do not intersect
+     *
+     * @param LocalDateRange $that
+     *
+     * @return LocalDateRange
+     */
+    public function getIntersection(LocalDateRange $that) : LocalDateRange
+    {
+        if (!$this->isIntersect($that)) {
+            throw new DateTimeException('Ranges "' . $this . '" and "' . $that . '" do not intersect');
+        }
+
+        $intersectStart = $this->start->isBefore($that->start) ? $that->start : $this->start;
+        $intersectEnd = $this->end->isAfter($that->end) ? $that->end: $this->end;
+        return new LocalDateRange($intersectStart, $intersectEnd);
+    }
+
+    /**
      * Returns an iterator for all the dates contained in this range.
      *
      * @return LocalDate[]
@@ -218,4 +236,5 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     {
         return $this->start . '/' . $this->end;
     }
+
 }

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -163,6 +163,21 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     }
 
     /**
+     * Returns whether this LocalDateRange intersect with the given date range.
+     *
+     * @param LocalDateRange $that
+     *
+     * @return bool
+     */
+    public function isIntersect(LocalDateRange $that) : bool
+    {
+        return $this->contains($that->start)
+            || $this->contains($that->end)
+            || $that->contains($this->start)
+            || $that->contains($this->end);
+    }
+
+    /**
      * Returns an iterator for all the dates contained in this range.
      *
      * @return LocalDate[]

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -169,7 +169,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      *
      * @return bool
      */
-    public function isIntersect(LocalDateRange $that) : bool
+    public function intersectsWith(LocalDateRange $that) : bool
     {
         return $this->contains($that->start)
             || $this->contains($that->end)
@@ -184,9 +184,9 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      *
      * @return LocalDateRange
      */
-    public function getIntersection(LocalDateRange $that) : LocalDateRange
+    public function getIntersectionWith(LocalDateRange $that) : LocalDateRange
     {
-        if (!$this->isIntersect($that)) {
+        if (!$this->intersectsWith($that)) {
             throw new DateTimeException('Ranges "' . $this . '" and "' . $that . '" do not intersect');
         }
 

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -220,22 +220,22 @@ class LocalDateRangeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider providerIsIntersect
+     * @dataProvider providerIntersectsWith
      *
      * @param string $a
      * @param string $b
      * @param bool $expectedResult
      */
-    public function testIsIntersect(string $a, string $b, bool $expectedResult)
+    public function testIntersectsWith(string $a, string $b, bool $expectedResult)
     {
         $aRange = LocalDateRange::parse($a);
         $bRange = LocalDateRange::parse($b);
 
-        $this->assertSame($expectedResult, $aRange->isIntersect($bRange));
-        $this->assertSame($expectedResult, $bRange->isIntersect($aRange));
+        $this->assertSame($expectedResult, $aRange->intersectsWith($bRange));
+        $this->assertSame($expectedResult, $bRange->intersectsWith($aRange));
     }
 
-    public function providerIsIntersect() : array
+    public function providerIntersectsWith() : array
     {
         return [
             ['2010-01-01/2010-01-01', '2010-01-01/2010-01-01', true],
@@ -248,22 +248,22 @@ class LocalDateRangeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider providerGetIntersection
+     * @dataProvider providerGetIntersectionWith
      *
      * @param string $a
      * @param string $b
      * @param string $expectedIntersection
      */
-    public function testGetIntersection(string $a, string $b, string $expectedIntersection)
+    public function testGetIntersectionWith(string $a, string $b, string $expectedIntersection)
     {
         $aRange = LocalDateRange::parse($a);
         $bRange = LocalDateRange::parse($b);
 
-        $this->assertSame($expectedIntersection, (string)$aRange->getIntersection($bRange));
-        $this->assertSame($expectedIntersection, (string)$bRange->getIntersection($aRange));
+        $this->assertSame($expectedIntersection, (string)$aRange->getIntersectionWith($bRange));
+        $this->assertSame($expectedIntersection, (string)$bRange->getIntersectionWith($aRange));
     }
 
-    public function providerGetIntersection() : array
+    public function providerGetIntersectionWith() : array
     {
         return [
             ['2010-01-01/2010-01-01', '2010-01-01/2010-01-01', '2010-01-01/2010-01-01'],
@@ -280,6 +280,6 @@ class LocalDateRangeTest extends AbstractTestCase
         $aRange = LocalDateRange::parse('2010-01-01/2010-03-01');
         $bRange = LocalDateRange::parse('2033-01-02/2033-01-02');
 
-        $aRange->getIntersection($bRange);
+        $aRange->getIntersectionWith($bRange);
     }
 }

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -217,4 +217,32 @@ class LocalDateRangeTest extends AbstractTestCase
             LocalDate::of(2011, 1, 1)
         ));
     }
+
+    /**
+     * @dataProvider providerIsIntersect
+     *
+     * @param string $a
+     * @param string $b
+     * @param bool $expectedResult
+     */
+    public function testIsIntersect(string $a, string $b, bool $expectedResult)
+    {
+        $aRange = LocalDateRange::parse($a);
+        $bRange = LocalDateRange::parse($b);
+
+        $this->assertSame($expectedResult, $aRange->isIntersect($bRange));
+        $this->assertSame($expectedResult, $bRange->isIntersect($aRange));
+    }
+
+    public function providerIsIntersect() : array
+    {
+        return [
+            ['2010-01-01/2010-01-01', '2010-01-01/2010-01-01', true],
+            ['2010-01-01/2020-01-01', '2010-01-02/2010-01-02', true],
+            ['2010-01-01/2020-02-27', '2010-01-10/2010-02-10', true],
+            ['2010-01-01/2010-01-01', '2010-01-02/2010-01-02', false],
+            ['2010-01-01/2010-01-01', '2020-01-02/2020-01-02', false],
+        ];
+
+    }
 }

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Tests;
 
+use Brick\DateTime\DateTimeException;
 use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalDateRange;
 
@@ -238,11 +239,47 @@ class LocalDateRangeTest extends AbstractTestCase
     {
         return [
             ['2010-01-01/2010-01-01', '2010-01-01/2010-01-01', true],
-            ['2010-01-01/2020-01-01', '2010-01-02/2010-01-02', true],
-            ['2010-01-01/2020-02-27', '2010-01-10/2010-02-10', true],
+            ['2010-01-01/2033-01-01', '2010-01-02/2010-01-02', true],
+            ['2010-01-01/2033-02-27', '2010-01-10/2010-02-10', true],
+            ['2010-01-01/2010-01-10', '2010-01-05/2010-01-15', true],
             ['2010-01-01/2010-01-01', '2010-01-02/2010-01-02', false],
-            ['2010-01-01/2010-01-01', '2020-01-02/2020-01-02', false],
+            ['2010-01-01/2010-01-01', '2020-01-02/2033-01-02', false],
         ];
+    }
 
+    /**
+     * @dataProvider providerGetIntersection
+     *
+     * @param string $a
+     * @param string $b
+     * @param string $expectedIntersection
+     */
+    public function testGetIntersection(string $a, string $b, string $expectedIntersection)
+    {
+        $aRange = LocalDateRange::parse($a);
+        $bRange = LocalDateRange::parse($b);
+
+        $this->assertSame($expectedIntersection, (string)$aRange->getIntersection($bRange));
+        $this->assertSame($expectedIntersection, (string)$bRange->getIntersection($aRange));
+    }
+
+    public function providerGetIntersection() : array
+    {
+        return [
+            ['2010-01-01/2010-01-01', '2010-01-01/2010-01-01', '2010-01-01/2010-01-01'],
+            ['2010-01-01/2033-01-01', '2010-01-02/2010-01-02', '2010-01-02/2010-01-02'],
+            ['2010-01-01/2033-02-27', '2010-01-10/2010-02-10', '2010-01-10/2010-02-10'],
+            ['2010-01-01/2010-01-10', '2010-01-05/2010-01-15', '2010-01-05/2010-01-10'],
+        ];
+    }
+
+    public function testGetIntersectionInvalidParams()
+    {
+        $this->expectException(DateTimeException::class);
+
+        $aRange = LocalDateRange::parse('2010-01-01/2010-03-01');
+        $bRange = LocalDateRange::parse('2033-01-02/2033-01-02');
+
+        $aRange->getIntersection($bRange);
     }
 }


### PR DESCRIPTION
New methods

- LocalDateRange::isIntersect() returns whether this LocalDateRange intersect with the given date range.
- LocalDateRange::getIntersection() returns intersection this LocalDateRange with the given date range, exception if ranges do not intersect
 