### PR TITLE
New toLocalDateRange method in Year, YearMonth, YearMonthRange and YearWeek classes

### DIFF
--- a/src/Year.php
+++ b/src/Year.php
@@ -229,6 +229,18 @@ final class Year implements \JsonSerializable
     }
 
     /**
+     * Returns LocalDateRange that contains all days of this year
+     * @return LocalDateRange
+     */
+    public function toLocalDateRange() : LocalDateRange
+    {
+        return LocalDateRange::of(
+            $this->atMonth(1)->getFirstDay(),
+            $this->atMonth(12)->getLastDay()
+        );
+    }
+
+    /**
      * Serializes as a string using {@see Year::__toString()}.
      */
     public function jsonSerialize() : string

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -282,6 +282,15 @@ final class YearMonth implements \JsonSerializable
     }
 
     /**
+     * Returns LocalDateRange that contains all days of this year and month
+     * @return LocalDateRange
+     */
+    public function toLocalDateRange(): LocalDateRange
+    {
+        return LocalDateRange::of($this->getFirstDay(), $this->getLastDay());
+    }
+
+    /**
      * Serializes as a string using {@see YearMonth::__toString()}.
      */
     public function jsonSerialize() : string

--- a/src/YearMonthRange.php
+++ b/src/YearMonthRange.php
@@ -163,6 +163,18 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
     }
 
     /**
+     * Returns LocalDateRange that contains all days of this year-months range
+     * @return LocalDateRange
+     */
+    public function toLocalDateRange(): LocalDateRange
+    {
+        return LocalDateRange::of(
+            $this->getStart()->getFirstDay(),
+            $this->getEnd()->getLastDay()
+        );
+    }
+
+    /**
      * Serializes as a string using {@see YearMonthRange::__toString()}.
      */
     public function jsonSerialize() : string

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -250,6 +250,15 @@ final class YearWeek implements \JsonSerializable
     }
 
     /**
+     * Returns LocalDateRange that contains all days of this year week
+     * @return LocalDateRange
+     */
+    public function toLocalDateRange(): LocalDateRange
+    {
+        return LocalDateRange::of($this->getFirstDay(), $this->getLastDay());
+    }
+
+    /**
      * Serializes as a string using {@see YearWeek::__toString()}.
      */
     public function jsonSerialize() : string

--- a/tests/YearMonthRangeTest.php
+++ b/tests/YearMonthRangeTest.php
@@ -176,6 +176,28 @@ class YearMonthRangeTest extends AbstractTestCase
         ];
     }
 
