### PR TITLE
add toDatePeriod method for LocalDateRange

### DIFF
--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -234,7 +234,8 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     /**
      * Converts this LocalDateRange to a native DatePeriod object.
      *
-     * The result is a DateTime with time 00:00 in the UTC time-zone.
+     * The result is a DatePeriod->start with time 00:00 and a DatePeriod->end 
+     * with time 23:59:59.999999 in the UTC time-zone.
      *
      * @return \DatePeriod
      */

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -8,6 +8,7 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
+use DatePeriod;
 
 /**
  * Represents an inclusive range of local dates.
@@ -228,6 +229,22 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     public function jsonSerialize() : string
     {
         return (string) $this;
+    }
+
+    /**
+     * Converts this LocalDateRange to a native DatePeriod object.
+     *
+     * The result is a DateTime with time 00:00 in the UTC time-zone.
+     *
+     * @return \DatePeriod
+     */
+    public function toDatePeriod() : \DatePeriod
+    {
+        $start = $this->getStart()->atTime(LocalTime::midnight())->toDateTime();
+        $end = $this->getEnd()->atTime(LocalTime::max())->toDateTime();
+        $interval = new \DateInterval('P1D');
+
+        return new \DatePeriod($start, $interval, $end);
     }
 
     /**

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -222,18 +222,19 @@ class LocalDateRangeTest extends AbstractTestCase
     /**
      * @dataProvider providerToDatePeriod
      *
-     * @param string $dateTime The date-time string that will be parse()d by LocalDate.
-     * @param string $expected The expected output from the native DateTime object.
+     * @param string $range The date-time string that will be parse()d by LocalDateRange.
+     * @param string $expectedStart The expected output from the native DateTime object.
+     * @param string $expectedEnd The expected output from the native DateTime object.
      */
-    public function testToDatePeriod($a, $expectedStart, $expectedEnd)
+    public function testToDatePeriod(string $range, string $expectedStart, string $expectedEnd)
     {
-        $range = LocalDateRange::parse($a);
+        $range = LocalDateRange::parse($range);
 
         $period = $range->toDatePeriod();
 
-        $range_arr = iterator_to_array($range);
-        $period_arr = iterator_to_array($period);
-        $zip = array_map(null, $range_arr, $period_arr);
+        $rangeArray = iterator_to_array($range);
+        $periodArray = iterator_to_array($period);
+        $zip = array_map(null, $rangeArray, $periodArray);
         foreach ($zip as [$date, $dateTime]) {
             $this->assertTrue($date->isEqualTo(LocalDate::fromDateTime($dateTime)));
         }
@@ -246,7 +247,7 @@ class LocalDateRangeTest extends AbstractTestCase
     /**
      * @return array
      */
-    public function providerToDatePeriod()
+    public function providerToDatePeriod(): array
     {
         return [
             ['2010-01-01/2010-01-01', '2010-01-01T00:00:00.000000+0000', '2010-01-01T23:59:59.999999+0000'],

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -220,6 +220,34 @@ class LocalDateRangeTest extends AbstractTestCase
     }
 
     /**
+     * @dataProvider providerToDatePeriod
+     *
+     * @param string $dateTime The date-time string that will be parse()d by LocalDate.
+     * @param string $expected The expected output from the native DateTime object.
+     */
+    public function testToDatePeriod($a, $expectedStart, $expectedEnd)
+    {
+        $range = LocalDateRange::parse($a);
+
+        $period = $range->toDatePeriod();
+        
+        $this->assertSame($expectedStart, $period->start->format('Y-m-d\TH:i:s.uO'));
+        $this->assertSame($expectedEnd, $period->end->format('Y-m-d\TH:i:s.uO'));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerToDatePeriod()
+    {
+        return [
+            ['2010-01-01/2010-01-01', '2010-01-01T00:00:00.000000+0000', '2010-01-01T23:59:59.999999+0000'],
+            ['2010-01-01/2010-01-02', '2010-01-01T00:00:00.000000+0000', '2010-01-02T23:59:59.999999+0000'],
+            ['2010-01-01/2010-12-31', '2010-01-01T00:00:00.000000+0000', '2010-12-31T23:59:59.999999+0000'],
+        ];
+    }
+
+    /**
      * @dataProvider providerIntersectsWith
      *
      * @param string $a

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -230,7 +230,15 @@ class LocalDateRangeTest extends AbstractTestCase
         $range = LocalDateRange::parse($a);
 
         $period = $range->toDatePeriod();
-        
+
+        $range_arr = iterator_to_array($range);
+        $period_arr = iterator_to_array($period);
+        $zip = array_map(null, $range_arr, $period_arr);
+        foreach ($zip as [$date, $dateTime]) {
+            $this->assertTrue($date->isEqualTo(LocalDate::fromDateTime($dateTime)));
+        }
+
+        $this->assertSame(iterator_count($period), $range->count());
         $this->assertSame($expectedStart, $period->start->format('Y-m-d\TH:i:s.uO'));
         $this->assertSame($expectedEnd, $period->end->format('Y-m-d\TH:i:s.uO'));
     }


### PR DESCRIPTION
Adds a `toDatePeriod` to the `LocalDateRange` object which returns a native \DatePeriod PHP object. 

I opted to do end of day (instead of midnight next day) to be inline with the inclusive nature of LocalDateRange.

Note: This is not `bricks/date-time` Period class - I hope this doesn't create confusion.