### PR TITLE
Set ID of TimeZone offset on construct

### DIFF
--- a/src/TimeZoneOffset.php
+++ b/src/TimeZoneOffset.php
@@ -29,7 +29,7 @@ final class TimeZoneOffset extends TimeZone
     private function __construct(int $totalSeconds)
     {
         $this->totalSeconds = $totalSeconds;
-        $this->getId();
+        $this->setId();
     }
 
     /**
@@ -143,18 +143,19 @@ final class TimeZoneOffset extends TimeZone
         return $this->totalSeconds;
     }
 
+    private function setId(): void
+    {
+        if ($this->totalSeconds < 0) {
+            $this->id = '-' . LocalTime::ofSecondOfDay(- $this->totalSeconds);
+        } elseif ($this->totalSeconds > 0) {
+            $this->id = '+' . LocalTime::ofSecondOfDay($this->totalSeconds);
+        } else {
+            $this->id = 'Z';
+        }
+    }
+
     public function getId() : string
     {
-        if (!isset($this->id)) {
-            if ($this->totalSeconds < 0) {
-                $this->id = '-' . LocalTime::ofSecondOfDay(- $this->totalSeconds);
-            } elseif ($this->totalSeconds > 0) {
-                $this->id = '+' . LocalTime::ofSecondOfDay($this->totalSeconds);
-            } else {
-                $this->id = 'Z';
-            }
-        }
-
         return $this->id;
     }
 

--- a/src/TimeZoneOffset.php
+++ b/src/TimeZoneOffset.php
@@ -18,10 +18,8 @@ final class TimeZoneOffset extends TimeZone
 
     /**
      * The string representation of this time-zone offset.
-     *
-     * This is generated on-the-fly, and will be null before the first call to getId().
      */
-    private ?string $id = null;
+    private string $id;
 
     /**
      * Private constructor. Use a factory method to obtain an instance.
@@ -31,6 +29,7 @@ final class TimeZoneOffset extends TimeZone
     private function __construct(int $totalSeconds)
     {
         $this->totalSeconds = $totalSeconds;
+        $this->getId();
     }
 
     /**
@@ -146,7 +145,7 @@ final class TimeZoneOffset extends TimeZone
 
     public function getId() : string
     {
-        if ($this->id === null) {
+        if (!isset($this->id)) {
             if ($this->totalSeconds < 0) {
                 $this->id = '-' . LocalTime::ofSecondOfDay(- $this->totalSeconds);
             } elseif ($this->totalSeconds > 0) {

--- a/tests/TimeZoneOffsetTest.php
+++ b/tests/TimeZoneOffsetTest.php
@@ -236,9 +236,8 @@ class TimeZoneOffsetTest extends AbstractTestCase
     public function testIdIsSetOnInstantiation(): void
     {
         $timezone = TimeZoneOffset::utc();
-        $string = (string) $timezone;
-        $result = TimeZoneOffset::parse($string);
+        $parsedTimezone = TimeZoneOffset::parse((string) $timezone);
 
-        $this->assertEquals($timezone, $result);
+        $this->assertEquals($timezone, $parsedTimezone);
     }
 }

--- a/tests/TimeZoneOffsetTest.php
+++ b/tests/TimeZoneOffsetTest.php
@@ -232,4 +232,13 @@ class TimeZoneOffsetTest extends AbstractTestCase
         $this->assertInstanceOf(\DateTimeZone::class, $dateTimeZone);
         $this->assertSame('-05:00', $dateTimeZone->getName());
     }
+
+    public function testIdIsSetOnInstantiation(): void
+    {
+        $timezone = TimeZoneOffset::utc();
+        $string = (string) $timezone;
+        $result = TimeZoneOffset::parse($string);
+
+        $this->assertEquals($timezone, $result);
+    }
 }


### PR DESCRIPTION
In order to compare TimeZone Offset reliably, the id must be set on construction.
Otherwise, when objects including timezones are compared, a test would fail because in some cases the id has been set. And in other cases, the id hasn't been set. 

Previously this test would fail:
 
```php
public function testIdIsSetOnInstantiation(): void
    {
        $timezone = TimeZoneOffset::utc();
        $parsedTimezone = TimeZoneOffset::parse((string) $timezone);

        $this->assertEquals($timezone, $parsedTimezone);
    }
```