+    /**
+     * @param string $yearMonthRange
+     * @param string $expectedRange
+     * @return void
+     * @dataProvider providerToLocalDateRange
+     */
+    public function testToLocalDateRange(string $yearMonthRange, string $expectedRange): void
+    {
+        $this->assertSame($expectedRange, (string)YearMonthRange::parse($yearMonthRange)->toLocalDateRange());
+    }
+
+    public function providerToLocalDateRange(): array
+    {
+        return [
+            ['1900-01/1900-12', '1900-01-01/1900-12-31'],
+            ['1900-02/1900-02', '1900-02-01/1900-02-28'],
+            ['2000-01/2000-02', '2000-01-01/2000-02-29'],
+            ['2001-01/2001-02', '2001-01-01/2001-02-28'],
+            ['1901-01/3000-12', '1901-01-01/3000-12-31'],
+        ];
+    }
+
     public function testJsonSerialize(): void
     {
         $this->assertSame(json_encode('2008-12/2011-01'), json_encode(YearMonthRange::of(

--- a/tests/YearMonthTest.php
+++ b/tests/YearMonthTest.php
@@ -439,6 +439,28 @@ class YearMonthTest extends AbstractTestCase
         ];
     }
 
+    /**
+     * @param int $year
+     * @param int $month
+     * @param string $expectedRange
+     * @return void
+     * @dataProvider providerToLocalDateRange
+     */
+    public function testToLocalDateRange(int $year, int $month, string $expectedRange): void
+    {
+        $this->assertSame($expectedRange, (string)YearMonth::of($year, $month)->toLocalDateRange());
+    }
+
+    public function providerToLocalDateRange(): array
+    {
+        return [
+            [1900, 2, '1900-02-01/1900-02-28'],
+            [2000, 2, '2000-02-01/2000-02-29'], // Leap year
+            [2001, 2, '2001-02-01/2001-02-28'],
+            [3000, 12, '3000-12-01/3000-12-31'],
+        ];
+    }
+
     public function testJsonSerialize(): void
     {
         $this->assertSame(json_encode('2013-09'), json_encode(YearMonth::of(2013, 9)));

--- a/tests/YearTest.php
+++ b/tests/YearTest.php
@@ -433,6 +433,26 @@ class YearTest extends AbstractTestCase
         ];
     }
 
+    /**
+     * @param int $year
+     * @param string $expectedRange
+     * @return void
+     * @dataProvider providerToLocalDateRange
+     */
+    public function testToLocalDateRange(int $year, string $expectedRange): void
+    {
+        $this->assertSame($expectedRange, (string)Year::of($year)->toLocalDateRange());
+    }
+
+    public function providerToLocalDateRange(): array
+    {
+        return [
+            [1900, '1900-01-01/1900-12-31'],
+            [2020, '2020-01-01/2020-12-31'],
+            [3000, '3000-01-01/3000-12-31'],
+        ];
+    }
+
     public function testJsonSerialize(): void
     {
         $this->assertSame(json_encode('1987'), json_encode(Year::of(1987)));

--- a/tests/YearWeekTest.php
+++ b/tests/YearWeekTest.php
@@ -381,9 +381,9 @@ class YearWeekTest extends AbstractTestCase
     public function testToLocalDateRange(int $year, int $week, string $firstDay, string $lastDay): void
     {
         $yearWeek = YearWeek::of($year, $week);
-        $expectedDareRange = LocalDateRange::parse($firstDay . '/' . $lastDay);
+        $expectedDateRange = (string)LocalDateRange::parse($firstDay . '/' . $lastDay);
 
-        $this->assertEquals($expectedDareRange, $yearWeek->toLocalDateRange());
+        $this->assertEquals($expectedDateRange, (string)$yearWeek->toLocalDateRange());
     }
 
     public function providerGetFirstLastDay() : array

--- a/tests/YearWeekTest.php
+++ b/tests/YearWeekTest.php
@@ -6,6 +6,7 @@ namespace Brick\DateTime\Tests;
 
 use Brick\DateTime\DateTimeException;
 use Brick\DateTime\DayOfWeek;
+use Brick\DateTime\LocalDateRange;
 use Brick\DateTime\YearWeek;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\LocalDate;
@@ -366,6 +367,23 @@ class YearWeekTest extends AbstractTestCase
 
         $this->assertIs(LocalDate::class, $firstDay, $yearWeek->getFirstDay());
         $this->assertIs(LocalDate::class, $lastDay, $yearWeek->getLastDay());
+    }
+
+    /**
+     * @dataProvider providerGetFirstLastDay
+     *
+     * @param int $year
+     * @param int $week
+     * @param string $firstDay
+     * @param string $lastDay
+     * @return void
+     */
+    public function testToLocalDateRange(int $year, int $week, string $firstDay, string $lastDay): void
+    {
+        $yearWeek = YearWeek::of($year, $week);
+        $expectedDareRange = LocalDateRange::parse($firstDay . '/' . $lastDay);
+
+        $this->assertEquals($expectedDareRange, $yearWeek->toLocalDateRange());
     }
 
     public function providerGetFirstLastDay() : array


### PR DESCRIPTION
New methods:

- `Year::toLocalDateRange`
- `YearMonth::toLocalDateRange`
- `YearMonthRange::toLocalDateRange`
- `YearWeek::toLocalDateRange`