### PR TITLE
Fix return type of TimeZoneRegion::parse()

### DIFF
--- a/src/TimeZoneRegion.php
+++ b/src/TimeZoneRegion.php
@@ -100,7 +100,7 @@ final class TimeZoneRegion extends TimeZone
      *
      * @throws DateTimeParseException
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : TimeZone
+    public static function parse(string $text, ?DateTimeParser $parser = null) : TimeZoneRegion
     {
         if (! $parser) {
             $parser = IsoParsers::timeZoneRegion();


### PR DESCRIPTION
`TimeZoneRegion::parse(...)` should return `TimeZoneRegion` and not `TimeZone`, matching the return type of the proxied `from(...)` method.