### PR TITLE
Make TimeZoneRegion::utc() return a TimeZoneRegion not an TimeZoneOffset

### DIFF
--- a/src/Instant.php
+++ b/src/Instant.php
@@ -363,7 +363,7 @@ final class Instant implements JsonSerializable, Stringable
      */
     public function toISOString(): string
     {
-        return (string) ZonedDateTime::ofInstant($this, TimeZone::utc());
+        return (string) ZonedDateTime::ofInstant($this, TimeZoneOffset::utc());
     }
 
     /**

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -715,7 +715,7 @@ final class LocalDateTime implements JsonSerializable, Stringable
      */
     public function toNativeDateTime(): DateTime
     {
-        return $this->atTimeZone(TimeZone::utc())->toNativeDateTime();
+        return $this->atTimeZone(TimeZoneOffset::utc())->toNativeDateTime();
     }
 
     /**

--- a/src/TimeZone.php
+++ b/src/TimeZone.php
@@ -41,10 +41,6 @@ abstract class TimeZone implements Stringable
         return TimeZoneRegion::parse($text);
     }
 
-    public static function utc(): TimeZoneOffset
-    {
-        return TimeZoneOffset::utc();
-    }
 
     /**
      * Returns the unique time-zone ID.

--- a/src/TimeZoneRegion.php
+++ b/src/TimeZoneRegion.php
@@ -55,6 +55,11 @@ final class TimeZoneRegion extends TimeZone
         return TimeZoneRegion::of($region);
     }
 
+    public static function utc() : TimeZoneRegion
+    {
+        return TimeZoneRegion::of('UTC');
+    }
+
     /**
      * Returns all the available time-zone identifiers.
      *

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -8,7 +8,7 @@ use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\DateTimeException;
 use Brick\DateTime\Duration;
 use Brick\DateTime\Instant;
-use Brick\DateTime\TimeZone;
+use Brick\DateTime\TimeZoneOffset;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 use function json_encode;
@@ -658,7 +658,7 @@ class InstantTest extends AbstractTestCase
 
     public function testAtTimeZone(): void
     {
-        $timeZone = TimeZone::utc();
+        $timeZone = TimeZoneOffset::utc();
         $instant = Instant::of(1000000000);
         $result = $instant->atTimeZone($timeZone);
         self::assertSame(1000000000, $result->getInstant()->getEpochSecond());

--- a/tests/TimeZoneOffsetTest.php
+++ b/tests/TimeZoneOffsetTest.php
@@ -10,6 +10,7 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\TimeZoneOffset;
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Brick\DateTime\TimeZoneRegion;
 
 use const PHP_VERSION_ID;
 

--- a/tests/TimeZoneRegionTest.php
+++ b/tests/TimeZoneRegionTest.php
@@ -163,4 +163,11 @@ class TimeZoneRegionTest extends AbstractTestCase
     {
         self::assertSame('America/Los_Angeles', (string) TimeZoneRegion::of('America/Los_Angeles'));
     }
+
+    public function testUTC(): void
+    {
+        $utcTimeZoneRegion = TimeZoneRegion::utc();
+        $this->assertInstanceOf(TimeZoneRegion::class, $utcTimeZoneRegion);
+        $this->assertSame('UTC', $utcTimeZoneRegion->getId());
+    }
 }

--- a/tests/TimeZoneTest.php
+++ b/tests/TimeZoneTest.php
@@ -66,16 +66,13 @@ class TimeZoneTest extends AbstractTestCase
 
     public function testUtc(): void
     {
-        $utc = TimeZone::utc();
-
-        self::assertTimeZoneOffsetIs(0, $utc);
-        self::assertSame($utc, TimeZone::utc());
+        $this->assertTimeZoneOffsetIs(0, TimeZoneOffset::utc());
     }
 
     public function testIsEqualTo(): void
     {
-        self::assertTrue(TimeZone::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(0)));
-        self::assertFalse(TimeZone::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(3600)));
+        self::assertTrue(TimeZoneOffset::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(0)));
+        self::assertFalse(TimeZoneOffset::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(3600)));
     }
 
     /**

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -520,7 +520,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     {
         $zonedDateTime = ZonedDateTime::of(
             LocalDateTime::of(2000, $monthValue, 1),
-            TimeZone::utc(),
+            TimeZoneOffset::utc(),
         );
 
         self::assertSame($month, $zonedDateTime->getMonth());


### PR DESCRIPTION
I think it's reasonable from a DX perspective to expect `TimeZoneRegion::utc()` to return a `TimeZoneRegion` instead of the offset.