### PR TITLE
Introduce coding style tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,5 @@
 phpunit.xml    export-ignore
 psalm.xml      export-ignore
 README.md      export-ignore
+tools/         export-ignore
 tests/         export-ignore

--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -1,0 +1,27 @@
+name: Coding Style
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  easy-coding-standard:
+    name: Easy Coding Standard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.0"
+
+      - name: Install composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          working-directory: "tools/ecs"
+
+      - name: Run ECS
+        run: tools/ecs/vendor/bin/ecs check --config tools/ecs/ecs.php

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,25 @@
+name: Static Analysis
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.0"
+
+      - name: Install composer dependencies
+        uses: "ramsey/composer-install@v2"
+
+      - name: Run Psalm
+        run: vendor/bin/psalm --show-info=false --find-unused-psalm-suppress --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,29 +1,10 @@
-name: CI
+name: Tests
 
 on:
   push:
   pull_request:
 
 jobs:
-  psalm:
-    name: Psalm
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.0"
-
-      - name: Install composer dependencies
-        uses: "ramsey/composer-install@v1"
-
-      - name: Run Psalm
-        run: vendor/bin/psalm --show-info=false --find-unused-psalm-suppress --no-progress
-
   phpunit:
     name: PHPUnit
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /vendor
 /composer.lock
 /.phpunit.result.cache
+
+# https://stackoverflow.com/a/16318111
+/tools/*
+!/tools/ecs
+/tools/ecs/*
+!/tools/ecs/composer.json
+!/tools/ecs/ecs.php

--- a/README.md
+++ b/README.md
@@ -195,3 +195,24 @@ The following exceptions can be thrown:
 ### Doctrine mappings
 
 You can use `brick/date-time` types in your Doctrine entities using the [brick/date-time-doctrine](https://github.com/brick/date-time-doctrine) package.
+
+Contributing
+--------
+
+### Coding Style
+
+Install Easy Coding Standard tool in its own folder
+
+```sh
+composer install --working-dir=tools/ecs
+```
+
+Run coding style analysis checks
+```sh
+./tools/ecs/vendor/bin/ecs check --config tools/ecs/ecs.php
+```
+
+Or fix issues found directly
+```sh
+./tools/ecs/vendor/bin/ecs check --config tools/ecs/ecs.php --fix
+```

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -9,5 +9,5 @@ interface Clock
     /**
      * Returns the current time.
      */
-    public function getTime() : Instant;
+    public function getTime(): Instant;
 }

--- a/src/Clock/FixedClock.php
+++ b/src/Clock/FixedClock.php
@@ -23,12 +23,12 @@ final class FixedClock implements Clock
         $this->instant = $instant;
     }
 
-    public function getTime() : Instant
+    public function getTime(): Instant
     {
         return $this->instant;
     }
 
-    public function setTime(Instant $instant) : void
+    public function setTime(Instant $instant): void
     {
         $this->instant = $instant;
     }
@@ -36,7 +36,7 @@ final class FixedClock implements Clock
     /**
      * Moves the clock by a number of seconds and/or nanos.
      */
-    public function move(int $seconds, int $nanos = 0) : void
+    public function move(int $seconds, int $nanos = 0): void
     {
         $duration = Duration::ofSeconds($seconds, $nanos);
         $this->instant = $this->instant->plus($duration);

--- a/src/Clock/OffsetClock.php
+++ b/src/Clock/OffsetClock.php
@@ -30,10 +30,10 @@ final class OffsetClock implements Clock
     public function __construct(Clock $referenceClock, Duration $offset)
     {
         $this->referenceClock = $referenceClock;
-        $this->offset         = $offset;
+        $this->offset = $offset;
     }
 
-    public function getTime() : Instant
+    public function getTime(): Instant
     {
         return $this->referenceClock->getTime()->plus($this->offset);
     }

--- a/src/Clock/ScaleClock.php
+++ b/src/Clock/ScaleClock.php
@@ -40,11 +40,11 @@ final class ScaleClock implements Clock
     public function __construct(Clock $referenceClock, int $timeScale)
     {
         $this->referenceClock = $referenceClock;
-        $this->startTime      = $referenceClock->getTime();
-        $this->timeScale      = $timeScale;
+        $this->startTime = $referenceClock->getTime();
+        $this->timeScale = $timeScale;
     }
 
-    public function getTime() : Instant
+    public function getTime(): Instant
     {
         $duration = Duration::between($this->startTime, $this->referenceClock->getTime());
         $duration = $duration->multipliedBy($this->timeScale);

--- a/src/Clock/SystemClock.php
+++ b/src/Clock/SystemClock.php
@@ -14,11 +14,11 @@ use Brick\DateTime\Instant;
  */
 final class SystemClock implements Clock
 {
-    public function getTime() : Instant
+    public function getTime(): Instant
     {
         [$fraction, $epochSecond] = \explode(' ', microtime());
 
-        $epochSecond    = (int) $epochSecond;
+        $epochSecond = (int) $epochSecond;
         $nanoAdjustment = 10 * (int) \substr($fraction, 2, 8);
 
         return Instant::of($epochSecond, $nanoAdjustment);

--- a/src/DateTimeException.php
+++ b/src/DateTimeException.php
@@ -4,29 +4,33 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use RuntimeException;
+
+use function sprintf;
+
 /**
  * This exception is used to indicate problems with creating, querying and manipulating date-time objects.
  */
-class DateTimeException extends \RuntimeException
+class DateTimeException extends RuntimeException
 {
     /**
-     * @param string $field  The tested field.
-     * @param int    $value  The actual value.
-     * @param int    $min    The minimum allowed value.
-     * @param int    $max    The maximum allowed value.
+     * @param string $field The tested field.
+     * @param int    $value The actual value.
+     * @param int    $min   The minimum allowed value.
+     * @param int    $max   The maximum allowed value.
      */
-    public static function fieldNotInRange(string $field, int $value, int $min, int $max) : self
+    public static function fieldNotInRange(string $field, int $value, int $min, int $max): self
     {
         return new self("Invalid $field: $value is not in the range $min to $max.");
     }
 
-    public static function timeZoneOffsetSecondsMustBeMultipleOf60(int $offsetSeconds) : self
+    public static function timeZoneOffsetSecondsMustBeMultipleOf60(int $offsetSeconds): self
     {
         return new self(sprintf('The time zone offset of %d seconds is not a multiple of 60', $offsetSeconds));
     }
 
-    public static function unknownTimeZoneRegion(string $region) : self
+    public static function unknownTimeZoneRegion(string $region): self
     {
-        return new self(\sprintf('Unknown time zone region "%s".', $region));
+        return new self(sprintf('Unknown time zone region "%s".', $region));
     }
 }

--- a/src/DayOfWeek.php
+++ b/src/DayOfWeek.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use JsonSerializable;
+
 /**
  * A day-of-week, such as Tuesday.
  *
  * This class is immutable.
  */
-final class DayOfWeek implements \JsonSerializable
+final class DayOfWeek implements JsonSerializable
 {
-    public const MONDAY    = 1;
-    public const TUESDAY   = 2;
+    public const MONDAY = 1;
+    public const TUESDAY = 2;
     public const WEDNESDAY = 3;
-    public const THURSDAY  = 4;
-    public const FRIDAY    = 5;
-    public const SATURDAY  = 6;
-    public const SUNDAY    = 7;
+    public const THURSDAY = 4;
+    public const FRIDAY = 5;
+    public const SATURDAY = 6;
+    public const SUNDAY = 7;
 
     /**
      * The ISO-8601 value for the day of the week, from 1 (Monday) to 7 (Sunday).
@@ -35,23 +37,6 @@ final class DayOfWeek implements \JsonSerializable
     }
 
     /**
-     * Returns a cached DayOfWeek instance.
-     *
-     * @param int $value The day-of-week value, validated from 1 to 7.
-     */
-    private static function get(int $value) : DayOfWeek
-    {
-        /** @var array<int, DayOfWeek> $values */
-        static $values = [];
-
-        if (! isset($values[$value])) {
-            $values[$value] = new DayOfWeek($value);
-        }
-
-        return $values[$value];
-    }
-
-    /**
      * Returns an instance of DayOfWeek for the given day-of-week value.
      *
      * @param int $dayOfWeek The day-of-week value, from 1 (Monday) to 7 (Sunday).
@@ -60,7 +45,7 @@ final class DayOfWeek implements \JsonSerializable
      *
      * @throws DateTimeException If the day-of-week is not valid.
      */
-    public static function of(int $dayOfWeek) : DayOfWeek
+    public static function of(int $dayOfWeek): DayOfWeek
     {
         Field\DayOfWeek::check($dayOfWeek);
 
@@ -72,7 +57,7 @@ final class DayOfWeek implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : DayOfWeek
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): DayOfWeek
     {
         return LocalDate::now($timeZone, $clock)->getDayOfWeek();
     }
@@ -84,7 +69,7 @@ final class DayOfWeek implements \JsonSerializable
      *
      * @return DayOfWeek[]
      */
-    public static function all(?DayOfWeek $first = null) : array
+    public static function all(?DayOfWeek $first = null): array
     {
         $days = [];
         $first = $first ?: DayOfWeek::get(DayOfWeek::MONDAY);
@@ -93,8 +78,7 @@ final class DayOfWeek implements \JsonSerializable
         do {
             $days[] = $current;
             $current = $current->plus(1);
-        }
-        while (! $current->isEqualTo($first));
+        } while (! $current->isEqualTo($first));
 
         return $days;
     }
@@ -102,7 +86,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns a day-of-week instance for Monday.
      */
-    public static function monday() : DayOfWeek
+    public static function monday(): DayOfWeek
     {
         return DayOfWeek::get(DayOfWeek::MONDAY);
     }
@@ -110,7 +94,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns a day-of-week instance for Tuesday.
      */
-    public static function tuesday() : DayOfWeek
+    public static function tuesday(): DayOfWeek
     {
         return DayOfWeek::get(DayOfWeek::TUESDAY);
     }
@@ -118,7 +102,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns a day-of-week instance for Wednesday.
      */
-    public static function wednesday() : DayOfWeek
+    public static function wednesday(): DayOfWeek
     {
         return DayOfWeek::get(DayOfWeek::WEDNESDAY);
     }
@@ -126,7 +110,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns a day-of-week instance for Thursday.
      */
-    public static function thursday() : DayOfWeek
+    public static function thursday(): DayOfWeek
     {
         return DayOfWeek::get(DayOfWeek::THURSDAY);
     }
@@ -134,7 +118,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns a day-of-week instance for Friday.
      */
-    public static function friday() : DayOfWeek
+    public static function friday(): DayOfWeek
     {
         return DayOfWeek::get(DayOfWeek::FRIDAY);
     }
@@ -142,7 +126,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns a day-of-week instance for Saturday.
      */
-    public static function saturday() : DayOfWeek
+    public static function saturday(): DayOfWeek
     {
         return DayOfWeek::get(DayOfWeek::SATURDAY);
     }
@@ -150,7 +134,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns a day-of-week instance for Sunday.
      */
-    public static function sunday() : DayOfWeek
+    public static function sunday(): DayOfWeek
     {
         return DayOfWeek::get(DayOfWeek::SUNDAY);
     }
@@ -160,7 +144,7 @@ final class DayOfWeek implements \JsonSerializable
      *
      * @return int The day-of-week value, from 1 (Monday) to 7 (Sunday).
      */
-    public function getValue() : int
+    public function getValue(): int
     {
         return $this->value;
     }
@@ -172,7 +156,7 @@ final class DayOfWeek implements \JsonSerializable
      *
      * @return bool True if this day-of-week is equal to the given value, false otherwise.
      */
-    public function is(int $dayOfWeek) : bool
+    public function is(int $dayOfWeek): bool
     {
         return $this->value === $dayOfWeek;
     }
@@ -184,7 +168,7 @@ final class DayOfWeek implements \JsonSerializable
      * do *not* use strict object comparison to compare two DayOfWeek instances,
      * as it is possible to get a different instance for the same day using serialization.
      */
-    public function isEqualTo(DayOfWeek $that) : bool
+    public function isEqualTo(DayOfWeek $that): bool
     {
         return $this->value === $that->value;
     }
@@ -192,7 +176,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns whether this DayOfWeek is Monday to Friday.
      */
-    public function isWeekday() : bool
+    public function isWeekday(): bool
     {
         return $this->value >= self::MONDAY && $this->value <= self::FRIDAY;
     }
@@ -200,7 +184,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns whether this DayOfWeek is Saturday or Sunday.
      */
-    public function isWeekend() : bool
+    public function isWeekend(): bool
     {
         return $this->value === self::SATURDAY || $this->value === self::SUNDAY;
     }
@@ -208,7 +192,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns the DayOfWeek that is the specified number of days after this one.
      */
-    public function plus(int $days) : DayOfWeek
+    public function plus(int $days): DayOfWeek
     {
         return DayOfWeek::get((((($this->value - 1 + $days) % 7) + 7) % 7) + 1);
     }
@@ -216,15 +200,15 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns the DayOfWeek that is the specified number of days before this one.
      */
-    public function minus(int $days) : DayOfWeek
+    public function minus(int $days): DayOfWeek
     {
-        return $this->plus(- $days);
+        return $this->plus(-$days);
     }
 
     /**
      * Serializes as a string using {@see DayOfWeek::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
@@ -232,7 +216,7 @@ final class DayOfWeek implements \JsonSerializable
     /**
      * Returns the capitalized English name of this day-of-week.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return [
             1 => 'Monday',
@@ -243,5 +227,22 @@ final class DayOfWeek implements \JsonSerializable
             6 => 'Saturday',
             7 => 'Sunday'
         ][$this->value];
+    }
+
+    /**
+     * Returns a cached DayOfWeek instance.
+     *
+     * @param int $value The day-of-week value, validated from 1 to 7.
+     */
+    private static function get(int $value): DayOfWeek
+    {
+        /** @var array<int, DayOfWeek> $values */
+        static $values = [];
+
+        if (! isset($values[$value])) {
+            $values[$value] = new DayOfWeek($value);
+        }
+
+        return $values[$value];
     }
 }

--- a/src/DefaultClock.php
+++ b/src/DefaultClock.php
@@ -28,7 +28,7 @@ final class DefaultClock
     /**
      * Gets the default clock.
      */
-    public static function get() : Clock
+    public static function get(): Clock
     {
         if (self::$clock === null) {
             self::$clock = new SystemClock();
@@ -40,7 +40,7 @@ final class DefaultClock
     /**
      * Sets the default clock.
      */
-    public static function set(Clock $clock) : void
+    public static function set(Clock $clock): void
     {
         self::$clock = $clock;
     }
@@ -48,7 +48,7 @@ final class DefaultClock
     /**
      * Resets the default clock to the system clock.
      */
-    public static function reset() : void
+    public static function reset(): void
     {
         self::$clock = null;
     }
@@ -58,7 +58,7 @@ final class DefaultClock
      *
      * @param Instant $instant The time to freeze to.
      */
-    public static function freeze(Instant $instant) : void
+    public static function freeze(Instant $instant): void
     {
         self::set(new FixedClock($instant));
     }
@@ -68,7 +68,7 @@ final class DefaultClock
      *
      * If the current default clock is frozen, you must `reset()` it first, or the time will stay frozen.
      */
-    public static function travel(Instant $instant) : void
+    public static function travel(Instant $instant): void
     {
         $clock = self::get();
         $offset = Duration::between($clock->getTime(), $instant);
@@ -87,7 +87,7 @@ final class DefaultClock
      * If the current default clock is frozen, you must `reset()` it first, or the time will stay frozen.
      * Multiple calls to `scale()` will result in a clock with the combined scales.
      */
-    public static function scale(int $timeScale) : void
+    public static function scale(int $timeScale): void
     {
         self::set(new ScaleClock(self::get(), $timeScale));
     }

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -4,16 +4,26 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
-use Brick\DateTime\Utility\Math;
-
 use ArithmeticError;
+use Brick\DateTime\Utility\Math;
+use JsonSerializable;
+
+use function assert;
+use function intdiv;
+use function is_int;
+use function preg_match;
+use function rtrim;
+use function sprintf;
+use function str_pad;
+
+use const STR_PAD_RIGHT;
 
 /**
  * Represents a duration of time measured in seconds.
  *
  * This class is immutable.
  */
-final class Duration implements \JsonSerializable
+final class Duration implements JsonSerializable
 {
     /**
      * The duration in seconds.
@@ -36,13 +46,13 @@ final class Duration implements \JsonSerializable
     private function __construct(int $seconds, int $nanos = 0)
     {
         $this->seconds = $seconds;
-        $this->nanos   = $nanos;
+        $this->nanos = $nanos;
     }
 
     /**
      * Returns a zero length Duration.
      */
-    public static function zero() : Duration
+    public static function zero(): Duration
     {
         return new Duration(0);
     }
@@ -65,7 +75,7 @@ final class Duration implements \JsonSerializable
      *
      * @throws Parser\DateTimeParseException
      */
-    public static function parse(string $text) : Duration
+    public static function parse(string $text): Duration
     {
         $pattern =
             '/^' .
@@ -79,7 +89,7 @@ final class Duration implements \JsonSerializable
             ')?' .
             '()$/i';
 
-        if (\preg_match($pattern, $text, $matches) !== 1) {
+        if (preg_match($pattern, $text, $matches) !== 1) {
             throw Parser\DateTimeParseException::invalidDuration($text);
         }
 
@@ -94,24 +104,24 @@ final class Duration implements \JsonSerializable
         $allNegative = ($sign === '-');
         $secondsNegative = ($seconds !== '' && $seconds[0] === '-');
 
-        $nanos = \str_pad($nanos, 9, '0', \STR_PAD_RIGHT);
+        $nanos = str_pad($nanos, 9, '0', STR_PAD_RIGHT);
 
-        $days    = (int) $days;
-        $hours   = (int) $hours;
+        $days = (int) $days;
+        $hours = (int) $hours;
         $minutes = (int) $minutes;
         $seconds = (int) $seconds;
-        $nanos   = (int) $nanos;
+        $nanos = (int) $nanos;
 
         if ($secondsNegative) {
             $nanos = -$nanos;
         }
 
         if ($allNegative) {
-            $days    = -$days;
-            $hours   = -$hours;
+            $days = -$days;
+            $hours = -$hours;
             $minutes = -$minutes;
             $seconds = -$seconds;
-            $nanos   = -$nanos;
+            $nanos = -$nanos;
         }
 
         $seconds +=
@@ -142,11 +152,11 @@ final class Duration implements \JsonSerializable
      * @param int $seconds        The number of seconds of the duration.
      * @param int $nanoAdjustment The adjustment to the duration in nanoseconds.
      */
-    public static function ofSeconds(int $seconds, int $nanoAdjustment = 0) : Duration
+    public static function ofSeconds(int $seconds, int $nanoAdjustment = 0): Duration
     {
         $nanoseconds = $nanoAdjustment % LocalTime::NANOS_PER_SECOND;
         $seconds += ($nanoAdjustment - $nanoseconds) / LocalTime::NANOS_PER_SECOND;
-        \assert(\is_int($seconds));
+        assert(is_int($seconds));
 
         if ($nanoseconds < 0) {
             $nanoseconds += LocalTime::NANOS_PER_SECOND;
@@ -159,7 +169,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a Duration from a number of milliseconds.
      */
-    public static function ofMillis(int $millis) : Duration
+    public static function ofMillis(int $millis): Duration
     {
         $seconds = intdiv($millis, LocalTime::MILLIS_PER_SECOND);
         $nanos = ($millis % LocalTime::MILLIS_PER_SECOND) * LocalTime::NANOS_PER_MILLI;
@@ -170,7 +180,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a Duration from a number of nanoseconds.
      */
-    public static function ofNanos(int $nanos) : Duration
+    public static function ofNanos(int $nanos): Duration
     {
         return self::ofSeconds(0, $nanos);
     }
@@ -178,7 +188,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a Duration from a number of minutes.
      */
-    public static function ofMinutes(int $minutes) : Duration
+    public static function ofMinutes(int $minutes): Duration
     {
         return new Duration(60 * $minutes);
     }
@@ -186,7 +196,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a Duration from a number of hours.
      */
-    public static function ofHours(int $hours) : Duration
+    public static function ofHours(int $hours): Duration
     {
         return new Duration(3600 * $hours);
     }
@@ -194,7 +204,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a Duration from a number of days.
      */
-    public static function ofDays(int $days) : Duration
+    public static function ofDays(int $days): Duration
     {
         return new Duration(86400 * $days);
     }
@@ -208,7 +218,7 @@ final class Duration implements \JsonSerializable
      * @param Instant $startInclusive The start instant, inclusive.
      * @param Instant $endExclusive   The end instant, exclusive.
      */
-    public static function between(Instant $startInclusive, Instant $endExclusive) : Duration
+    public static function between(Instant $startInclusive, Instant $endExclusive): Duration
     {
         $seconds = $endExclusive->getEpochSecond() - $startInclusive->getEpochSecond();
         $nanos = $endExclusive->getNano() - $startInclusive->getNano();
@@ -219,7 +229,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns whether this Duration is zero length.
      */
-    public function isZero() : bool
+    public function isZero(): bool
     {
         return $this->seconds === 0 && $this->nanos === 0;
     }
@@ -227,7 +237,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns whether this Duration is positive, excluding zero.
      */
-    public function isPositive() : bool
+    public function isPositive(): bool
     {
         return $this->seconds > 0 || ($this->seconds === 0 && $this->nanos !== 0);
     }
@@ -235,7 +245,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns whether this Duration is positive or zero.
      */
-    public function isPositiveOrZero() : bool
+    public function isPositiveOrZero(): bool
     {
         return $this->seconds >= 0;
     }
@@ -243,7 +253,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns whether this Duration is negative, excluding zero.
      */
-    public function isNegative() : bool
+    public function isNegative(): bool
     {
         return $this->seconds < 0;
     }
@@ -251,7 +261,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns whether this Duration is negative or zero.
      */
-    public function isNegativeOrZero() : bool
+    public function isNegativeOrZero(): bool
     {
         return $this->seconds < 0 || ($this->seconds === 0 && $this->nanos === 0);
     }
@@ -259,7 +269,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration added.
      */
-    public function plus(Duration $duration) : Duration
+    public function plus(Duration $duration): Duration
     {
         if ($duration->isZero()) {
             return $this;
@@ -279,7 +289,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in seconds added.
      */
-    public function plusSeconds(int $seconds) : Duration
+    public function plusSeconds(int $seconds): Duration
     {
         if ($seconds === 0) {
             return $this;
@@ -291,7 +301,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in minutes added.
      */
-    public function plusMinutes(int $minutes) : Duration
+    public function plusMinutes(int $minutes): Duration
     {
         return $this->plusSeconds($minutes * LocalTime::SECONDS_PER_MINUTE);
     }
@@ -299,7 +309,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in hours added.
      */
-    public function plusHours(int $hours) : Duration
+    public function plusHours(int $hours): Duration
     {
         return $this->plusSeconds($hours * LocalTime::SECONDS_PER_HOUR);
     }
@@ -307,7 +317,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in days added.
      */
-    public function plusDays(int $days) : Duration
+    public function plusDays(int $days): Duration
     {
         return $this->plusSeconds($days * LocalTime::SECONDS_PER_DAY);
     }
@@ -315,7 +325,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration added.
      */
-    public function minus(Duration $duration) : Duration
+    public function minus(Duration $duration): Duration
     {
         if ($duration->isZero()) {
             return $this;
@@ -327,7 +337,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in seconds subtracted.
      */
-    public function minusSeconds(int $seconds) : Duration
+    public function minusSeconds(int $seconds): Duration
     {
         return $this->plusSeconds(-$seconds);
     }
@@ -335,7 +345,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in minutes subtracted.
      */
-    public function minusMinutes(int $minutes) : Duration
+    public function minusMinutes(int $minutes): Duration
     {
         return $this->plusMinutes(-$minutes);
     }
@@ -343,7 +353,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in hours subtracted.
      */
-    public function minusHours(int $hours) : Duration
+    public function minusHours(int $hours): Duration
     {
         return $this->plusHours(-$hours);
     }
@@ -351,7 +361,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the specified duration in days subtracted.
      */
-    public function minusDays(int $days) : Duration
+    public function minusDays(int $days): Duration
     {
         return $this->plusDays(-$days);
     }
@@ -359,7 +369,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration multiplied by the given value.
      */
-    public function multipliedBy(int $multiplicand) : Duration
+    public function multipliedBy(int $multiplicand): Duration
     {
         if ($multiplicand === 1) {
             return $this;
@@ -378,7 +388,7 @@ final class Duration implements \JsonSerializable
      *
      * @throws DateTimeException If the divisor is zero.
      */
-    public function dividedBy(int $divisor) : Duration
+    public function dividedBy(int $divisor): Duration
     {
         if ($divisor === 0) {
             throw new DateTimeException('Cannot divide a Duration by zero.');
@@ -397,14 +407,14 @@ final class Duration implements \JsonSerializable
         }
 
         $remainder = $seconds % $divisor;
-        $seconds = \intdiv($seconds, $divisor);
+        $seconds = intdiv($seconds, $divisor);
 
         $r1 = $nanos % $divisor;
-        $nanos = \intdiv($nanos, $divisor);
+        $nanos = intdiv($nanos, $divisor);
 
         $r2 = LocalTime::NANOS_PER_SECOND % $divisor;
-        $nanos += $remainder * \intdiv(LocalTime::NANOS_PER_SECOND, $divisor);
-        $nanos += \intdiv($r1 + $remainder * $r2, $divisor);
+        $nanos += $remainder * intdiv(LocalTime::NANOS_PER_SECOND, $divisor);
+        $nanos += intdiv($r1 + $remainder * $r2, $divisor);
 
         if ($nanos < 0) {
             $seconds--;
@@ -417,7 +427,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with the length negated.
      */
-    public function negated() : Duration
+    public function negated(): Duration
     {
         if ($this->isZero()) {
             return $this;
@@ -437,7 +447,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns a copy of this Duration with a positive length.
      */
-    public function abs() : Duration
+    public function abs(): Duration
     {
         return $this->isNegative() ? $this->negated() : $this;
     }
@@ -449,7 +459,7 @@ final class Duration implements \JsonSerializable
      *
      * @return int [-1,0,1] If this duration is less than, equal to, or greater than the given duration.
      */
-    public function compareTo(Duration $that) : int
+    public function compareTo(Duration $that): int
     {
         $seconds = $this->seconds - $that->seconds;
 
@@ -469,7 +479,7 @@ final class Duration implements \JsonSerializable
     /**
      * Checks if this Duration is equal to the specified duration.
      */
-    public function isEqualTo(Duration $that) : bool
+    public function isEqualTo(Duration $that): bool
     {
         return $this->compareTo($that) === 0;
     }
@@ -477,7 +487,7 @@ final class Duration implements \JsonSerializable
     /**
      * Checks if this Duration is greater than the specified duration.
      */
-    public function isGreaterThan(Duration $that) : bool
+    public function isGreaterThan(Duration $that): bool
     {
         return $this->compareTo($that) > 0;
     }
@@ -485,7 +495,7 @@ final class Duration implements \JsonSerializable
     /**
      * Checks if this Duration is less than the specified duration.
      */
-    public function isLessThan(Duration $that) : bool
+    public function isLessThan(Duration $that): bool
     {
         return $this->compareTo($that) < 0;
     }
@@ -493,7 +503,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns the total length in seconds of this Duration.
      */
-    public function getSeconds() : int
+    public function getSeconds(): int
     {
         return $this->seconds;
     }
@@ -501,7 +511,7 @@ final class Duration implements \JsonSerializable
     /**
      * Returns the nanoseconds adjustment of this Duration, in the range 0 to 999,999,999.
      */
-    public function getNanos() : int
+    public function getNanos(): int
     {
         return $this->nanos;
     }
@@ -513,10 +523,10 @@ final class Duration implements \JsonSerializable
      *
      * @todo deprecate in favour of toMillis() - caution: rounding is different
      */
-    public function getTotalMillis() : int
+    public function getTotalMillis(): int
     {
         $millis = $this->seconds * 1000;
-        $millis += \intdiv($this->nanos, 1000000);
+        $millis += intdiv($this->nanos, 1000000);
 
         return $millis;
     }
@@ -526,15 +536,15 @@ final class Duration implements \JsonSerializable
      *
      * The result is rounded towards negative infinity.
      */
-    public function getTotalMicros() : int
+    public function getTotalMicros(): int
     {
         $micros = $this->seconds * 1000000;
-        $micros += \intdiv($this->nanos, 1000);
+        $micros += intdiv($this->nanos, 1000);
 
         return $micros;
     }
 
-    public function getTotalNanos() : int
+    public function getTotalNanos(): int
     {
         $nanos = $this->seconds * 1000000000;
         $nanos += $this->nanos;
@@ -550,9 +560,9 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toDays() : int
+    public function toDays(): int
     {
-        return \intdiv($this->seconds, LocalTime::SECONDS_PER_DAY);
+        return intdiv($this->seconds, LocalTime::SECONDS_PER_DAY);
     }
 
     /**
@@ -562,7 +572,7 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toDaysPart() : int
+    public function toDaysPart(): int
     {
         return $this->toDays();
     }
@@ -574,9 +584,9 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toHours() : int
+    public function toHours(): int
     {
-        return \intdiv($this->seconds, LocalTime::SECONDS_PER_HOUR);
+        return intdiv($this->seconds, LocalTime::SECONDS_PER_HOUR);
     }
 
     /**
@@ -587,7 +597,7 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toHoursPart() : int
+    public function toHoursPart(): int
     {
         return $this->toHours() % 24;
     }
@@ -599,9 +609,9 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toMinutes() : int
+    public function toMinutes(): int
     {
-        return \intdiv($this->seconds, LocalTime::SECONDS_PER_MINUTE);
+        return intdiv($this->seconds, LocalTime::SECONDS_PER_MINUTE);
     }
 
     /**
@@ -612,7 +622,7 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toMinutesPart() : int
+    public function toMinutesPart(): int
     {
         return $this->toMinutes() % LocalTime::MINUTES_PER_HOUR;
     }
@@ -624,7 +634,7 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toSeconds() : int
+    public function toSeconds(): int
     {
         return $this->seconds;
     }
@@ -637,7 +647,7 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toSecondsPart() : int
+    public function toSecondsPart(): int
     {
         return $this->toSeconds() % LocalTime::SECONDS_PER_MINUTE;
     }
@@ -652,7 +662,7 @@ final class Duration implements \JsonSerializable
      *
      * @throws ArithmeticError
      */
-    public function toMillis() : int
+    public function toMillis(): int
     {
         $tempSeconds = $this->seconds;
         $tempNanos = $this->nanos;
@@ -663,7 +673,7 @@ final class Duration implements \JsonSerializable
         }
 
         $millis = Math::multiplyExact($tempSeconds, LocalTime::MILLIS_PER_SECOND);
-        $millis = Math::addExact($millis, \intdiv($tempNanos, LocalTime::NANOS_PER_MILLI));
+        $millis = Math::addExact($millis, intdiv($tempNanos, LocalTime::NANOS_PER_MILLI));
 
         return $millis;
     }
@@ -678,9 +688,9 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toMillisPart() : int
+    public function toMillisPart(): int
     {
-        return \intdiv($this->nanos, LocalTime::NANOS_PER_MILLI);
+        return intdiv($this->nanos, LocalTime::NANOS_PER_MILLI);
     }
 
     /**
@@ -690,7 +700,7 @@ final class Duration implements \JsonSerializable
      *
      * @throws ArithmeticError
      */
-    public function toNanos() : int
+    public function toNanos(): int
     {
         $tempSeconds = $this->seconds;
         $tempNanos = $this->nanos;
@@ -715,7 +725,7 @@ final class Duration implements \JsonSerializable
      *
      * This instance is immutable and unaffected by this method call.
      */
-    public function toNanosPart() : int
+    public function toNanosPart(): int
     {
         return $this->nanos;
     }
@@ -723,7 +733,7 @@ final class Duration implements \JsonSerializable
     /**
      * Serializes as a string using {@see Duration::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
@@ -739,10 +749,10 @@ final class Duration implements \JsonSerializable
      *
      * Note that multiples of 24 hours are not output as days to avoid confusion with Period.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         $seconds = $this->seconds;
-        $nanos   = $this->nanos;
+        $nanos = $this->nanos;
 
         if ($seconds === 0 && $nanos === 0) {
             return 'PT0S';
@@ -755,8 +765,8 @@ final class Duration implements \JsonSerializable
             $nanos = LocalTime::NANOS_PER_SECOND - $nanos;
         }
 
-        $hours = \intdiv($seconds, LocalTime::SECONDS_PER_HOUR);
-        $minutes = \intdiv($seconds % LocalTime::SECONDS_PER_HOUR, LocalTime::SECONDS_PER_MINUTE);
+        $hours = intdiv($seconds, LocalTime::SECONDS_PER_HOUR);
+        $minutes = intdiv($seconds % LocalTime::SECONDS_PER_HOUR, LocalTime::SECONDS_PER_MINUTE);
         $seconds = $seconds % LocalTime::SECONDS_PER_MINUTE;
 
         $string = 'PT';
@@ -775,7 +785,7 @@ final class Duration implements \JsonSerializable
         $string .= (($seconds === 0 && $negative) ? '-0' : $seconds);
 
         if ($nanos !== 0) {
-            $string .= '.' . \rtrim(\sprintf('%09d', $nanos), '0');
+            $string .= '.' . rtrim(sprintf('%09d', $nanos), '0');
         }
 
         return $string . 'S';

--- a/src/Field/DayOfMonth.php
+++ b/src/Field/DayOfMonth.php
@@ -28,7 +28,7 @@ final class DayOfMonth
      *
      * @throws DateTimeException If the day-of-month is not valid.
      */
-    public static function check(int $dayOfMonth, ?int $monthOfYear = null, ?int $year = null) : void
+    public static function check(int $dayOfMonth, ?int $monthOfYear = null, ?int $year = null): void
     {
         if ($dayOfMonth < 1 || $dayOfMonth > 31) {
             throw DateTimeException::fieldNotInRange(self::NAME, $dayOfMonth, 1, 31);

--- a/src/Field/DayOfWeek.php
+++ b/src/Field/DayOfWeek.php
@@ -21,7 +21,7 @@ final class DayOfWeek
      *
      * @throws DateTimeException If the day-of-week is not valid.
      */
-    public static function check(int $dayOfWeek) : void
+    public static function check(int $dayOfWeek): void
     {
         if ($dayOfWeek < 1 || $dayOfWeek > 7) {
             throw DateTimeException::fieldNotInRange(self::NAME, $dayOfWeek, 1, 7);

--- a/src/Field/DayOfYear.php
+++ b/src/Field/DayOfYear.php
@@ -22,7 +22,7 @@ final class DayOfYear
      *
      * @throws DateTimeException If the day-of-year is not valid.
      */
-    public static function check(int $dayOfYear, ?int $year = null) : void
+    public static function check(int $dayOfYear, ?int $year = null): void
     {
         if ($dayOfYear < 1 || $dayOfYear > 366) {
             throw DateTimeException::fieldNotInRange(self::NAME, $dayOfYear, 1, 366);

--- a/src/Field/HourOfDay.php
+++ b/src/Field/HourOfDay.php
@@ -26,7 +26,7 @@ final class HourOfDay
      *
      * @throws DateTimeException If the hour-of-day is not valid.
      */
-    public static function check(int $hourOfDay) : void
+    public static function check(int $hourOfDay): void
     {
         if ($hourOfDay < 0 || $hourOfDay > 23) {
             throw DateTimeException::fieldNotInRange(self::NAME, $hourOfDay, 0, 23);

--- a/src/Field/MinuteOfHour.php
+++ b/src/Field/MinuteOfHour.php
@@ -26,7 +26,7 @@ final class MinuteOfHour
      *
      * @throws DateTimeException If the minute-of-hour is not valid.
      */
-    public static function check(int $minuteOfHour) : void
+    public static function check(int $minuteOfHour): void
     {
         if ($minuteOfHour < 0 || $minuteOfHour > 59) {
             throw DateTimeException::fieldNotInRange(self::NAME, $minuteOfHour, 0, 59);

--- a/src/Field/MonthOfYear.php
+++ b/src/Field/MonthOfYear.php
@@ -26,7 +26,7 @@ final class MonthOfYear
      *
      * @throws DateTimeException If the month-of-year is not valid.
      */
-    public static function check(int $monthOfYear) : void
+    public static function check(int $monthOfYear): void
     {
         if ($monthOfYear < 1 || $monthOfYear > 12) {
             throw DateTimeException::fieldNotInRange(self::NAME, $monthOfYear, 1, 12);
@@ -41,7 +41,7 @@ final class MonthOfYear
      * @param int      $monthOfYear The month-of-year, validated.
      * @param int|null $year        An optional year the month-of-year belongs to, validated.
      */
-    public static function getLength(int $monthOfYear, ?int $year = null) : int
+    public static function getLength(int $monthOfYear, ?int $year = null): int
     {
         switch ($monthOfYear) {
             case 2:
@@ -63,18 +63,18 @@ final class MonthOfYear
      *
      * @param int $monthOfYear The month-of-year, validated.
      */
-    public static function getName(int $monthOfYear) : string
+    public static function getName(int $monthOfYear): string
     {
         $names = [
-            1  => 'January',
-            2  => 'February',
-            3  => 'March',
-            4  => 'April',
-            5  => 'May',
-            6  => 'June',
-            7  => 'July',
-            8  => 'August',
-            9  => 'September',
+            1 => 'January',
+            2 => 'February',
+            3 => 'March',
+            4 => 'April',
+            5 => 'May',
+            6 => 'June',
+            7 => 'July',
+            8 => 'August',
+            9 => 'September',
             10 => 'October',
             11 => 'November',
             12 => 'December'

--- a/src/Field/NanoOfSecond.php
+++ b/src/Field/NanoOfSecond.php
@@ -21,7 +21,7 @@ final class NanoOfSecond
      *
      * @throws DateTimeException If the nano-of-second is not valid.
      */
-    public static function check(int $nanoOfSecond) : void
+    public static function check(int $nanoOfSecond): void
     {
         if ($nanoOfSecond < 0 || $nanoOfSecond > 999999999) {
             throw DateTimeException::fieldNotInRange(self::NAME, $nanoOfSecond, 0, 999999999);

--- a/src/Field/SecondOfDay.php
+++ b/src/Field/SecondOfDay.php
@@ -21,7 +21,7 @@ final class SecondOfDay
      *
      * @throws DateTimeException If the second-of-day is not valid.
      */
-    public static function check(int $secondOfDay) : void
+    public static function check(int $secondOfDay): void
     {
         if ($secondOfDay < 0 || $secondOfDay > 86399) {
             throw DateTimeException::fieldNotInRange(self::NAME, $secondOfDay, 0, 86399);

--- a/src/Field/SecondOfMinute.php
+++ b/src/Field/SecondOfMinute.php
@@ -26,7 +26,7 @@ final class SecondOfMinute
      *
      * @throws DateTimeException If the second-of-minute is not valid.
      */
-    public static function check(int $secondOfMinute) : void
+    public static function check(int $secondOfMinute): void
     {
         if ($secondOfMinute < 0 || $secondOfMinute > 59) {
             throw DateTimeException::fieldNotInRange(self::NAME, $secondOfMinute, 0, 59);

--- a/src/Field/TimeZoneOffsetHour.php
+++ b/src/Field/TimeZoneOffsetHour.php
@@ -26,7 +26,7 @@ final class TimeZoneOffsetHour
      *
      * @throws DateTimeException If the offset-hour is not valid.
      */
-    public static function check(int $offsetHour) : void
+    public static function check(int $offsetHour): void
     {
         if ($offsetHour < -18 || $offsetHour > 18) {
             throw DateTimeException::fieldNotInRange(self::NAME, $offsetHour, -18, 18);

--- a/src/Field/TimeZoneOffsetMinute.php
+++ b/src/Field/TimeZoneOffsetMinute.php
@@ -26,7 +26,7 @@ final class TimeZoneOffsetMinute
      *
      * @throws DateTimeException If the offset-minute is not valid.
      */
-    public static function check(int $offsetMinute) : void
+    public static function check(int $offsetMinute): void
     {
         if ($offsetMinute < -59 || $offsetMinute > 59) {
             throw DateTimeException::fieldNotInRange(self::NAME, $offsetMinute, -59, 59);

--- a/src/Field/TimeZoneOffsetTotalSeconds.php
+++ b/src/Field/TimeZoneOffsetTotalSeconds.php
@@ -28,7 +28,7 @@ final class TimeZoneOffsetTotalSeconds
      *
      * @throws DateTimeException If the offset-seconds is not valid.
      */
-    public static function check(int $offsetSeconds) : void
+    public static function check(int $offsetSeconds): void
     {
         if ($offsetSeconds < -self::MAX_SECONDS || $offsetSeconds > self::MAX_SECONDS) {
             throw DateTimeException::fieldNotInRange(self::NAME, $offsetSeconds, -self::MAX_SECONDS, self::MAX_SECONDS);

--- a/src/Field/WeekOfYear.php
+++ b/src/Field/WeekOfYear.php
@@ -24,7 +24,7 @@ final class WeekOfYear
      *
      * @throws DateTimeException If the week-of-year is not valid.
      */
-    public static function check(int $weekOfYear, ?int $year = null) : void
+    public static function check(int $weekOfYear, ?int $year = null): void
     {
         if ($weekOfYear < 1 || $weekOfYear > 53) {
             throw DateTimeException::fieldNotInRange(self::NAME, $weekOfYear, 1, 53);
@@ -44,7 +44,7 @@ final class WeekOfYear
      *
      * @return bool True if 53 weeks, false if 52 weeks.
      */
-    public static function is53WeekYear(int $year) : bool
+    public static function is53WeekYear(int $year): bool
     {
         $date = LocalDate::of($year, 1, 1);
         $dayOfWeek = $date->getDayOfWeek();
@@ -60,7 +60,7 @@ final class WeekOfYear
      *
      * @return int The number of weeks in the year.
      */
-    public static function getWeeksInYear(int $year) : int
+    public static function getWeeksInYear(int $year): int
     {
         return self::is53WeekYear($year) ? 53 : 52;
     }

--- a/src/Field/Year.php
+++ b/src/Field/Year.php
@@ -36,7 +36,7 @@ final class Year
      *
      * @throws DateTimeException If the year is not valid.
      */
-    public static function check(int $year) : void
+    public static function check(int $year): void
     {
         if ($year < self::MIN_VALUE || $year > self::MAX_VALUE) {
             throw DateTimeException::fieldNotInRange(self::NAME, $year, self::MIN_VALUE, self::MAX_VALUE);
@@ -46,7 +46,7 @@ final class Year
     /**
      * @param int $year The year, validated.
      */
-    public static function isLeap(int $year) : bool
+    public static function isLeap(int $year): bool
     {
         return (($year & 3) === 0) && (($year % 100) !== 0 || ($year % 400) === 0);
     }

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -4,6 +4,17 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use JsonSerializable;
+
+use function assert;
+use function is_int;
+use function rtrim;
+use function str_pad;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+use const STR_PAD_LEFT;
+
 /**
  * Represents a point in time, with a nanosecond precision.
  *
@@ -11,7 +22,7 @@ namespace Brick\DateTime;
  * without any calendar concept of date, time or time zone. It is not very meaningful to humans,
  * but can be converted to a `ZonedDateTime` by providing a time zone.
  */
-final class Instant implements \JsonSerializable
+final class Instant implements JsonSerializable
 {
     /**
      * The number of seconds since the epoch of 1970-01-01T00:00:00Z.
@@ -32,7 +43,7 @@ final class Instant implements \JsonSerializable
     private function __construct(int $epochSecond, int $nano)
     {
         $this->epochSecond = $epochSecond;
-        $this->nano        = $nano;
+        $this->nano = $nano;
     }
 
     /**
@@ -50,11 +61,11 @@ final class Instant implements \JsonSerializable
      * @param int $epochSecond    The number of seconds since the UNIX epoch of 1970-01-01T00:00:00Z.
      * @param int $nanoAdjustment The adjustment to the epoch second in nanoseconds.
      */
-    public static function of(int $epochSecond, int $nanoAdjustment = 0) : Instant
+    public static function of(int $epochSecond, int $nanoAdjustment = 0): Instant
     {
         $nanos = $nanoAdjustment % LocalTime::NANOS_PER_SECOND;
         $epochSecond += ($nanoAdjustment - $nanos) / LocalTime::NANOS_PER_SECOND;
-        \assert(\is_int($epochSecond));
+        assert(is_int($epochSecond));
 
         if ($nanos < 0) {
             $nanos += LocalTime::NANOS_PER_SECOND;
@@ -64,12 +75,12 @@ final class Instant implements \JsonSerializable
         return new Instant($epochSecond, $nanos);
     }
 
-    public static function epoch() : Instant
+    public static function epoch(): Instant
     {
         return new Instant(0, 0);
     }
 
-    public static function now(?Clock $clock = null) : Instant
+    public static function now(?Clock $clock = null): Instant
     {
         if ($clock === null) {
             $clock = DefaultClock::get();
@@ -83,9 +94,9 @@ final class Instant implements \JsonSerializable
      *
      * This could be used by an application as a "far past" instant.
      */
-    public static function min() : Instant
+    public static function min(): Instant
     {
-        return new Instant(\PHP_INT_MIN, 0);
+        return new Instant(PHP_INT_MIN, 0);
     }
 
     /**
@@ -93,12 +104,12 @@ final class Instant implements \JsonSerializable
      *
      * This could be used by an application as a "far future" instant.
      */
-    public static function max() : Instant
+    public static function max(): Instant
     {
-        return new Instant(\PHP_INT_MAX, 999999999);
+        return new Instant(PHP_INT_MAX, 999999999);
     }
 
-    public function plus(Duration $duration) : Instant
+    public function plus(Duration $duration): Instant
     {
         if ($duration->isZero()) {
             return $this;
@@ -110,7 +121,7 @@ final class Instant implements \JsonSerializable
         return Instant::of($seconds, $nanos);
     }
 
-    public function minus(Duration $duration) : Instant
+    public function minus(Duration $duration): Instant
     {
         if ($duration->isZero()) {
             return $this;
@@ -119,7 +130,7 @@ final class Instant implements \JsonSerializable
         return $this->plus($duration->negated());
     }
 
-    public function plusSeconds(int $seconds) : Instant
+    public function plusSeconds(int $seconds): Instant
     {
         if ($seconds === 0) {
             return $this;
@@ -128,32 +139,32 @@ final class Instant implements \JsonSerializable
         return new Instant($this->epochSecond + $seconds, $this->nano);
     }
 
-    public function minusSeconds(int $seconds) : Instant
+    public function minusSeconds(int $seconds): Instant
     {
         return $this->plusSeconds(-$seconds);
     }
 
-    public function plusMinutes(int $minutes) : Instant
+    public function plusMinutes(int $minutes): Instant
     {
         return $this->plusSeconds($minutes * LocalTime::SECONDS_PER_MINUTE);
     }
 
-    public function minusMinutes(int $minutes) : Instant
+    public function minusMinutes(int $minutes): Instant
     {
         return $this->plusMinutes(-$minutes);
     }
 
-    public function plusHours(int $hours) : Instant
+    public function plusHours(int $hours): Instant
     {
         return $this->plusSeconds($hours * LocalTime::SECONDS_PER_HOUR);
     }
 
-    public function minusHours(int $hours) : Instant
+    public function minusHours(int $hours): Instant
     {
         return $this->plusHours(-$hours);
     }
 
-    public function plusDays(int $days) : Instant
+    public function plusDays(int $days): Instant
     {
         return $this->plusSeconds($days * LocalTime::SECONDS_PER_DAY);
     }
@@ -161,7 +172,7 @@ final class Instant implements \JsonSerializable
     /**
      * Returns a copy of this Instant with the epoch second altered.
      */
-    public function withEpochSecond(int $epochSecond) : Instant
+    public function withEpochSecond(int $epochSecond): Instant
     {
         if ($epochSecond === $this->epochSecond) {
             return $this;
@@ -175,7 +186,7 @@ final class Instant implements \JsonSerializable
      *
      * @throws DateTimeException If the nano-of-second if not valid.
      */
-    public function withNano(int $nano) : Instant
+    public function withNano(int $nano): Instant
     {
         if ($nano === $this->nano) {
             return $this;
@@ -186,17 +197,17 @@ final class Instant implements \JsonSerializable
         return new Instant($this->epochSecond, $nano);
     }
 
-    public function minusDays(int $days) : Instant
+    public function minusDays(int $days): Instant
     {
         return $this->plusDays(-$days);
     }
 
-    public function getEpochSecond() : int
+    public function getEpochSecond(): int
     {
         return $this->epochSecond;
     }
 
-    public function getNano() : int
+    public function getNano(): int
     {
         return $this->nano;
     }
@@ -206,7 +217,7 @@ final class Instant implements \JsonSerializable
      *
      * @return int [-1,0,1] If this instant is before, on, or after the given instant.
      */
-    public function compareTo(Instant $that) : int
+    public function compareTo(Instant $that): int
     {
         $seconds = $this->getEpochSecond() - $that->getEpochSecond();
 
@@ -226,7 +237,7 @@ final class Instant implements \JsonSerializable
     /**
      * Returns whether this instant equals another.
      */
-    public function isEqualTo(Instant $that) : bool
+    public function isEqualTo(Instant $that): bool
     {
         return $this->compareTo($that) === 0;
     }
@@ -234,7 +245,7 @@ final class Instant implements \JsonSerializable
     /**
      * Returns whether this instant is after another.
      */
-    public function isAfter(Instant $that) : bool
+    public function isAfter(Instant $that): bool
     {
         return $this->compareTo($that) === 1;
     }
@@ -242,7 +253,7 @@ final class Instant implements \JsonSerializable
     /**
      * Returns whether this instant is after or equal to another.
      */
-    public function isAfterOrEqualTo(Instant $that) : bool
+    public function isAfterOrEqualTo(Instant $that): bool
     {
         return $this->compareTo($that) >= 0;
     }
@@ -250,7 +261,7 @@ final class Instant implements \JsonSerializable
     /**
      * Returns whether this instant is before another.
      */
-    public function isBefore(Instant $that) : bool
+    public function isBefore(Instant $that): bool
     {
         return $this->compareTo($that) === -1;
     }
@@ -258,17 +269,17 @@ final class Instant implements \JsonSerializable
     /**
      * Returns whether this instant is before or equal to another.
      */
-    public function isBeforeOrEqualTo(Instant $that) : bool
+    public function isBeforeOrEqualTo(Instant $that): bool
     {
         return $this->compareTo($that) <= 0;
     }
 
-    public function isBetweenInclusive(Instant $from, Instant $to) : bool
+    public function isBetweenInclusive(Instant $from, Instant $to): bool
     {
         return $this->isAfterOrEqualTo($from) && $this->isBeforeOrEqualTo($to);
     }
 
-    public function isBetweenExclusive(Instant $from, Instant $to) : bool
+    public function isBetweenExclusive(Instant $from, Instant $to): bool
     {
         return $this->isAfter($from) && $this->isBefore($to);
     }
@@ -278,7 +289,7 @@ final class Instant implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public function isFuture(?Clock $clock = null) : bool
+    public function isFuture(?Clock $clock = null): bool
     {
         return $this->isAfter(Instant::now($clock));
     }
@@ -288,7 +299,7 @@ final class Instant implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public function isPast(?Clock $clock = null) : bool
+    public function isPast(?Clock $clock = null): bool
     {
         return $this->isBefore(Instant::now($clock));
     }
@@ -296,7 +307,7 @@ final class Instant implements \JsonSerializable
     /**
      * Returns a ZonedDateTime formed from this instant and the specified time-zone.
      */
-    public function atTimeZone(TimeZone $timeZone) : ZonedDateTime
+    public function atTimeZone(TimeZone $timeZone): ZonedDateTime
     {
         return ZonedDateTime::ofInstant($this, $timeZone);
     }
@@ -308,7 +319,7 @@ final class Instant implements \JsonSerializable
      *
      * Examples: `123456789`, `123456789.5`, `123456789.000000001`.
      */
-    public function toDecimal() : string
+    public function toDecimal(): string
     {
         $result = (string) $this->epochSecond;
 
@@ -326,12 +337,12 @@ final class Instant implements \JsonSerializable
     /**
      * Serializes as a string using {@see Instant::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return (string) ZonedDateTime::ofInstant($this, TimeZone::utc());
     }

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use JsonSerializable;
+
 /**
  * Represents a period of time between two instants, inclusive of the start instant and exclusive of the end.
  * The end instant is always greater than or equal to the start instant.
  *
  * This class is immutable.
  */
-final class Interval implements \JsonSerializable
+final class Interval implements JsonSerializable
 {
     /**
      * The start instant, inclusive.
@@ -41,7 +43,7 @@ final class Interval implements \JsonSerializable
     /**
      * Returns the start instant, inclusive, of this Interval.
      */
-    public function getStart() : Instant
+    public function getStart(): Instant
     {
         return $this->start;
     }
@@ -49,7 +51,7 @@ final class Interval implements \JsonSerializable
     /**
      * Returns the end instant, exclusive, of this Interval.
      */
-    public function getEnd() : Instant
+    public function getEnd(): Instant
     {
         return $this->end;
     }
@@ -59,7 +61,7 @@ final class Interval implements \JsonSerializable
      *
      * @throws DateTimeException If the given start instant is after the current end instant.
      */
-    public function withStart(Instant $start) : Interval
+    public function withStart(Instant $start): Interval
     {
         return new Interval($start, $this->end);
     }
@@ -69,7 +71,7 @@ final class Interval implements \JsonSerializable
      *
      * @throws DateTimeException If the given end instant is before the current start instant.
      */
-    public function withEnd(Instant $end) : Interval
+    public function withEnd(Instant $end): Interval
     {
         return new Interval($this->start, $end);
     }
@@ -77,7 +79,7 @@ final class Interval implements \JsonSerializable
     /**
      * Returns a Duration representing the time elapsed in this Interval.
      */
-    public function getDuration() : Duration
+    public function getDuration(): Duration
     {
         return Duration::between($this->start, $this->end);
     }
@@ -85,12 +87,12 @@ final class Interval implements \JsonSerializable
     /**
      * Serializes as a string using {@see Interval::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->start . '/' . $this->end;
     }

--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -4,18 +4,26 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
-use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\IsoParsers;
 use Brick\DateTime\Utility\Math;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonSerializable;
+
+use function intdiv;
+use function min;
+use function sprintf;
 
 /**
  * A date without a time-zone in the ISO-8601 calendar system, such as `2007-12-03`.
  *
  * This class is immutable.
  */
-final class LocalDate implements \JsonSerializable
+final class LocalDate implements JsonSerializable
 {
     /**
      * The minimum supported year for instances of `LocalDate`, -999,999.
@@ -61,9 +69,9 @@ final class LocalDate implements \JsonSerializable
      */
     private function __construct(int $year, int $month, int $day)
     {
-        $this->year  = $year;
+        $this->year = $year;
         $this->month = $month;
-        $this->day   = $day;
+        $this->day = $day;
     }
 
     /**
@@ -75,7 +83,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the date is not valid.
      */
-    public static function of(int $year, int $month, int $day) : LocalDate
+    public static function of(int $year, int $month, int $day): LocalDate
     {
         Field\Year::check($year);
         Field\MonthOfYear::check($month);
@@ -92,14 +100,14 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If either value is not valid.
      */
-    public static function ofYearDay(int $year, int $dayOfYear) : LocalDate
+    public static function ofYearDay(int $year, int $dayOfYear): LocalDate
     {
         Field\Year::check($year);
         Field\DayOfYear::check($dayOfYear, $year);
 
         $isLeap = Field\Year::isLeap($year);
 
-        $monthOfYear = Month::of(\intdiv($dayOfYear - 1, 31) + 1);
+        $monthOfYear = Month::of(intdiv($dayOfYear - 1, 31) + 1);
         $monthEnd = $monthOfYear->getFirstDayOfYear($isLeap) + $monthOfYear->getLength($isLeap) - 1;
 
         if ($dayOfYear > $monthEnd) {
@@ -115,11 +123,11 @@ final class LocalDate implements \JsonSerializable
      * @throws DateTimeException      If the date is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : LocalDate
+    public static function from(DateTimeParseResult $result): LocalDate
     {
-        $year  = (int) $result->getField(Field\Year::NAME);
+        $year = (int) $result->getField(Field\Year::NAME);
         $month = (int) $result->getField(Field\MonthOfYear::NAME);
-        $day   = (int) $result->getField(Field\DayOfMonth::NAME);
+        $day = (int) $result->getField(Field\DayOfMonth::NAME);
 
         return LocalDate::of($year, $month, $day);
     }
@@ -133,7 +141,7 @@ final class LocalDate implements \JsonSerializable
      * @throws DateTimeException      If the date is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : LocalDate
+    public static function parse(string $text, ?DateTimeParser $parser = null): LocalDate
     {
         if (! $parser) {
             $parser = IsoParsers::localDate();
@@ -145,7 +153,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Creates a LocalDate from a native DateTime or DateTimeImmutable object.
      */
-    public static function fromNativeDateTime(\DateTimeInterface $dateTime) : LocalDate
+    public static function fromNativeDateTime(DateTimeInterface $dateTime): LocalDate
     {
         return new LocalDate(
             (int) $dateTime->format('Y'),
@@ -156,9 +164,10 @@ final class LocalDate implements \JsonSerializable
 
     /**
      * Creates a LocalDate from a native DateTime or DateTimeImmutable object.
+     *
      * @deprecated please use fromNativeDateTime instead
      */
-    public static function fromDateTime(\DateTimeInterface $dateTime) : LocalDate
+    public static function fromDateTime(DateTimeInterface $dateTime): LocalDate
     {
         return self::fromNativeDateTime($dateTime);
     }
@@ -171,7 +180,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the resulting date has a year out of range.
      */
-    public static function ofEpochDay(int $epochDay) : LocalDate
+    public static function ofEpochDay(int $epochDay): LocalDate
     {
         $zeroDay = $epochDay + self::DAYS_0000_TO_1970;
         // Find the march-based year.
@@ -179,25 +188,25 @@ final class LocalDate implements \JsonSerializable
         $adjust = 0;
         if ($zeroDay < 0) {
             // Adjust negative years to positive for calculation.
-            $adjustCycles = \intdiv(($zeroDay + 1), self::DAYS_PER_CYCLE) - 1;
+            $adjustCycles = intdiv(($zeroDay + 1), self::DAYS_PER_CYCLE) - 1;
             $adjust = $adjustCycles * 400;
             $zeroDay += -$adjustCycles * self::DAYS_PER_CYCLE;
         }
-        $yearEst = \intdiv(400 * $zeroDay + 591, self::DAYS_PER_CYCLE);
-        $doyEst = $zeroDay - (365 * $yearEst + \intdiv($yearEst, 4) - \intdiv($yearEst, 100) + \intdiv($yearEst, 400));
+        $yearEst = intdiv(400 * $zeroDay + 591, self::DAYS_PER_CYCLE);
+        $doyEst = $zeroDay - (365 * $yearEst + intdiv($yearEst, 4) - intdiv($yearEst, 100) + intdiv($yearEst, 400));
         if ($doyEst < 0) {
             // Fix estimate.
             $yearEst--;
-            $doyEst = $zeroDay - (365 * $yearEst + \intdiv($yearEst, 4) - \intdiv($yearEst, 100) + \intdiv($yearEst, 400));
+            $doyEst = $zeroDay - (365 * $yearEst + intdiv($yearEst, 4) - intdiv($yearEst, 100) + intdiv($yearEst, 400));
         }
         $yearEst += $adjust; // Reset any negative year.
         $marchDoy0 = $doyEst;
 
         // Convert march-based values back to January-based.
-        $marchMonth0 = \intdiv($marchDoy0 * 5 + 2, 153);
+        $marchMonth0 = intdiv($marchDoy0 * 5 + 2, 153);
         $month = ($marchMonth0 + 2) % 12 + 1;
-        $dom = $marchDoy0 - \intdiv($marchMonth0 * 306 + 5, 10) + 1;
-        $yearEst += \intdiv($marchMonth0, 10);
+        $dom = $marchDoy0 - intdiv($marchMonth0 * 306 + 5, 10) + 1;
+        $yearEst += intdiv($marchMonth0, 10);
 
         // Check year now we are certain it is correct.
         Field\Year::check($yearEst);
@@ -210,7 +219,7 @@ final class LocalDate implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : LocalDate
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): LocalDate
     {
         return ZonedDateTime::now($timeZone, $clock)->getDate();
     }
@@ -220,7 +229,7 @@ final class LocalDate implements \JsonSerializable
      *
      * This can be used by an application as a "far past" date.
      */
-    public static function min() : LocalDate
+    public static function min(): LocalDate
     {
         return LocalDate::of(self::MIN_YEAR, 1, 1);
     }
@@ -230,7 +239,7 @@ final class LocalDate implements \JsonSerializable
      *
      * This can be used by an application as a "far future" date.
      */
-    public static function max() : LocalDate
+    public static function max(): LocalDate
     {
         return LocalDate::of(self::MAX_YEAR, 12, 31);
     }
@@ -244,7 +253,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the array is empty.
      */
-    public static function minOf(LocalDate ...$dates) : LocalDate
+    public static function minOf(LocalDate ...$dates): LocalDate
     {
         if (! $dates) {
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
@@ -270,7 +279,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the array is empty.
      */
-    public static function maxOf(LocalDate ...$dates) : LocalDate
+    public static function maxOf(LocalDate ...$dates): LocalDate
     {
         if (! $dates) {
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
@@ -287,27 +296,27 @@ final class LocalDate implements \JsonSerializable
         return $max;
     }
 
-    public function getYear() : int
+    public function getYear(): int
     {
         return $this->year;
     }
 
-    public function getMonth() : int
+    public function getMonth(): int
     {
         return $this->month;
     }
 
-    public function getDay() : int
+    public function getDay(): int
     {
         return $this->day;
     }
 
-    public function getYearMonth() : YearMonth
+    public function getYearMonth(): YearMonth
     {
         return YearMonth::of($this->year, $this->month);
     }
 
-    public function getDayOfWeek() : DayOfWeek
+    public function getDayOfWeek(): DayOfWeek
     {
         return DayOfWeek::of(Math::floorMod($this->toEpochDay() + 3, 7) + 1);
     }
@@ -315,12 +324,12 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns the day-of-year, from 1 to 365, or 366 in a leap year.
      */
-    public function getDayOfYear() : int
+    public function getDayOfYear(): int
     {
         return Month::of($this->month)->getFirstDayOfYear($this->isLeapYear()) + $this->day - 1;
     }
 
-    public function getYearWeek() : YearWeek
+    public function getYearWeek(): YearWeek
     {
         $year = $this->year;
         $week = intdiv($this->getDayOfYear() - $this->getDayOfWeek()->getValue() + 10, 7);
@@ -343,7 +352,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the year is outside the valid range.
      */
-    public function withYear(int $year) : LocalDate
+    public function withYear(int $year): LocalDate
     {
         if ($year === $this->year) {
             return $this;
@@ -361,7 +370,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the month is invalid.
      */
-    public function withMonth(int $month) : LocalDate
+    public function withMonth(int $month): LocalDate
     {
         if ($month === $this->month) {
             return $this;
@@ -379,7 +388,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the day is invalid for the current year and month.
      */
-    public function withDay(int $day) : LocalDate
+    public function withDay(int $day): LocalDate
     {
         if ($day === $this->day) {
             return $this;
@@ -393,7 +402,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns a copy of this LocalDate with the specified Period added.
      */
-    public function plusPeriod(Period $period) : LocalDate
+    public function plusPeriod(Period $period): LocalDate
     {
         return $this
             ->plusYears($period->getYears())
@@ -409,7 +418,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @throws DateTimeException If the resulting year is out of range.
      */
-    public function plusYears(int $years) : LocalDate
+    public function plusYears(int $years): LocalDate
     {
         if ($years === 0) {
             return $this;
@@ -424,7 +433,7 @@ final class LocalDate implements \JsonSerializable
      * If the day-of-month is invalid for the resulting year and month,
      * it will be changed to the last valid day of the month.
      */
-    public function plusMonths(int $months) : LocalDate
+    public function plusMonths(int $months): LocalDate
     {
         $month = $this->month + $months - 1;
 
@@ -439,7 +448,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns a copy of this LocalDate with the specified period in weeks added.
      */
-    public function plusWeeks(int $weeks) : LocalDate
+    public function plusWeeks(int $weeks): LocalDate
     {
         if ($weeks === 0) {
             return $this;
@@ -451,7 +460,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns a copy of this LocalDate with the specified period in days added.
      */
-    public function plusDays(int $days) : LocalDate
+    public function plusDays(int $days): LocalDate
     {
         if ($days === 0) {
             return $this;
@@ -467,7 +476,7 @@ final class LocalDate implements \JsonSerializable
      *
      * Note: this is currently a naive implementation that could be greatly improved.
      */
-    public function plusWeekdays(int $days) : LocalDate
+    public function plusWeekdays(int $days): LocalDate
     {
         $result = $this;
 
@@ -499,7 +508,7 @@ final class LocalDate implements \JsonSerializable
      * If the current date is on a weekend and the number of days is zero, the result is the current date.
      * This is a slightly different behaviour from PHP DateTime's "- n weekdays", that would return the next monday.
      */
-    public function minusWeekdays(int $days) : LocalDate
+    public function minusWeekdays(int $days): LocalDate
     {
         return $this->plusWeekdays(-$days);
     }
@@ -507,7 +516,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns a copy of this LocalDate with the specified Period subtracted.
      */
-    public function minusPeriod(Period $period) : LocalDate
+    public function minusPeriod(Period $period): LocalDate
     {
         return $this->plusPeriod($period->negated());
     }
@@ -515,33 +524,33 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns a copy of this LocalDate with the specified period in years subtracted.
      */
-    public function minusYears(int $years) : LocalDate
+    public function minusYears(int $years): LocalDate
     {
-        return $this->plusYears(- $years);
+        return $this->plusYears(-$years);
     }
 
     /**
      * Returns a copy of this LocalDate with the specified period in months subtracted.
      */
-    public function minusMonths(int $months) : LocalDate
+    public function minusMonths(int $months): LocalDate
     {
-        return $this->plusMonths(- $months);
+        return $this->plusMonths(-$months);
     }
 
     /**
      * Returns a copy of this LocalDate with the specified period in weeks subtracted.
      */
-    public function minusWeeks(int $weeks) : LocalDate
+    public function minusWeeks(int $weeks): LocalDate
     {
-        return $this->plusWeeks(- $weeks);
+        return $this->plusWeeks(-$weeks);
     }
 
     /**
      * Returns a copy of this LocalDate with the specified period in days subtracted.
      */
-    public function minusDays(int $days) : LocalDate
+    public function minusDays(int $days): LocalDate
     {
-        return $this->plusDays(- $days);
+        return $this->plusDays(-$days);
     }
 
     /**
@@ -549,7 +558,7 @@ final class LocalDate implements \JsonSerializable
      *
      * @return int [-1,0,1] If this date is before, on, or after the given date.
      */
-    public function compareTo(LocalDate $that) : int
+    public function compareTo(LocalDate $that): int
     {
         if ($this->year < $that->year) {
             return -1;
@@ -573,27 +582,27 @@ final class LocalDate implements \JsonSerializable
         return 0;
     }
 
-    public function isEqualTo(LocalDate $that) : bool
+    public function isEqualTo(LocalDate $that): bool
     {
         return $this->compareTo($that) === 0;
     }
 
-    public function isBefore(LocalDate $that) : bool
+    public function isBefore(LocalDate $that): bool
     {
         return $this->compareTo($that) === -1;
     }
 
-    public function isBeforeOrEqualTo(LocalDate $that) : bool
+    public function isBeforeOrEqualTo(LocalDate $that): bool
     {
         return $this->compareTo($that) <= 0;
     }
 
-    public function isAfter(LocalDate $that) : bool
+    public function isAfter(LocalDate $that): bool
     {
         return $this->compareTo($that) === 1;
     }
 
-    public function isAfterOrEqualTo(LocalDate $that) : bool
+    public function isAfterOrEqualTo(LocalDate $that): bool
     {
         return $this->compareTo($that) >= 0;
     }
@@ -614,7 +623,7 @@ final class LocalDate implements \JsonSerializable
      *
      * For example, from `2010-01-15` to `2011-03-18` is 1 year, 2 months and 3 days.
      */
-    public function until(LocalDate $endDateExclusive) : Period
+    public function until(LocalDate $endDateExclusive): Period
     {
         $totalMonths = $endDateExclusive->getProlepticMonth() - $this->getProlepticMonth();
         $days = $endDateExclusive->day - $this->day;
@@ -628,7 +637,7 @@ final class LocalDate implements \JsonSerializable
             $days -= $endDateExclusive->getLengthOfMonth();
         }
 
-        $years = \intdiv($totalMonths, 12);
+        $years = intdiv($totalMonths, 12);
         $months = $totalMonths % 12;
 
         return Period::of($years, $months, $days);
@@ -640,7 +649,7 @@ final class LocalDate implements \JsonSerializable
      * The start date is included, but the end date is not.
      * For example, `2018-02-15` to `2018-04-01` is 45 days.
      */
-    public function daysUntil(LocalDate $endDateExclusive) : int
+    public function daysUntil(LocalDate $endDateExclusive): int
     {
         return $endDateExclusive->toEpochDay() - $this->toEpochDay();
     }
@@ -648,7 +657,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns a local date-time formed from this date at the specified time.
      */
-    public function atTime(LocalTime $time) : LocalDateTime
+    public function atTime(LocalTime $time): LocalDateTime
     {
         return new LocalDateTime($this, $time);
     }
@@ -656,7 +665,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Checks if the year is a leap year, according to the ISO proleptic calendar system rules.
      */
-    public function isLeapYear() : bool
+    public function isLeapYear(): bool
     {
         return Field\Year::isLeap($this->year);
     }
@@ -664,7 +673,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns the length of the year represented by this date, in days.
      */
-    public function getLengthOfYear() : int
+    public function getLengthOfYear(): int
     {
         return $this->isLeapYear() ? 366 : 365;
     }
@@ -672,7 +681,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns the length of the month represented by this date, in days.
      */
-    public function getLengthOfMonth() : int
+    public function getLengthOfMonth(): int
     {
         return Field\MonthOfYear::getLength($this->month, $this->year);
     }
@@ -680,7 +689,7 @@ final class LocalDate implements \JsonSerializable
     /**
      * Returns the number of days since the UNIX epoch of 1st January 1970.
      */
-    public function toEpochDay() : int
+    public function toEpochDay(): int
     {
         $y = $this->year;
         $m = $this->month;
@@ -688,12 +697,12 @@ final class LocalDate implements \JsonSerializable
         $total = 365 * $y;
 
         if ($y >= 0) {
-            $total += \intdiv($y + 3, 4) - \intdiv($y + 99, 100) + \intdiv($y + 399, 400);
+            $total += intdiv($y + 3, 4) - intdiv($y + 99, 100) + intdiv($y + 399, 400);
         } else {
-            $total -= \intdiv($y, -4) - \intdiv($y, -100) + \intdiv($y, -400);
+            $total -= intdiv($y, -4) - intdiv($y, -100) + intdiv($y, -400);
         }
 
-        $total += \intdiv(367 * $m - 362, 12);
+        $total += intdiv(367 * $m - 362, 12);
         $total += $this->day - 1;
 
         if ($m > 2) {
@@ -710,9 +719,10 @@ final class LocalDate implements \JsonSerializable
      * Converts this LocalDate to a native DateTime object.
      *
      * The result is a DateTime with time 00:00 in the UTC time-zone.
+     *
      * @deprecated please use toNativeDateTime instead
      */
-    public function toDateTime() : \DateTime
+    public function toDateTime(): DateTime
     {
         return $this->toNativeDateTime();
     }
@@ -722,7 +732,7 @@ final class LocalDate implements \JsonSerializable
      *
      * The result is a DateTime with time 00:00 in the UTC time-zone.
      */
-    public function toNativeDateTime() : \DateTime
+    public function toNativeDateTime(): DateTime
     {
         return $this->atTime(LocalTime::midnight())->toDateTime();
     }
@@ -731,9 +741,10 @@ final class LocalDate implements \JsonSerializable
      * Converts this LocalDate to a native DateTimeImmutable object.
      *
      * The result is a DateTimeImmutable with time 00:00 in the UTC time-zone.
+     *
      * @deprecated please use toNativeDateTimeImmutable instead
      */
-    public function toDateTimeImmutable() : \DateTimeImmutable
+    public function toDateTimeImmutable(): DateTimeImmutable
     {
         return $this->toNativeDateTimeImmutable();
     }
@@ -743,19 +754,27 @@ final class LocalDate implements \JsonSerializable
      *
      * The result is a DateTimeImmutable with time 00:00 in the UTC time-zone.
      */
-    public function toNativeDateTimeImmutable() : \DateTimeImmutable
+    public function toNativeDateTimeImmutable(): DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromMutable($this->toNativeDateTime());
+        return DateTimeImmutable::createFromMutable($this->toNativeDateTime());
+    }
+
+    /**
+     * Serializes as a string using {@see LocalDate::__toString()}.
+     */
+    public function jsonSerialize(): string
+    {
+        return (string) $this;
     }
 
     /**
      * Returns the ISO 8601 representation of this LocalDate.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         $pattern = ($this->year < 0 ? '%05d' : '%04d') . '-%02d-%02d';
 
-        return \sprintf($pattern, $this->year, $this->month, $this->day);
+        return sprintf($pattern, $this->year, $this->month, $this->day);
     }
 
     /**
@@ -765,24 +784,16 @@ final class LocalDate implements \JsonSerializable
      * @param int $month The month-of-year to represent, validated from 1 to 12.
      * @param int $day   The day-of-month to represent, validated from 1 to 31.
      */
-    private function resolvePreviousValid(int $year, int $month, int $day) : LocalDate
+    private function resolvePreviousValid(int $year, int $month, int $day): LocalDate
     {
         if ($day > 28) {
-            $day = \min($day, YearMonth::of($year, $month)->getLengthOfMonth());
+            $day = min($day, YearMonth::of($year, $month)->getLengthOfMonth());
         }
 
         return new LocalDate($year, $month, $day);
     }
 
-    /**
-     * Serializes as a string using {@see LocalDate::__toString()}.
-     */
-    public function jsonSerialize() : string
-    {
-        return (string) $this;
-    }
-
-    private function getProlepticMonth() : int
+    private function getProlepticMonth(): int
     {
         return $this->year * 12 + $this->month - 1;
     }

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -8,6 +8,12 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
+use Countable;
+use DateInterval;
+use DatePeriod;
+use Generator;
+use IteratorAggregate;
+use JsonSerializable;
 
 /**
  * Represents an inclusive range of local dates.
@@ -15,7 +21,7 @@ use Brick\DateTime\Parser\IsoParsers;
  * This object is iterable and countable: the iterator returns all the LocalDate objects contained
  * in the range, while `count()` returns the total number of dates contained in the range.
  */
-final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSerializable
+final class LocalDateRange implements IteratorAggregate, Countable, JsonSerializable
 {
     /**
      * The start date, inclusive.
@@ -34,7 +40,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     private function __construct(LocalDate $start, LocalDate $end)
     {
         $this->start = $start;
-        $this->end   = $end;
+        $this->end = $end;
     }
 
     /**
@@ -45,7 +51,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      *
      * @throws DateTimeException If the end date is before the start date.
      */
-    public static function of(LocalDate $start, LocalDate $end) : LocalDateRange
+    public static function of(LocalDate $start, LocalDate $end): LocalDateRange
     {
         if ($end->isBefore($start)) {
             throw new DateTimeException('The end date must not be before the start date.');
@@ -62,7 +68,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      * @throws DateTimeException      If the date range is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : LocalDateRange
+    public static function from(DateTimeParseResult $result): LocalDateRange
     {
         $startDate = LocalDate::from($result);
 
@@ -94,7 +100,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      * @throws DateTimeException      If either of the dates is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : LocalDateRange
+    public static function parse(string $text, ?DateTimeParser $parser = null): LocalDateRange
     {
         if (! $parser) {
             $parser = IsoParsers::localDateRange();
@@ -106,7 +112,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     /**
      * Returns the start date, inclusive.
      */
-    public function getStart() : LocalDate
+    public function getStart(): LocalDate
     {
         return $this->start;
     }
@@ -114,7 +120,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     /**
      * Returns the end date, inclusive.
      */
-    public function getEnd() : LocalDate
+    public function getEnd(): LocalDate
     {
         return $this->end;
     }
@@ -126,7 +132,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      *
      * @return bool True if this range equals the given one, false otherwise.
      */
-    public function isEqualTo(LocalDateRange $that) : bool
+    public function isEqualTo(LocalDateRange $that): bool
     {
         return $this->start->isEqualTo($that->start)
             && $this->end->isEqualTo($that->end);
@@ -139,7 +145,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      *
      * @return bool True if this range contains the given date, false otherwise.
      */
-    public function contains(LocalDate $date) : bool
+    public function contains(LocalDate $date): bool
     {
         return ! ($date->isBefore($this->start) || $date->isAfter($this->end));
     }
@@ -147,7 +153,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     /**
      * Returns whether this LocalDateRange intersects with the given date range.
      */
-    public function intersectsWith(LocalDateRange $that) : bool
+    public function intersectsWith(LocalDateRange $that): bool
     {
         return $this->contains($that->start)
             || $this->contains($that->end)
@@ -160,14 +166,14 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      *
      * @throws DateTimeException If the ranges do not intersect.
      */
-    public function getIntersectionWith(LocalDateRange $that) : LocalDateRange
+    public function getIntersectionWith(LocalDateRange $that): LocalDateRange
     {
-        if (!$this->intersectsWith($that)) {
+        if (! $this->intersectsWith($that)) {
             throw new DateTimeException('Ranges "' . $this . '" and "' . $that . '" do not intersect.');
         }
 
         $intersectStart = $this->start->isBefore($that->start) ? $that->start : $this->start;
-        $intersectEnd = $this->end->isAfter($that->end) ? $that->end: $this->end;
+        $intersectEnd = $this->end->isAfter($that->end) ? $that->end : $this->end;
 
         return new LocalDateRange($intersectStart, $intersectEnd);
     }
@@ -209,9 +215,9 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     /**
      * Returns an iterator for all the dates contained in this range.
      *
-     * @return \Generator<LocalDate>
+     * @return Generator<LocalDate>
      */
-    public function getIterator() : \Generator
+    public function getIterator(): Generator
     {
         for ($current = $this->start; $current->isBeforeOrEqualTo($this->end); $current = $current->plusDays(1)) {
             yield $current;
@@ -223,7 +229,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      *
      * @return int The number of days, >= 1.
      */
-    public function count() : int
+    public function count(): int
     {
         return $this->end->toEpochDay() - $this->start->toEpochDay() + 1;
     }
@@ -231,7 +237,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     /**
      * Serializes as a string using {@see LocalDateRange::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
@@ -242,18 +248,19 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
      * The result is a DatePeriod->start with time 00:00 and a DatePeriod->end
      * with time 23:59:59.999999 in the UTC time-zone.
      */
-    public function toNativeDatePeriod() : \DatePeriod
+    public function toNativeDatePeriod(): DatePeriod
     {
         $start = $this->getStart()->atTime(LocalTime::midnight())->toDateTime();
         $end = $this->getEnd()->atTime(LocalTime::max())->toDateTime();
-        $interval = new \DateInterval('P1D');
+        $interval = new DateInterval('P1D');
 
-        return new \DatePeriod($start, $interval, $end);
+        return new DatePeriod($start, $interval, $end);
     }
+
     /**
      * @deprecated please use toNativeDatePeriod instead
      */
-    public function toDatePeriod() : \DatePeriod
+    public function toDatePeriod(): DatePeriod
     {
         return $this->toNativeDatePeriod();
     }
@@ -261,7 +268,7 @@ final class LocalDateRange implements \IteratorAggregate, \Countable, \JsonSeria
     /**
      * Returns an ISO 8601 string representation of this date range.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->start . '/' . $this->end;
     }

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -9,13 +9,19 @@ use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
 use Brick\DateTime\Utility\Math;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonSerializable;
+
+use function intdiv;
 
 /**
  * A date-time without a time-zone in the ISO-8601 calendar system, such as 2007-12-03T10:15:30.
  *
  * This class is immutable.
  */
-final class LocalDateTime implements \JsonSerializable
+final class LocalDateTime implements JsonSerializable
 {
     private LocalDate $date;
 
@@ -38,7 +44,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the date or time is not valid.
      */
-    public static function of(int $year, int $month, int $day, int $hour = 0, int $minute = 0, int $second = 0, int $nano = 0) : LocalDateTime
+    public static function of(int $year, int $month, int $day, int $hour = 0, int $minute = 0, int $second = 0, int $nano = 0): LocalDateTime
     {
         $date = LocalDate::of($year, $month, $day);
         $time = LocalTime::of($hour, $minute, $second, $nano);
@@ -51,7 +57,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : LocalDateTime
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): LocalDateTime
     {
         return ZonedDateTime::now($timeZone, $clock)->getDateTime();
     }
@@ -60,7 +66,7 @@ final class LocalDateTime implements \JsonSerializable
      * @throws DateTimeException      If the date-time is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : LocalDateTime
+    public static function from(DateTimeParseResult $result): LocalDateTime
     {
         return new LocalDateTime(
             LocalDate::from($result),
@@ -77,7 +83,7 @@ final class LocalDateTime implements \JsonSerializable
      * @throws DateTimeException      If the date-time is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : LocalDateTime
+    public static function parse(string $text, ?DateTimeParser $parser = null): LocalDateTime
     {
         if (! $parser) {
             $parser = IsoParsers::localDateTime();
@@ -89,7 +95,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Creates a LocalDateTime from a native DateTime or DateTimeImmutable object.
      */
-    public static function fromDateTime(\DateTimeInterface $dateTime) : LocalDateTime
+    public static function fromDateTime(DateTimeInterface $dateTime): LocalDateTime
     {
         return new LocalDateTime(
             LocalDate::fromNativeDateTime($dateTime),
@@ -100,7 +106,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns the smallest possible value for LocalDateTime.
      */
-    public static function min() : LocalDateTime
+    public static function min(): LocalDateTime
     {
         return new LocalDateTime(LocalDate::min(), LocalTime::min());
     }
@@ -108,7 +114,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns the highest possible value for LocalDateTime.
      */
-    public static function max() : LocalDateTime
+    public static function max(): LocalDateTime
     {
         return new LocalDateTime(LocalDate::max(), LocalTime::max());
     }
@@ -122,7 +128,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the array is empty.
      */
-    public static function minOf(LocalDateTime ...$times) : LocalDateTime
+    public static function minOf(LocalDateTime ...$times): LocalDateTime
     {
         if (! $times) {
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
@@ -148,7 +154,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the array is empty.
      */
-    public static function maxOf(LocalDateTime ...$times) : LocalDateTime
+    public static function maxOf(LocalDateTime ...$times): LocalDateTime
     {
         if (! $times) {
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
@@ -165,57 +171,57 @@ final class LocalDateTime implements \JsonSerializable
         return $max;
     }
 
-    public function getDate() : LocalDate
+    public function getDate(): LocalDate
     {
         return $this->date;
     }
 
-    public function getTime() : LocalTime
+    public function getTime(): LocalTime
     {
         return $this->time;
     }
 
-    public function getYear() : int
+    public function getYear(): int
     {
         return $this->date->getYear();
     }
 
-    public function getMonth() : int
+    public function getMonth(): int
     {
         return $this->date->getMonth();
     }
 
-    public function getDay() : int
+    public function getDay(): int
     {
         return $this->date->getDay();
     }
 
-    public function getDayOfWeek() : DayOfWeek
+    public function getDayOfWeek(): DayOfWeek
     {
         return $this->date->getDayOfWeek();
     }
 
-    public function getDayOfYear() : int
+    public function getDayOfYear(): int
     {
         return $this->date->getDayOfYear();
     }
 
-    public function getHour() : int
+    public function getHour(): int
     {
         return $this->time->getHour();
     }
 
-    public function getMinute() : int
+    public function getMinute(): int
     {
         return $this->time->getMinute();
     }
 
-    public function getSecond() : int
+    public function getSecond(): int
     {
         return $this->time->getSecond();
     }
 
-    public function getNano() : int
+    public function getNano(): int
     {
         return $this->time->getNano();
     }
@@ -223,7 +229,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the date altered.
      */
-    public function withDate(LocalDate $date) : LocalDateTime
+    public function withDate(LocalDate $date): LocalDateTime
     {
         if ($date->isEqualTo($this->date)) {
             return $this;
@@ -235,7 +241,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the time altered.
      */
-    public function withTime(LocalTime $time) : LocalDateTime
+    public function withTime(LocalTime $time): LocalDateTime
     {
         if ($time->isEqualTo($this->time)) {
             return $this;
@@ -251,7 +257,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the year is outside the valid range.
      */
-    public function withYear(int $year) : LocalDateTime
+    public function withYear(int $year): LocalDateTime
     {
         $date = $this->date->withYear($year);
 
@@ -269,7 +275,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the month is invalid.
      */
-    public function withMonth(int $month) : LocalDateTime
+    public function withMonth(int $month): LocalDateTime
     {
         $date = $this->date->withMonth($month);
 
@@ -287,7 +293,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the day is invalid for the current year and month.
      */
-    public function withDay(int $day) : LocalDateTime
+    public function withDay(int $day): LocalDateTime
     {
         $date = $this->date->withDay($day);
 
@@ -303,7 +309,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the hour is invalid.
      */
-    public function withHour(int $hour) : LocalDateTime
+    public function withHour(int $hour): LocalDateTime
     {
         $time = $this->time->withHour($hour);
 
@@ -319,7 +325,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the minute-of-hour if not valid.
      */
-    public function withMinute(int $minute) : LocalDateTime
+    public function withMinute(int $minute): LocalDateTime
     {
         $time = $this->time->withMinute($minute);
 
@@ -335,7 +341,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the second-of-minute if not valid.
      */
-    public function withSecond(int $second) : LocalDateTime
+    public function withSecond(int $second): LocalDateTime
     {
         $time = $this->time->withSecond($second);
 
@@ -351,7 +357,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the nano-of-second if not valid.
      */
-    public function withNano(int $nano) : LocalDateTime
+    public function withNano(int $nano): LocalDateTime
     {
         $time = $this->time->withNano($nano);
 
@@ -369,7 +375,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @return ZonedDateTime The zoned date-time formed from this date-time.
      */
-    public function atTimeZone(TimeZone $zone) : ZonedDateTime
+    public function atTimeZone(TimeZone $zone): ZonedDateTime
     {
         return ZonedDateTime::of($this, $zone);
     }
@@ -377,7 +383,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified Period added.
      */
-    public function plusPeriod(Period $period) : LocalDateTime
+    public function plusPeriod(Period $period): LocalDateTime
     {
         $date = $this->date->plusPeriod($period);
 
@@ -391,7 +397,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specific Duration added.
      */
-    public function plusDuration(Duration $duration) : LocalDateTime
+    public function plusDuration(Duration $duration): LocalDateTime
     {
         if ($duration->isZero()) {
             return $this;
@@ -407,7 +413,7 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the resulting year is out of range.
      */
-    public function plusYears(int $years) : LocalDateTime
+    public function plusYears(int $years): LocalDateTime
     {
         if ($years === 0) {
             return $this;
@@ -419,7 +425,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in months added.
      */
-    public function plusMonths(int $months) : LocalDateTime
+    public function plusMonths(int $months): LocalDateTime
     {
         if ($months === 0) {
             return $this;
@@ -431,7 +437,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in weeks added.
      */
-    public function plusWeeks(int $weeks) : LocalDateTime
+    public function plusWeeks(int $weeks): LocalDateTime
     {
         if ($weeks === 0) {
             return $this;
@@ -443,7 +449,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in days added.
      */
-    public function plusDays(int $days) : LocalDateTime
+    public function plusDays(int $days): LocalDateTime
     {
         if ($days === 0) {
             return $this;
@@ -455,7 +461,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in hours added.
      */
-    public function plusHours(int $hours) : LocalDateTime
+    public function plusHours(int $hours): LocalDateTime
     {
         if ($hours === 0) {
             return $this;
@@ -467,7 +473,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in minutes added.
      */
-    public function plusMinutes(int $minutes) : LocalDateTime
+    public function plusMinutes(int $minutes): LocalDateTime
     {
         if ($minutes === 0) {
             return $this;
@@ -479,7 +485,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in seconds added.
      */
-    public function plusSeconds(int $seconds) : LocalDateTime
+    public function plusSeconds(int $seconds): LocalDateTime
     {
         if ($seconds === 0) {
             return $this;
@@ -491,7 +497,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in nanoseconds added.
      */
-    public function plusNanos(int $nanos) : LocalDateTime
+    public function plusNanos(int $nanos): LocalDateTime
     {
         if ($nanos === 0) {
             return $this;
@@ -503,7 +509,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified Period subtracted.
      */
-    public function minusPeriod(Period $period) : LocalDateTime
+    public function minusPeriod(Period $period): LocalDateTime
     {
         return $this->plusPeriod($period->negated());
     }
@@ -511,7 +517,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specific Duration subtracted.
      */
-    public function minusDuration(Duration $duration) : LocalDateTime
+    public function minusDuration(Duration $duration): LocalDateTime
     {
         return $this->plusDuration($duration->negated());
     }
@@ -519,7 +525,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in years subtracted.
      */
-    public function minusYears(int $years) : LocalDateTime
+    public function minusYears(int $years): LocalDateTime
     {
         if ($years === 0) {
             return $this;
@@ -531,7 +537,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in months subtracted.
      */
-    public function minusMonths(int $months) : LocalDateTime
+    public function minusMonths(int $months): LocalDateTime
     {
         if ($months === 0) {
             return $this;
@@ -543,7 +549,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in weeks subtracted.
      */
-    public function minusWeeks(int $weeks) : LocalDateTime
+    public function minusWeeks(int $weeks): LocalDateTime
     {
         if ($weeks === 0) {
             return $this;
@@ -555,7 +561,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in days subtracted.
      */
-    public function minusDays(int $days) : LocalDateTime
+    public function minusDays(int $days): LocalDateTime
     {
         if ($days === 0) {
             return $this;
@@ -567,7 +573,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in hours subtracted.
      */
-    public function minusHours(int $hours) : LocalDateTime
+    public function minusHours(int $hours): LocalDateTime
     {
         if ($hours === 0) {
             return $this;
@@ -579,7 +585,7 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in minutes subtracted.
      */
-    public function minusMinutes(int $minutes) : LocalDateTime
+    public function minusMinutes(int $minutes): LocalDateTime
     {
         if ($minutes === 0) {
             return $this;
@@ -590,12 +596,8 @@ final class LocalDateTime implements \JsonSerializable
 
     /**
      * Returns a copy of this LocalDateTime with the specified period in seconds subtracted.
-     *
-     * @param int $seconds
-     *
-     * @return LocalDateTime
      */
-    public function minusSeconds(int $seconds) : LocalDateTime
+    public function minusSeconds(int $seconds): LocalDateTime
     {
         if ($seconds === 0) {
             return $this;
@@ -607,13 +609,109 @@ final class LocalDateTime implements \JsonSerializable
     /**
      * Returns a copy of this LocalDateTime with the specified period in nanoseconds subtracted.
      */
-    public function minusNanos(int $nanos) : LocalDateTime
+    public function minusNanos(int $nanos): LocalDateTime
     {
         if ($nanos === 0) {
             return $this;
         }
 
         return $this->plusWithOverflow(0, 0, 0, $nanos, -1);
+    }
+
+    /**
+     * Compares this date-time to another date-time.
+     *
+     * @param LocalDateTime $that The date-time to compare to.
+     *
+     * @return int [-1,0,1] If this date-time is before, on, or after the given date-time.
+     */
+    public function compareTo(LocalDateTime $that): int
+    {
+        return $this->date->compareTo($that->date) ?: $this->time->compareTo($that->time);
+    }
+
+    public function isEqualTo(LocalDateTime $that): bool
+    {
+        return $this->compareTo($that) === 0;
+    }
+
+    public function isBefore(LocalDateTime $that): bool
+    {
+        return $this->compareTo($that) === -1;
+    }
+
+    public function isBeforeOrEqualTo(LocalDateTime $that): bool
+    {
+        return $this->compareTo($that) <= 0;
+    }
+
+    public function isAfter(LocalDateTime $that): bool
+    {
+        return $this->compareTo($that) === 1;
+    }
+
+    public function isAfterOrEqualTo(LocalDateTime $that): bool
+    {
+        return $this->compareTo($that) >= 0;
+    }
+
+    /**
+     * Returns whether this LocalDateTime is in the future, in the given time-zone, according to the given clock.
+     *
+     * If no clock is provided, the system clock is used.
+     */
+    public function isFuture(TimeZone $timeZone, ?Clock $clock = null): bool
+    {
+        return $this->isAfter(LocalDateTime::now($timeZone, $clock));
+    }
+
+    /**
+     * Returns whether this LocalDateTime is in the past, in the given time-zone, according to the given clock.
+     *
+     * If no clock is provided, the system clock is used.
+     */
+    public function isPast(TimeZone $timeZone, ?Clock $clock = null): bool
+    {
+        return $this->isBefore(LocalDateTime::now($timeZone, $clock));
+    }
+
+    /**
+     * Converts this LocalDateTime to a native DateTime object.
+     *
+     * The result is a DateTime in the UTC time-zone.
+     *
+     * Note that the native DateTime object supports a precision up to the microsecond,
+     * so the nanoseconds are rounded down to the nearest microsecond.
+     */
+    public function toDateTime(): DateTime
+    {
+        return $this->atTimeZone(TimeZone::utc())->toDateTime();
+    }
+
+    /**
+     * Converts this LocalDateTime to a native DateTimeImmutable object.
+     *
+     * The result is a DateTimeImmutable in the UTC time-zone.
+     *
+     * Note that the native DateTimeImmutable object supports a precision up to the microsecond,
+     * so the nanoseconds are rounded down to the nearest microsecond.
+     */
+    public function toDateTimeImmutable(): DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromMutable($this->toDateTime());
+    }
+
+    /**
+     * Serializes as a string using {@see LocalDateTime::__toString()}.
+     */
+    public function jsonSerialize(): string
+    {
+        return (string) $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->date . 'T' . $this->time;
     }
 
     /**
@@ -627,12 +725,12 @@ final class LocalDateTime implements \JsonSerializable
      *
      * @return LocalDateTime The combined result.
      */
-    private function plusWithOverflow(int $hours, int $minutes, int $seconds, int $nanos, int $sign) : LocalDateTime
+    private function plusWithOverflow(int $hours, int $minutes, int $seconds, int $nanos, int $sign): LocalDateTime
     {
         $totDays =
-            \intdiv($hours, LocalTime::HOURS_PER_DAY) +
-            \intdiv($minutes, LocalTime::MINUTES_PER_DAY) +
-            \intdiv($seconds, LocalTime::SECONDS_PER_DAY);
+            intdiv($hours, LocalTime::HOURS_PER_DAY) +
+            intdiv($minutes, LocalTime::MINUTES_PER_DAY) +
+            intdiv($seconds, LocalTime::SECONDS_PER_DAY);
         $totDays *= $sign;
 
         $totSeconds =
@@ -654,101 +752,5 @@ final class LocalDateTime implements \JsonSerializable
         $newTime = ($newSoD === $curSoD ? $this->time : LocalTime::ofSecondOfDay($newSoD, $newNano));
 
         return new LocalDateTime($newDate, $newTime);
-    }
-
-    /**
-     * Compares this date-time to another date-time.
-     *
-     * @param LocalDateTime $that The date-time to compare to.
-     *
-     * @return int [-1,0,1] If this date-time is before, on, or after the given date-time.
-     */
-    public function compareTo(LocalDateTime $that) : int
-    {
-        return $this->date->compareTo($that->date) ?: $this->time->compareTo($that->time);
-    }
-
-    public function isEqualTo(LocalDateTime $that) : bool
-    {
-        return $this->compareTo($that) === 0;
-    }
-
-    public function isBefore(LocalDateTime $that) : bool
-    {
-        return $this->compareTo($that) === -1;
-    }
-
-    public function isBeforeOrEqualTo(LocalDateTime $that) : bool
-    {
-        return $this->compareTo($that) <= 0;
-    }
-
-    public function isAfter(LocalDateTime $that) : bool
-    {
-        return $this->compareTo($that) === 1;
-    }
-
-    public function isAfterOrEqualTo(LocalDateTime $that) : bool
-    {
-        return $this->compareTo($that) >= 0;
-    }
-
-    /**
-     * Returns whether this LocalDateTime is in the future, in the given time-zone, according to the given clock.
-     *
-     * If no clock is provided, the system clock is used.
-     */
-    public function isFuture(TimeZone $timeZone, ?Clock $clock = null) : bool
-    {
-        return $this->isAfter(LocalDateTime::now($timeZone, $clock));
-    }
-
-    /**
-     * Returns whether this LocalDateTime is in the past, in the given time-zone, according to the given clock.
-     *
-     * If no clock is provided, the system clock is used.
-     */
-    public function isPast(TimeZone $timeZone, ?Clock $clock = null) : bool
-    {
-        return $this->isBefore(LocalDateTime::now($timeZone, $clock));
-    }
-
-    /**
-     * Converts this LocalDateTime to a native DateTime object.
-     *
-     * The result is a DateTime in the UTC time-zone.
-     *
-     * Note that the native DateTime object supports a precision up to the microsecond,
-     * so the nanoseconds are rounded down to the nearest microsecond.
-     */
-    public function toDateTime() : \DateTime
-    {
-        return $this->atTimeZone(TimeZone::utc())->toDateTime();
-    }
-
-    /**
-     * Converts this LocalDateTime to a native DateTimeImmutable object.
-     *
-     * The result is a DateTimeImmutable in the UTC time-zone.
-     *
-     * Note that the native DateTimeImmutable object supports a precision up to the microsecond,
-     * so the nanoseconds are rounded down to the nearest microsecond.
-     */
-    public function toDateTimeImmutable() : \DateTimeImmutable
-    {
-        return \DateTimeImmutable::createFromMutable($this->toDateTime());
-    }
-
-    /**
-     * Serializes as a string using {@see LocalDateTime::__toString()}.
-     */
-    public function jsonSerialize() : string
-    {
-        return (string) $this;
-    }
-
-    public function __toString() : string
-    {
-        return $this->date . 'T' . $this->time;
     }
 }

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -12,25 +12,34 @@ use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
 use Brick\DateTime\Utility\Math;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonSerializable;
+
+use function intdiv;
+use function rtrim;
+use function sprintf;
+use function substr;
 
 /**
  * A time without a time-zone in the ISO-8601 calendar system, such as 10:15:30.
  *
  * This class is immutable.
  */
-final class LocalTime implements \JsonSerializable
+final class LocalTime implements JsonSerializable
 {
-    public const MONTHS_PER_YEAR    = 12;
-    public const DAYS_PER_WEEK      = 7;
-    public const HOURS_PER_DAY      = 24;
-    public const MINUTES_PER_HOUR   = 60;
-    public const MINUTES_PER_DAY    = 1440;
+    public const MONTHS_PER_YEAR = 12;
+    public const DAYS_PER_WEEK = 7;
+    public const HOURS_PER_DAY = 24;
+    public const MINUTES_PER_HOUR = 60;
+    public const MINUTES_PER_DAY = 1440;
     public const SECONDS_PER_MINUTE = 60;
-    public const SECONDS_PER_HOUR   = 3600;
-    public const SECONDS_PER_DAY    = 86400;
-    public const NANOS_PER_SECOND   = 1000000000;
-    public const NANOS_PER_MILLI    = 1000000;
-    public const MILLIS_PER_SECOND  = 1000;
+    public const SECONDS_PER_HOUR = 3600;
+    public const SECONDS_PER_DAY = 86400;
+    public const NANOS_PER_SECOND = 1000000000;
+    public const NANOS_PER_MILLI = 1000000;
+    public const MILLIS_PER_SECOND = 1000;
 
     /**
      * The hour, in the range 0 to 23.
@@ -62,10 +71,10 @@ final class LocalTime implements \JsonSerializable
      */
     private function __construct(int $hour, int $minute, int $second, int $nano)
     {
-        $this->hour   = $hour;
+        $this->hour = $hour;
         $this->minute = $minute;
         $this->second = $second;
-        $this->nano   = $nano;
+        $this->nano = $nano;
     }
 
     /**
@@ -76,7 +85,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException
      */
-    public static function of(int $hour, int $minute, int $second = 0, int $nano = 0) : LocalTime
+    public static function of(int $hour, int $minute, int $second = 0, int $nano = 0): LocalTime
     {
         Field\HourOfDay::check($hour);
         Field\MinuteOfHour::check($minute);
@@ -94,14 +103,14 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException
      */
-    public static function ofSecondOfDay(int $secondOfDay, int $nanoOfSecond = 0) : LocalTime
+    public static function ofSecondOfDay(int $secondOfDay, int $nanoOfSecond = 0): LocalTime
     {
         Field\SecondOfDay::check($secondOfDay);
         Field\NanoOfSecond::check($nanoOfSecond);
 
-        $hours = \intdiv($secondOfDay, self::SECONDS_PER_HOUR);
+        $hours = intdiv($secondOfDay, self::SECONDS_PER_HOUR);
         $secondOfDay -= $hours * self::SECONDS_PER_HOUR;
-        $minutes = \intdiv($secondOfDay, self::SECONDS_PER_MINUTE);
+        $minutes = intdiv($secondOfDay, self::SECONDS_PER_MINUTE);
         $secondOfDay -= $minutes * self::SECONDS_PER_MINUTE;
 
         return new LocalTime($hours, $minutes, $secondOfDay, $nanoOfSecond);
@@ -111,14 +120,14 @@ final class LocalTime implements \JsonSerializable
      * @throws DateTimeException      If the time is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : LocalTime
+    public static function from(DateTimeParseResult $result): LocalTime
     {
-        $hour     = $result->getField(HourOfDay::NAME);
-        $minute   = $result->getField(MinuteOfHour::NAME);
-        $second   = $result->getOptionalField(SecondOfMinute::NAME);
+        $hour = $result->getField(HourOfDay::NAME);
+        $minute = $result->getField(MinuteOfHour::NAME);
+        $second = $result->getOptionalField(SecondOfMinute::NAME);
         $fraction = $result->getOptionalField(Field\FractionOfSecond::NAME);
 
-        $nano = \substr($fraction . '000000000', 0, 9);
+        $nano = substr($fraction . '000000000', 0, 9);
 
         return LocalTime::of((int) $hour, (int) $minute, (int) $second, (int) $nano);
     }
@@ -132,7 +141,7 @@ final class LocalTime implements \JsonSerializable
      * @throws DateTimeException      If the time is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : LocalTime
+    public static function parse(string $text, ?DateTimeParser $parser = null): LocalTime
     {
         if (! $parser) {
             $parser = IsoParsers::localTime();
@@ -144,7 +153,7 @@ final class LocalTime implements \JsonSerializable
     /**
      * Creates a LocalTime from a native DateTime or DateTimeImmutable object.
      */
-    public static function fromNativeDateTime(\DateTimeInterface $dateTime) : LocalTime
+    public static function fromNativeDateTime(DateTimeInterface $dateTime): LocalTime
     {
         return new LocalTime(
             (int) $dateTime->format('G'),
@@ -159,7 +168,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @deprecated please use fromNativeDateTime instead
      */
-    public static function fromDateTime(\DateTimeInterface $dateTime) : LocalTime
+    public static function fromDateTime(DateTimeInterface $dateTime): LocalTime
     {
         return self::fromNativeDateTime($dateTime);
     }
@@ -169,17 +178,17 @@ final class LocalTime implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : LocalTime
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): LocalTime
     {
         return ZonedDateTime::now($timeZone, $clock)->getTime();
     }
 
-    public static function midnight() : LocalTime
+    public static function midnight(): LocalTime
     {
         return new LocalTime(0, 0, 0, 0);
     }
 
-    public static function noon() : LocalTime
+    public static function noon(): LocalTime
     {
         return new LocalTime(12, 0, 0, 0);
     }
@@ -187,7 +196,7 @@ final class LocalTime implements \JsonSerializable
     /**
      * Returns the smallest possible value for LocalTime.
      */
-    public static function min() : LocalTime
+    public static function min(): LocalTime
     {
         return new LocalTime(0, 0, 0, 0);
     }
@@ -195,7 +204,7 @@ final class LocalTime implements \JsonSerializable
     /**
      * Returns the highest possible value for LocalTime.
      */
-    public static function max() : LocalTime
+    public static function max(): LocalTime
     {
         return new LocalTime(23, 59, 59, 999999999);
     }
@@ -209,7 +218,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException If the array is empty.
      */
-    public static function minOf(LocalTime ...$times) : LocalTime
+    public static function minOf(LocalTime ...$times): LocalTime
     {
         if (! $times) {
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
@@ -235,7 +244,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException If the array is empty.
      */
-    public static function maxOf(LocalTime ...$times) : LocalTime
+    public static function maxOf(LocalTime ...$times): LocalTime
     {
         if (! $times) {
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
@@ -252,22 +261,22 @@ final class LocalTime implements \JsonSerializable
         return $max;
     }
 
-    public function getHour() : int
+    public function getHour(): int
     {
         return $this->hour;
     }
 
-    public function getMinute() : int
+    public function getMinute(): int
     {
         return $this->minute;
     }
 
-    public function getSecond() : int
+    public function getSecond(): int
     {
         return $this->second;
     }
 
-    public function getNano() : int
+    public function getNano(): int
     {
         return $this->nano;
     }
@@ -279,7 +288,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException If the hour-of-day if not valid.
      */
-    public function withHour(int $hour) : LocalTime
+    public function withHour(int $hour): LocalTime
     {
         if ($hour === $this->hour) {
             return $this;
@@ -297,7 +306,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException If the minute-of-hour if not valid.
      */
-    public function withMinute(int $minute) : LocalTime
+    public function withMinute(int $minute): LocalTime
     {
         if ($minute === $this->minute) {
             return $this;
@@ -315,7 +324,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException If the second-of-minute if not valid.
      */
-    public function withSecond(int $second) : LocalTime
+    public function withSecond(int $second): LocalTime
     {
         if ($second === $this->second) {
             return $this;
@@ -333,7 +342,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException If the nano-of-second if not valid.
      */
-    public function withNano(int $nano) : LocalTime
+    public function withNano(int $nano): LocalTime
     {
         if ($nano === $this->nano) {
             return $this;
@@ -349,7 +358,7 @@ final class LocalTime implements \JsonSerializable
      *
      * The calculation wraps around midnight.
      */
-    public function plusDuration(Duration $duration) : LocalTime
+    public function plusDuration(Duration $duration): LocalTime
     {
         return $this
             ->plusSeconds($duration->getSeconds())
@@ -368,7 +377,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @return LocalTime A LocalTime based on this time with the hours added.
      */
-    public function plusHours(int $hours) : LocalTime
+    public function plusHours(int $hours): LocalTime
     {
         if ($hours === 0) {
             return $this;
@@ -391,7 +400,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @return LocalTime A LocalTime based on this time with the minutes added.
      */
-    public function plusMinutes(int $minutes) : LocalTime
+    public function plusMinutes(int $minutes): LocalTime
     {
         if ($minutes === 0) {
             return $this;
@@ -404,7 +413,7 @@ final class LocalTime implements \JsonSerializable
             return $this;
         }
 
-        $hour = \intdiv($newMofd, self::MINUTES_PER_HOUR);
+        $hour = intdiv($newMofd, self::MINUTES_PER_HOUR);
         $minute = $newMofd % self::MINUTES_PER_HOUR;
 
         return new LocalTime($hour, $minute, $this->second, $this->nano);
@@ -417,7 +426,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @return LocalTime A LocalTime based on this time with the seconds added.
      */
-    public function plusSeconds(int $seconds) : LocalTime
+    public function plusSeconds(int $seconds): LocalTime
     {
         if ($seconds === 0) {
             return $this;
@@ -430,8 +439,8 @@ final class LocalTime implements \JsonSerializable
             return $this;
         }
 
-        $hour = \intdiv($newSofd, self::SECONDS_PER_HOUR);
-        $minute = \intdiv($newSofd, self::SECONDS_PER_MINUTE) % self::MINUTES_PER_HOUR;
+        $hour = intdiv($newSofd, self::SECONDS_PER_HOUR);
+        $minute = intdiv($newSofd, self::SECONDS_PER_MINUTE) % self::MINUTES_PER_HOUR;
         $second = $newSofd % self::SECONDS_PER_MINUTE;
 
         return new LocalTime($hour, $minute, $second, $this->nano);
@@ -446,7 +455,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @throws DateTimeException
      */
-    public function plusNanos(int $nanos) : LocalTime
+    public function plusNanos(int $nanos): LocalTime
     {
         if ($nanos === 0) {
             return $this;
@@ -474,27 +483,27 @@ final class LocalTime implements \JsonSerializable
      *
      * The calculation wraps around midnight.
      */
-    public function minusDuration(Duration $duration) : LocalTime
+    public function minusDuration(Duration $duration): LocalTime
     {
         return $this->plusDuration($duration->negated());
     }
 
-    public function minusHours(int $hours) : LocalTime
+    public function minusHours(int $hours): LocalTime
     {
-        return $this->plusHours(- $hours);
+        return $this->plusHours(-$hours);
     }
 
-    public function minusMinutes(int $minutes) : LocalTime
+    public function minusMinutes(int $minutes): LocalTime
     {
-        return $this->plusMinutes(- $minutes);
+        return $this->plusMinutes(-$minutes);
     }
 
-    public function minusSeconds(int $seconds) : LocalTime
+    public function minusSeconds(int $seconds): LocalTime
     {
-        return $this->plusSeconds(- $seconds);
+        return $this->plusSeconds(-$seconds);
     }
 
-    public function minusNanos(int $nanos) : LocalTime
+    public function minusNanos(int $nanos): LocalTime
     {
         return $this->plusNanos(-$nanos);
     }
@@ -506,7 +515,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @return int [-1,0,1] If this time is before, on, or after the given time.
      */
-    public function compareTo(LocalTime $that) : int
+    public function compareTo(LocalTime $that): int
     {
         $seconds = $this->toSecondOfDay() - $that->toSecondOfDay();
 
@@ -528,7 +537,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @param LocalTime $that The time to compare to.
      */
-    public function isEqualTo(LocalTime $that) : bool
+    public function isEqualTo(LocalTime $that): bool
     {
         return $this->compareTo($that) === 0;
     }
@@ -538,7 +547,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @param LocalTime $that The time to compare to.
      */
-    public function isBefore(LocalTime $that) : bool
+    public function isBefore(LocalTime $that): bool
     {
         return $this->compareTo($that) === -1;
     }
@@ -548,7 +557,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @param LocalTime $that The time to compare to.
      */
-    public function isBeforeOrEqualTo(LocalTime $that) : bool
+    public function isBeforeOrEqualTo(LocalTime $that): bool
     {
         return $this->compareTo($that) <= 0;
     }
@@ -558,7 +567,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @param LocalTime $that The time to compare to.
      */
-    public function isAfter(LocalTime $that) : bool
+    public function isAfter(LocalTime $that): bool
     {
         return $this->compareTo($that) === 1;
     }
@@ -568,7 +577,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @param LocalTime $that The time to compare to.
      */
-    public function isAfterOrEqualTo(LocalTime $that) : bool
+    public function isAfterOrEqualTo(LocalTime $that): bool
     {
         return $this->compareTo($that) >= 0;
     }
@@ -576,7 +585,7 @@ final class LocalTime implements \JsonSerializable
     /**
      * Combines this time with a date to create a LocalDateTime.
      */
-    public function atDate(LocalDate $date) : LocalDateTime
+    public function atDate(LocalDate $date): LocalDateTime
     {
         return new LocalDateTime($date, $this);
     }
@@ -586,7 +595,7 @@ final class LocalTime implements \JsonSerializable
      *
      * This does not include the nanoseconds.
      */
-    public function toSecondOfDay() : int
+    public function toSecondOfDay(): int
     {
         return $this->hour * self::SECONDS_PER_HOUR
             + $this->minute * self::SECONDS_PER_MINUTE
@@ -601,7 +610,7 @@ final class LocalTime implements \JsonSerializable
      * Note that the native DateTime object supports a precision up to the microsecond,
      * so the nanoseconds are rounded down to the nearest microsecond.
      */
-    public function toNativeDateTime() : \DateTime
+    public function toNativeDateTime(): DateTime
     {
         return $this->atDate(LocalDate::of(0, 1, 1))->toDateTime();
     }
@@ -616,7 +625,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @deprecated please use toNativeDateTime instead
      */
-    public function toDateTime() : \DateTime
+    public function toDateTime(): DateTime
     {
         return $this->toNativeDateTime();
     }
@@ -629,9 +638,9 @@ final class LocalTime implements \JsonSerializable
      * Note that the native DateTimeImmutable object supports a precision up to the microsecond,
      * so the nanoseconds are rounded down to the nearest microsecond.
      */
-    public function toNativeDateTimeImmutable() : \DateTimeImmutable
+    public function toNativeDateTimeImmutable(): DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromMutable($this->toNativeDateTime());
+        return DateTimeImmutable::createFromMutable($this->toNativeDateTime());
     }
 
     /**
@@ -644,7 +653,7 @@ final class LocalTime implements \JsonSerializable
      *
      * @deprecated please use toNativeDateTimeImmutable instead
      */
-    public function toDateTimeImmutable() : \DateTimeImmutable
+    public function toDateTimeImmutable(): DateTimeImmutable
     {
         return $this->toNativeDateTimeImmutable();
     }
@@ -652,7 +661,7 @@ final class LocalTime implements \JsonSerializable
     /**
      * Serializes as a string using {@see LocalTime::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
@@ -670,18 +679,18 @@ final class LocalTime implements \JsonSerializable
      * the time where the omitted parts are implied to be zero.
      * The nanoseconds value, if present, can be 0 to 9 digits.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->nano === 0) {
             if ($this->second === 0) {
-                return \sprintf('%02u:%02u', $this->hour, $this->minute);
+                return sprintf('%02u:%02u', $this->hour, $this->minute);
             } else {
-                return \sprintf('%02u:%02u:%02u', $this->hour, $this->minute, $this->second);
+                return sprintf('%02u:%02u:%02u', $this->hour, $this->minute, $this->second);
             }
         }
 
-        $nanos = \rtrim(\sprintf('%09u', $this->nano), '0');
+        $nanos = rtrim(sprintf('%09u', $this->nano), '0');
 
-        return \sprintf('%02u:%02u:%02u.%s', $this->hour, $this->minute, $this->second, $nanos);
+        return sprintf('%02u:%02u:%02u.%s', $this->hour, $this->minute, $this->second, $nanos);
     }
 }

--- a/src/Month.php
+++ b/src/Month.php
@@ -4,23 +4,25 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use JsonSerializable;
+
 /**
  * Represents a month-of-year such as January.
  */
-final class Month implements \JsonSerializable
+final class Month implements JsonSerializable
 {
-    public const JANUARY   = 1;
-    public const FEBRUARY  = 2;
-    public const MARCH     = 3;
-    public const APRIL     = 4;
-    public const MAY       = 5;
-    public const JUNE      = 6;
-    public const JULY      = 7;
-    public const AUGUST    = 8;
+    public const JANUARY = 1;
+    public const FEBRUARY = 2;
+    public const MARCH = 3;
+    public const APRIL = 4;
+    public const MAY = 5;
+    public const JUNE = 6;
+    public const JULY = 7;
+    public const AUGUST = 8;
     public const SEPTEMBER = 9;
-    public const OCTOBER   = 10;
-    public const NOVEMBER  = 11;
-    public const DECEMBER  = 12;
+    public const OCTOBER = 10;
+    public const NOVEMBER = 11;
+    public const DECEMBER = 12;
 
     /**
      * The month number, from 1 (January) to 12 (December).
@@ -38,25 +40,6 @@ final class Month implements \JsonSerializable
     }
 
     /**
-     * Returns a cached Month instance.
-     *
-     * @param int $value The month value, validated from 1 to 12.
-     *
-     * @return Month The cached Month instance.
-     */
-    private static function get(int $value) : Month
-    {
-        /** @var array<int, Month> $values */
-        static $values = [];
-
-        if (! isset($values[$value])) {
-            $values[$value] = new Month($value);
-        }
-
-        return $values[$value];
-    }
-
-    /**
      * Returns an instance of Month for the given month value.
      *
      * @param int $value The month number, from 1 (January) to 12 (December).
@@ -65,7 +48,7 @@ final class Month implements \JsonSerializable
      *
      * @throws DateTimeException
      */
-    public static function of(int $value) : Month
+    public static function of(int $value): Month
     {
         Field\MonthOfYear::check($value);
 
@@ -77,7 +60,7 @@ final class Month implements \JsonSerializable
      *
      * @return Month[]
      */
-    public static function getAll() : array
+    public static function getAll(): array
     {
         $months = [];
 
@@ -93,7 +76,7 @@ final class Month implements \JsonSerializable
      *
      * @return int The month number, from 1 (January) to 12 (December).
      */
-    public function getValue() : int
+    public function getValue(): int
     {
         return $this->month;
     }
@@ -105,7 +88,7 @@ final class Month implements \JsonSerializable
      *
      * @return bool True if this month is equal to the given value, false otherwise.
      */
-    public function is(int $month) : bool
+    public function is(int $month): bool
     {
         return $this->month === $month;
     }
@@ -113,9 +96,9 @@ final class Month implements \JsonSerializable
     /**
      * Returns whether this Month equals another Month.
      */
-    public function isEqualTo(Month $that) : bool
+    public function isEqualTo(Month $that): bool
     {
-        return ($this->month === $that->month);
+        return $this->month === $that->month;
     }
 
     /**
@@ -123,7 +106,7 @@ final class Month implements \JsonSerializable
      *
      * @return int The minimum length of this month in days, from 28 to 31.
      */
-    public function getMinLength() : int
+    public function getMinLength(): int
     {
         switch ($this->month) {
             case Month::FEBRUARY:
@@ -143,7 +126,7 @@ final class Month implements \JsonSerializable
      *
      * @return int The maximum length of this month in days, from 29 to 31.
      */
-    public function getMaxLength() : int
+    public function getMaxLength(): int
     {
         switch ($this->month) {
             case Month::FEBRUARY:
@@ -164,7 +147,7 @@ final class Month implements \JsonSerializable
      * This returns the day-of-year that this month begins on, using the leap
      * year flag to determine the length of February.
      */
-    public function getFirstDayOfYear(bool $leapYear) : int
+    public function getFirstDayOfYear(bool $leapYear): int
     {
         $leap = $leapYear ? 1 : 0;
 
@@ -205,11 +188,11 @@ final class Month implements \JsonSerializable
      * April, June, September and November have 30 days.
      * All other months have 31 days.
      */
-    public function getLength(bool $leapYear) : int
+    public function getLength(bool $leapYear): int
     {
         switch ($this->month) {
             case Month::FEBRUARY:
-                return ($leapYear ? 29 : 28);
+                return $leapYear ? 29 : 28;
             case Month::APRIL:
             case Month::JUNE:
             case Month::SEPTEMBER:
@@ -226,7 +209,7 @@ final class Month implements \JsonSerializable
      * The calculation rolls around the end of the year from December to January.
      * The specified period may be negative.
      */
-    public function plus(int $months) : Month
+    public function plus(int $months): Month
     {
         return Month::get((((($this->month - 1 + $months) % 12) + 12) % 12) + 1);
     }
@@ -237,15 +220,15 @@ final class Month implements \JsonSerializable
      * The calculation rolls around the start of the year from January to December.
      * The specified period may be negative.
      */
-    public function minus(int $months) : Month
+    public function minus(int $months): Month
     {
-        return $this->plus(- $months);
+        return $this->plus(-$months);
     }
 
     /**
      * Serializes as a string using {@see Month::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
@@ -253,21 +236,40 @@ final class Month implements \JsonSerializable
     /**
      * Returns the capitalized English name of this Month.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return [
-            1  => 'January',
-            2  => 'February',
-            3  => 'March',
-            4  => 'April',
-            5  => 'May',
-            6  => 'June',
-            7  => 'July',
-            8  => 'August',
-            9  => 'September',
+            1 => 'January',
+            2 => 'February',
+            3 => 'March',
+            4 => 'April',
+            5 => 'May',
+            6 => 'June',
+            7 => 'July',
+            8 => 'August',
+            9 => 'September',
             10 => 'October',
             11 => 'November',
             12 => 'December'
         ][$this->month];
+    }
+
+    /**
+     * Returns a cached Month instance.
+     *
+     * @param int $value The month value, validated from 1 to 12.
+     *
+     * @return Month The cached Month instance.
+     */
+    private static function get(int $value): Month
+    {
+        /** @var array<int, Month> $values */
+        static $values = [];
+
+        if (! isset($values[$value])) {
+            $values[$value] = new Month($value);
+        }
+
+        return $values[$value];
     }
 }

--- a/src/MonthDay.php
+++ b/src/MonthDay.php
@@ -8,11 +8,14 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
+use JsonSerializable;
+
+use function sprintf;
 
 /**
  * A month-day in the ISO-8601 calendar system, such as `--12-03`.
  */
-final class MonthDay implements \JsonSerializable
+final class MonthDay implements JsonSerializable
 {
     /**
      * The month-of-year, from 1 to 12.
@@ -33,7 +36,7 @@ final class MonthDay implements \JsonSerializable
     private function __construct(int $month, int $day)
     {
         $this->month = $month;
-        $this->day   = $day;
+        $this->day = $day;
     }
 
     /**
@@ -44,7 +47,7 @@ final class MonthDay implements \JsonSerializable
      *
      * @throws DateTimeException If the month-day is not valid.
      */
-    public static function of(int $month, int $day) : MonthDay
+    public static function of(int $month, int $day): MonthDay
     {
         Field\MonthOfYear::check($month);
         Field\DayOfMonth::check($day, $month);
@@ -56,7 +59,7 @@ final class MonthDay implements \JsonSerializable
      * @throws DateTimeException      If the month-day is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : MonthDay
+    public static function from(DateTimeParseResult $result): MonthDay
     {
         return MonthDay::of(
             (int) $result->getField(Field\MonthOfYear::NAME),
@@ -73,7 +76,7 @@ final class MonthDay implements \JsonSerializable
      * @throws DateTimeException      If the date is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : MonthDay
+    public static function parse(string $text, ?DateTimeParser $parser = null): MonthDay
     {
         if (! $parser) {
             $parser = IsoParsers::monthDay();
@@ -87,7 +90,7 @@ final class MonthDay implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : MonthDay
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): MonthDay
     {
         $date = LocalDate::now($timeZone, $clock);
 
@@ -97,7 +100,7 @@ final class MonthDay implements \JsonSerializable
     /**
      * Returns the month-of-year.
      */
-    public function getMonth() : int
+    public function getMonth(): int
     {
         return $this->month;
     }
@@ -105,7 +108,7 @@ final class MonthDay implements \JsonSerializable
     /**
      * Returns the day-of-month.
      */
-    public function getDay() : int
+    public function getDay(): int
     {
         return $this->day;
     }
@@ -115,7 +118,7 @@ final class MonthDay implements \JsonSerializable
      *
      * @return int [-1,0,1] If this date is before, on, or after the given date.
      */
-    public function compareTo(MonthDay $that) : int
+    public function compareTo(MonthDay $that): int
     {
         if ($this->month < $that->month) {
             return -1;
@@ -136,7 +139,7 @@ final class MonthDay implements \JsonSerializable
     /**
      * Returns whether this month-day is equal to the specified month-day.
      */
-    public function isEqualTo(MonthDay $that) : bool
+    public function isEqualTo(MonthDay $that): bool
     {
         return $this->compareTo($that) === 0;
     }
@@ -144,7 +147,7 @@ final class MonthDay implements \JsonSerializable
     /**
      * Returns whether this month-day is before the specified month-day.
      */
-    public function isBefore(MonthDay $that) : bool
+    public function isBefore(MonthDay $that): bool
     {
         return $this->compareTo($that) === -1;
     }
@@ -152,7 +155,7 @@ final class MonthDay implements \JsonSerializable
     /**
      * Returns whether this month-day is after the specified month-day.
      */
-    public function isAfter(MonthDay $that) : bool
+    public function isAfter(MonthDay $that): bool
     {
         return $this->compareTo($that) === 1;
     }
@@ -163,7 +166,7 @@ final class MonthDay implements \JsonSerializable
      * This method checks whether this month and day and the input year form a valid date.
      * This can only return false for February 29th.
      */
-    public function isValidYear(int $year) : bool
+    public function isValidYear(int $year): bool
     {
         return $this->month !== 2 || $this->day !== 29 || Field\Year::isLeap($year);
     }
@@ -176,7 +179,7 @@ final class MonthDay implements \JsonSerializable
      *
      * @throws DateTimeException If the month is invalid.
      */
-    public function withMonth(int $month) : MonthDay
+    public function withMonth(int $month): MonthDay
     {
         if ($month === $this->month) {
             return $this;
@@ -196,7 +199,7 @@ final class MonthDay implements \JsonSerializable
      *
      * @throws DateTimeException If the day-of-month is invalid for the month.
      */
-    public function withDay(int $day) : MonthDay
+    public function withDay(int $day): MonthDay
     {
         if ($day === $this->day) {
             return $this;
@@ -217,7 +220,7 @@ final class MonthDay implements \JsonSerializable
      *
      * @throws DateTimeException If the year is invalid.
      */
-    public function atYear(int $year) : LocalDate
+    public function atYear(int $year): LocalDate
     {
         return LocalDate::of($year, $this->month, $this->isValidYear($year) ? $this->day : 28);
     }
@@ -225,13 +228,13 @@ final class MonthDay implements \JsonSerializable
     /**
      * Serializes as a string using {@see MonthDay::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
-        return \sprintf('--%02d-%02d', $this->month, $this->day);
+        return sprintf('--%02d-%02d', $this->month, $this->day);
     }
 }

--- a/src/Parser/DateTimeParseException.php
+++ b/src/Parser/DateTimeParseException.php
@@ -11,12 +11,12 @@ use Brick\DateTime\DateTimeException;
  */
 class DateTimeParseException extends DateTimeException
 {
-    public static function invalidDuration(string $textToParse) : self
+    public static function invalidDuration(string $textToParse): self
     {
         return new self('Text cannot be parsed to a Duration: ' . $textToParse);
     }
 
-    public static function invalidPeriod(string $textToParse) : self
+    public static function invalidPeriod(string $textToParse): self
     {
         return new self('Text cannot be parsed to a Period: ' . $textToParse);
     }

--- a/src/Parser/DateTimeParseResult.php
+++ b/src/Parser/DateTimeParseResult.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Parser;
 
+use function array_shift;
+use function sprintf;
+
 /**
  * Result of a date-time string parsing.
  */
@@ -14,7 +17,7 @@ final class DateTimeParseResult
      */
     private array $fields = [];
 
-    public function addField(string $name, string $value) : void
+    public function addField(string $name, string $value): void
     {
         $this->fields[$name][] = $value;
     }
@@ -22,7 +25,7 @@ final class DateTimeParseResult
     /**
      * Returns whether this result has at least one value for the given field.
      */
-    public function hasField(string $name) : bool
+    public function hasField(string $name): bool
     {
         return isset($this->fields[$name]) && $this->fields[$name];
     }
@@ -36,12 +39,12 @@ final class DateTimeParseResult
      *
      * @throws DateTimeParseException If the field is not present in this set.
      */
-    public function getField(string $name) : string
+    public function getField(string $name): string
     {
         $value = $this->getOptionalField($name);
 
         if ($value === '') {
-            throw new DateTimeParseException(\sprintf('Field %s is not present in the parsed result.', $name));
+            throw new DateTimeParseException(sprintf('Field %s is not present in the parsed result.', $name));
         }
 
         return $value;
@@ -50,11 +53,11 @@ final class DateTimeParseResult
     /**
      * Returns the first value for the given field, or an empty string if not present.
      */
-    public function getOptionalField(string $name) : string
+    public function getOptionalField(string $name): string
     {
         if (isset($this->fields[$name])) {
             if ($this->fields[$name]) {
-                return \array_shift($this->fields[$name]);
+                return array_shift($this->fields[$name]);
             }
         }
 

--- a/src/Parser/DateTimeParser.php
+++ b/src/Parser/DateTimeParser.php
@@ -16,5 +16,5 @@ interface DateTimeParser
      *
      * @throws DateTimeParseException If the given text could not be parsed.
      */
-    public function parse(string $text) : DateTimeParseResult;
+    public function parse(string $text): DateTimeParseResult;
 }

--- a/src/Parser/IsoParsers.php
+++ b/src/Parser/IsoParsers.php
@@ -31,7 +31,7 @@ final class IsoParsers
     /**
      * Returns a parser for an ISO local date such as `2014-12-31`.
      */
-    public static function localDate() : PatternParser
+    public static function localDate(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -54,7 +54,7 @@ final class IsoParsers
      *
      * The second and fraction of second are optional.
      */
-    public static function localTime() : PatternParser
+    public static function localTime(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -83,7 +83,7 @@ final class IsoParsers
      *
      * The second and fraction of second are optional.
      */
-    public static function localDateTime() : PatternParser
+    public static function localDateTime(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -102,7 +102,7 @@ final class IsoParsers
     /**
      * Returns a parser for a range of local dates such as `2014-01-05/2015-03-15`.
      */
-    public static function localDateRange() : PatternParser
+    public static function localDateRange(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -138,7 +138,7 @@ final class IsoParsers
      * Note that ISO 8601 does not seem to define a format for year-month ranges, but we're using the same format as
      * date ranges here.
      */
-    public static function yearMonthRange() : PatternParser
+    public static function yearMonthRange(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -167,7 +167,7 @@ final class IsoParsers
     /**
      * Returns a parser for a year-month such as `2014-12`.
      */
-    public static function yearMonth() : PatternParser
+    public static function yearMonth(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -186,7 +186,7 @@ final class IsoParsers
     /**
      * Returns a parser for a month-day such as `12-31`.
      */
-    public static function monthDay() : PatternParser
+    public static function monthDay(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -206,7 +206,7 @@ final class IsoParsers
     /**
      * Returns a parser for a time-zone offset such as `Z` or `+01:00`.
      */
-    public static function timeZoneOffset() : PatternParser
+    public static function timeZoneOffset(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -232,7 +232,7 @@ final class IsoParsers
     /**
      * Returns a parser for a time-zone region such as `Europe/London`.
      */
-    public static function timeZoneRegion() : PatternParser
+    public static function timeZoneRegion(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -249,7 +249,7 @@ final class IsoParsers
     /**
      * Returns a parser for an offset date-time such as `2004-01-31T12:45:56+01:00`.
      */
-    public static function offsetDateTime() : PatternParser
+    public static function offsetDateTime(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;
@@ -267,7 +267,7 @@ final class IsoParsers
     /**
      * Returns a parser for a date-time with offset and zone such as `2011-12-03T10:15:30+01:00[Europe/Paris].
      */
-    public static function zonedDateTime() : PatternParser
+    public static function zonedDateTime(): PatternParser
     {
         /** @var PatternParser|null $parser */
         static $parser;

--- a/src/Parser/PatternParser.php
+++ b/src/Parser/PatternParser.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Parser;
 
+use function preg_match;
+use function sprintf;
+
 /**
  * Matches a regular expression pattern to a set of date-time fields.
  */
@@ -23,10 +26,10 @@ final class PatternParser implements DateTimeParser
     public function __construct(string $pattern, array $fields)
     {
         $this->pattern = $pattern;
-        $this->fields  = $fields;
+        $this->fields = $fields;
     }
 
-    public function getPattern() : string
+    public function getPattern(): string
     {
         return $this->pattern;
     }
@@ -34,17 +37,17 @@ final class PatternParser implements DateTimeParser
     /**
      * @return string[]
      */
-    public function getFields() : array
+    public function getFields(): array
     {
         return $this->fields;
     }
 
-    public function parse(string $text) : DateTimeParseResult
+    public function parse(string $text): DateTimeParseResult
     {
         $pattern = '/^' . $this->pattern . '$/';
 
-        if (\preg_match($pattern, $text, $matches) !== 1) {
-            throw new DateTimeParseException(\sprintf('Failed to parse "%s".', $text));
+        if (preg_match($pattern, $text, $matches) !== 1) {
+            throw new DateTimeParseException(sprintf('Failed to parse "%s".', $text));
         }
 
         $result = new DateTimeParseResult();

--- a/src/Parser/PatternParserBuilder.php
+++ b/src/Parser/PatternParserBuilder.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Parser;
 
+use RuntimeException;
+
+use function array_merge;
+use function array_pop;
+use function preg_quote;
+
 /**
  * Builds a PatternParser with a fluent API.
  */
@@ -21,22 +27,22 @@ final class PatternParserBuilder
      */
     private array $stack = [];
 
-    public function append(PatternParser $parser) : self
+    public function append(PatternParser $parser): self
     {
         $this->pattern .= $parser->getPattern();
-        $this->fields = \array_merge($this->fields, $parser->getFields());
+        $this->fields = array_merge($this->fields, $parser->getFields());
 
         return $this;
     }
 
-    public function appendLiteral(string $literal) : self
+    public function appendLiteral(string $literal): self
     {
-        $this->pattern .= \preg_quote($literal, '/');
+        $this->pattern .= preg_quote($literal, '/');
 
         return $this;
     }
 
-    public function appendCapturePattern(string $pattern, string $field) : self
+    public function appendCapturePattern(string $pattern, string $field): self
     {
         $this->pattern .= '(' . $pattern . ')';
         $this->fields[] = $field;
@@ -44,7 +50,7 @@ final class PatternParserBuilder
         return $this;
     }
 
-    public function startOptional() : self
+    public function startOptional(): self
     {
         $this->pattern .= '(?:';
         $this->stack[] = 'O';
@@ -52,10 +58,10 @@ final class PatternParserBuilder
         return $this;
     }
 
-    public function endOptional() : self
+    public function endOptional(): self
     {
-        if (\array_pop($this->stack) !== 'O') {
-            throw new \RuntimeException('Cannot call endOptional() without a call to startOptional() first.');
+        if (array_pop($this->stack) !== 'O') {
+            throw new RuntimeException('Cannot call endOptional() without a call to startOptional() first.');
         }
 
         $this->pattern .= ')?';
@@ -63,7 +69,7 @@ final class PatternParserBuilder
         return $this;
     }
 
-    public function startGroup() : self
+    public function startGroup(): self
     {
         $this->pattern .= '(?:';
         $this->stack[] = 'G';
@@ -71,10 +77,10 @@ final class PatternParserBuilder
         return $this;
     }
 
-    public function endGroup() : self
+    public function endGroup(): self
     {
-        if (\array_pop($this->stack) !== 'G') {
-            throw new \RuntimeException('Cannot call endGroup() without a call to startGroup() first.');
+        if (array_pop($this->stack) !== 'G') {
+            throw new RuntimeException('Cannot call endGroup() without a call to startGroup() first.');
         }
 
         $this->pattern .= ')';
@@ -82,17 +88,17 @@ final class PatternParserBuilder
         return $this;
     }
 
-    public function appendOr() : self
+    public function appendOr(): self
     {
         $this->pattern .= '|';
 
         return $this;
     }
 
-    public function toParser() : PatternParser
+    public function toParser(): PatternParser
     {
         if ($this->stack) {
-            throw new \RuntimeException('Builder misses call to endOptional() or endGroup().');
+            throw new RuntimeException('Builder misses call to endOptional() or endGroup().');
         }
 
         return new PatternParser($this->pattern, $this->fields);

--- a/src/Period.php
+++ b/src/Period.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use DateInterval;
+use JsonSerializable;
+
+use function intdiv;
+use function preg_match;
+use function sprintf;
+
 /**
  * A date-based amount of time in the ISO-8601 calendar system, such as '2 years, 3 months and 4 days'.
  *
  * This class is immutable.
  */
-final class Period implements \JsonSerializable
+final class Period implements JsonSerializable
 {
     private int $years;
 
@@ -26,9 +33,9 @@ final class Period implements \JsonSerializable
      */
     private function __construct(int $years, int $months, int $days)
     {
-        $this->years  = $years;
+        $this->years = $years;
         $this->months = $months;
-        $this->days   = $days;
+        $this->days = $days;
     }
 
     /**
@@ -38,27 +45,27 @@ final class Period implements \JsonSerializable
      * @param int $months The number of months.
      * @param int $days   The number of days.
      */
-    public static function of(int $years, int $months, int $days) : Period
+    public static function of(int $years, int $months, int $days): Period
     {
         return new Period($years, $months, $days);
     }
 
-    public static function ofYears(int $years) : Period
+    public static function ofYears(int $years): Period
     {
         return new Period($years, 0, 0);
     }
 
-    public static function ofMonths(int $months) : Period
+    public static function ofMonths(int $months): Period
     {
         return new Period(0, $months, 0);
     }
 
-    public static function ofWeeks(int $weeks) : Period
+    public static function ofWeeks(int $weeks): Period
     {
         return new Period(0, 0, $weeks * LocalTime::DAYS_PER_WEEK);
     }
 
-    public static function ofDays(int $days) : Period
+    public static function ofDays(int $days): Period
     {
         return new Period(0, 0, $days);
     }
@@ -66,7 +73,7 @@ final class Period implements \JsonSerializable
     /**
      * Creates a zero Period.
      */
-    public static function zero() : Period
+    public static function zero(): Period
     {
         return new Period(0, 0, 0);
     }
@@ -87,7 +94,7 @@ final class Period implements \JsonSerializable
      *
      * @throws Parser\DateTimeParseException
      */
-    public static function parse(string $text) : Period
+    public static function parse(string $text): Period
     {
         $pattern =
             '/^' .
@@ -99,7 +106,7 @@ final class Period implements \JsonSerializable
             '(?:([\-\+]?[0-9]+)D)?' .
             '()$/i';
 
-        if (\preg_match($pattern, $text, $matches) !== 1) {
+        if (preg_match($pattern, $text, $matches) !== 1) {
             throw Parser\DateTimeParseException::invalidPeriod($text);
         }
 
@@ -109,17 +116,17 @@ final class Period implements \JsonSerializable
             throw Parser\DateTimeParseException::invalidPeriod($text);
         }
 
-        $years  = (int) $years;
+        $years = (int) $years;
         $months = (int) $months;
-        $weeks  = (int) $weeks;
-        $days   = (int) $days;
+        $weeks = (int) $weeks;
+        $days = (int) $days;
 
         $days += LocalTime::DAYS_PER_WEEK * $weeks;
 
         if ($sign === '-') {
-            $years  = -$years;
+            $years = -$years;
             $months = -$months;
-            $days   = -$days;
+            $days = -$days;
         }
 
         return new Period($years, $months, $days);
@@ -130,7 +137,7 @@ final class Period implements \JsonSerializable
      *
      * @throws DateTimeException If the DateInterval contains non-zero hours, minutes, seconds or microseconds.
      */
-    public static function fromNativeDateInterval(\DateInterval $dateInterval): Period
+    public static function fromNativeDateInterval(DateInterval $dateInterval): Period
     {
         if ($dateInterval->h !== 0) {
             throw new DateTimeException('Cannot create a Period from a DateInterval with a non-zero hour.');
@@ -164,11 +171,11 @@ final class Period implements \JsonSerializable
     /**
      * Creates a Period from a PHP DateInterval object.
      *
-     * @throws DateTimeException If the DateInterval contains non-zero hours, minutes, seconds or microseconds.
-     *
      * @deprecated please use fromNativeDateInterval instead
+     *
+     * @throws DateTimeException If the DateInterval contains non-zero hours, minutes, seconds or microseconds.
      */
-    public static function fromDateInterval(\DateInterval $dateInterval): Period
+    public static function fromDateInterval(DateInterval $dateInterval): Period
     {
         return self::fromNativeDateInterval($dateInterval);
     }
@@ -187,27 +194,27 @@ final class Period implements \JsonSerializable
      * The result of this method can be a negative period if the end is before the start.
      * The negative sign will be the same in each of year, month and day.
      */
-    public static function between(LocalDate $startInclusive, LocalDate $endExclusive) : Period
+    public static function between(LocalDate $startInclusive, LocalDate $endExclusive): Period
     {
         return $startInclusive->until($endExclusive);
     }
 
-    public function getYears() : int
+    public function getYears(): int
     {
         return $this->years;
     }
 
-    public function getMonths() : int
+    public function getMonths(): int
     {
         return $this->months;
     }
 
-    public function getDays() : int
+    public function getDays(): int
     {
         return $this->days;
     }
 
-    public function withYears(int $years) : Period
+    public function withYears(int $years): Period
     {
         if ($years === $this->years) {
             return $this;
@@ -216,7 +223,7 @@ final class Period implements \JsonSerializable
         return new Period($years, $this->months, $this->days);
     }
 
-    public function withMonths(int $months) : Period
+    public function withMonths(int $months): Period
     {
         if ($months === $this->months) {
             return $this;
@@ -225,7 +232,7 @@ final class Period implements \JsonSerializable
         return new Period($this->years, $months, $this->days);
     }
 
-    public function withDays(int $days) : Period
+    public function withDays(int $days): Period
     {
         if ($days === $this->days) {
             return $this;
@@ -234,7 +241,7 @@ final class Period implements \JsonSerializable
         return new Period($this->years, $this->months, $days);
     }
 
-    public function plusYears(int $years) : Period
+    public function plusYears(int $years): Period
     {
         if ($years === 0) {
             return $this;
@@ -243,7 +250,7 @@ final class Period implements \JsonSerializable
         return new Period($this->years + $years, $this->months, $this->days);
     }
 
-    public function plusMonths(int $months) : Period
+    public function plusMonths(int $months): Period
     {
         if ($months === 0) {
             return $this;
@@ -252,7 +259,7 @@ final class Period implements \JsonSerializable
         return new Period($this->years, $this->months + $months, $this->days);
     }
 
-    public function plusDays(int $days) : Period
+    public function plusDays(int $days): Period
     {
         if ($days === 0) {
             return $this;
@@ -261,7 +268,7 @@ final class Period implements \JsonSerializable
         return new Period($this->years, $this->months, $this->days + $days);
     }
 
-    public function minusYears(int $years) : Period
+    public function minusYears(int $years): Period
     {
         if ($years === 0) {
             return $this;
@@ -270,7 +277,7 @@ final class Period implements \JsonSerializable
         return new Period($this->years - $years, $this->months, $this->days);
     }
 
-    public function minusMonths(int $months) : Period
+    public function minusMonths(int $months): Period
     {
         if ($months === 0) {
             return $this;
@@ -279,7 +286,7 @@ final class Period implements \JsonSerializable
         return new Period($this->years, $this->months - $months, $this->days);
     }
 
-    public function minusDays(int $days) : Period
+    public function minusDays(int $days): Period
     {
         if ($days === 0) {
             return $this;
@@ -291,7 +298,7 @@ final class Period implements \JsonSerializable
     /**
      * Returns a new Period with each value multiplied by the given scalar.
      */
-    public function multipliedBy(int $scalar) : Period
+    public function multipliedBy(int $scalar): Period
     {
         if ($scalar === 1) {
             return $this;
@@ -307,16 +314,16 @@ final class Period implements \JsonSerializable
     /**
      * Returns a new instance with each amount in this Period negated.
      */
-    public function negated() : Period
+    public function negated(): Period
     {
         if ($this->isZero()) {
             return $this;
         }
 
         return new Period(
-            - $this->years,
-            - $this->months,
-            - $this->days
+            -$this->years,
+            -$this->months,
+            -$this->days
         );
     }
 
@@ -332,11 +339,11 @@ final class Period implements \JsonSerializable
      * For example, a period of "1 year and -25 months" will be normalized to
      * "-1 year and -1 month".
      */
-    public function normalized() : Period
+    public function normalized(): Period
     {
         $totalMonths = $this->years * LocalTime::MONTHS_PER_YEAR + $this->months;
 
-        $splitYears = \intdiv($totalMonths, 12);
+        $splitYears = intdiv($totalMonths, 12);
         $splitMonths = $totalMonths % 12;
 
         if ($splitYears === $this->years || $splitMonths === $this->months) {
@@ -346,12 +353,12 @@ final class Period implements \JsonSerializable
         return new Period($splitYears, $splitMonths, $this->days);
     }
 
-    public function isZero() : bool
+    public function isZero(): bool
     {
         return $this->years === 0 && $this->months === 0 && $this->days === 0;
     }
 
-    public function isEqualTo(Period $that) : bool
+    public function isEqualTo(Period $that): bool
     {
         return $this->years === $that->years
             && $this->months === $that->months
@@ -366,7 +373,7 @@ final class Period implements \JsonSerializable
      *
      * @deprecated please use toNativeDateInterval instead
      */
-    public function toDateInterval() : \DateInterval
+    public function toDateInterval(): DateInterval
     {
         return $this->toNativeDateInterval();
     }
@@ -377,9 +384,9 @@ final class Period implements \JsonSerializable
      * We cannot use the constructor with the output of __toString(),
      * as it does not support negative values.
      */
-    public function toNativeDateInterval() : \DateInterval
+    public function toNativeDateInterval(): DateInterval
     {
-        return \DateInterval::createFromDateString(\sprintf(
+        return DateInterval::createFromDateString(sprintf(
             '%d years %d months %d days',
             $this->years,
             $this->months,
@@ -390,12 +397,12 @@ final class Period implements \JsonSerializable
     /**
      * Serializes as a string using {@see Period::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->isZero()) {
             return 'P0D';

--- a/src/Stopwatch.php
+++ b/src/Stopwatch.php
@@ -32,7 +32,7 @@ final class Stopwatch
             $clock = DefaultClock::get();
         }
 
-        $this->clock    = $clock;
+        $this->clock = $clock;
         $this->duration = Duration::zero();
     }
 
@@ -41,7 +41,7 @@ final class Stopwatch
      *
      * If the timer is already started, this method does nothing.
      */
-    public function start() : void
+    public function start(): void
     {
         if ($this->startTime === null) {
             $this->startTime = $this->clock->getTime();
@@ -53,7 +53,7 @@ final class Stopwatch
      *
      * If the timer is already stopped, this method does nothing.
      */
-    public function stop() : void
+    public function stop(): void
     {
         if ($this->startTime === null) {
             return;
@@ -69,12 +69,12 @@ final class Stopwatch
     /**
      * Returns the time this stopwatch has been started at, or null if it is not running.
      */
-    public function getStartTime() : ?Instant
+    public function getStartTime(): ?Instant
     {
         return $this->startTime;
     }
 
-    public function isRunning() : bool
+    public function isRunning(): bool
     {
         return $this->startTime !== null;
     }
@@ -85,7 +85,7 @@ final class Stopwatch
      * This includes the times between previous start() and stop() calls if any,
      * as well as the time since the stopwatch was last started if it is running.
      */
-    public function getElapsedTime() : Duration
+    public function getElapsedTime(): Duration
     {
         if ($this->startTime === null) {
             return $this->duration;

--- a/src/TimeZone.php
+++ b/src/TimeZone.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Brick\DateTime;
 
 use Brick\DateTime\Parser\DateTimeParseException;
+use DateTimeZone;
 
 /**
  * A time-zone. This is the parent class for `TimeZoneOffset` and `TimeZoneRegion`.
@@ -19,7 +20,7 @@ abstract class TimeZone
      *
      * @throws DateTimeParseException
      */
-    public static function parse(string $text) : TimeZone
+    public static function parse(string $text): TimeZone
     {
         if ($text === 'Z' || $text === 'z') {
             return TimeZoneOffset::utc();
@@ -36,7 +37,7 @@ abstract class TimeZone
         return TimeZoneRegion::parse($text);
     }
 
-    public static function utc() : TimeZoneOffset
+    public static function utc(): TimeZoneOffset
     {
         return TimeZoneOffset::utc();
     }
@@ -44,7 +45,7 @@ abstract class TimeZone
     /**
      * Returns the unique time-zone ID.
      */
-    abstract public function getId() : string;
+    abstract public function getId(): string;
 
     /**
      * Returns the offset from UTC at the given instant.
@@ -53,45 +54,46 @@ abstract class TimeZone
      *
      * @return int The offset from UTC in seconds.
      */
-    abstract public function getOffset(Instant $pointInTime) : int;
+    abstract public function getOffset(Instant $pointInTime): int;
 
-    public function isEqualTo(TimeZone $other) : bool
+    public function isEqualTo(TimeZone $other): bool
     {
         return $this->getId() === $other->getId();
-    }
-
-    public function __toString() : string
-    {
-        return $this->getId();
     }
 
     /**
      * @deprecated please use fromNativeDateTimeZone instead
      */
-    public static function fromDateTimeZone(\DateTimeZone $dateTimeZone) : TimeZone
+    public static function fromDateTimeZone(DateTimeZone $dateTimeZone): TimeZone
     {
         return self::fromNativeDateTimeZone($dateTimeZone);
     }
 
-    public static function fromNativeDateTimeZone(\DateTimeZone $dateTimeZone) : TimeZone
+    public static function fromNativeDateTimeZone(DateTimeZone $dateTimeZone): TimeZone
     {
         return TimeZone::parse($dateTimeZone->getName());
     }
 
     /**
      * Returns an equivalent native `DateTimeZone` object for this TimeZone.
+     *
      * @deprecated please use toNativeDateTimeZone instead
      */
-    abstract public function toDateTimeZone() : \DateTimeZone;
+    abstract public function toDateTimeZone(): DateTimeZone;
 
     /**
      * Returns an equivalent native `DateTimeZone` object for this TimeZone.
      */
-    public function toNativeDateTimeZone() : \DateTimeZone
+    public function toNativeDateTimeZone(): DateTimeZone
     {
         /**
          * @psalm-suppress DeprecatedMethod
          */
         return $this->toDateTimeZone();
+    }
+
+    public function __toString(): string
+    {
+        return $this->getId();
     }
 }

--- a/src/TimeZoneOffset.php
+++ b/src/TimeZoneOffset.php
@@ -8,6 +8,7 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
+use DateTimeZone;
 
 /**
  * A time-zone offset from Greenwich/UTC, such as `+02:00`.
@@ -43,7 +44,7 @@ final class TimeZoneOffset extends TimeZone
      *
      * @throws DateTimeException If the values are not in range or the signs don't match.
      */
-    public static function of(int $hours, int $minutes = 0) : TimeZoneOffset
+    public static function of(int $hours, int $minutes = 0): TimeZoneOffset
     {
         Field\TimeZoneOffsetHour::check($hours);
         Field\TimeZoneOffsetMinute::check($minutes);
@@ -72,14 +73,14 @@ final class TimeZoneOffset extends TimeZone
      *
      * @throws DateTimeException
      */
-    public static function ofTotalSeconds(int $totalSeconds) : TimeZoneOffset
+    public static function ofTotalSeconds(int $totalSeconds): TimeZoneOffset
     {
         Field\TimeZoneOffsetTotalSeconds::check($totalSeconds);
 
         return new TimeZoneOffset($totalSeconds);
     }
 
-    public static function utc() : TimeZoneOffset
+    public static function utc(): TimeZoneOffset
     {
         return new TimeZoneOffset(0);
     }
@@ -88,7 +89,7 @@ final class TimeZoneOffset extends TimeZone
      * @throws DateTimeException      If the offset is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : TimeZoneOffset
+    public static function from(DateTimeParseResult $result): TimeZoneOffset
     {
         $sign = $result->getField(Field\TimeZoneOffsetSign::NAME);
 
@@ -96,14 +97,14 @@ final class TimeZoneOffset extends TimeZone
             return TimeZoneOffset::utc();
         }
 
-        $hour   = $result->getField(Field\TimeZoneOffsetHour::NAME);
+        $hour = $result->getField(Field\TimeZoneOffsetHour::NAME);
         $minute = $result->getField(Field\TimeZoneOffsetMinute::NAME);
 
-        $hour   = (int) $hour;
+        $hour = (int) $hour;
         $minute = (int) $minute;
 
         if ($sign === '-') {
-            $hour   = -$hour;
+            $hour = -$hour;
             $minute = -$minute;
         }
 
@@ -121,7 +122,7 @@ final class TimeZoneOffset extends TimeZone
      *
      * @throws DateTimeParseException
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : TimeZone
+    public static function parse(string $text, ?DateTimeParser $parser = null): TimeZone
     {
         if (! $parser) {
             $parser = IsoParsers::timeZoneOffset();
@@ -139,16 +140,16 @@ final class TimeZoneOffset extends TimeZone
      *
      * @return int The total time-zone offset amount in seconds.
      */
-    public function getTotalSeconds() : int
+    public function getTotalSeconds(): int
     {
         return $this->totalSeconds;
     }
 
-    public function getId() : string
+    public function getId(): string
     {
         if ($this->id === null) {
             if ($this->totalSeconds < 0) {
-                $this->id = '-' . LocalTime::ofSecondOfDay(- $this->totalSeconds);
+                $this->id = '-' . LocalTime::ofSecondOfDay(-$this->totalSeconds);
             } elseif ($this->totalSeconds > 0) {
                 $this->id = '+' . LocalTime::ofSecondOfDay($this->totalSeconds);
             } else {
@@ -159,7 +160,7 @@ final class TimeZoneOffset extends TimeZone
         return $this->id;
     }
 
-    public function getOffset(Instant $pointInTime) : int
+    public function getOffset(Instant $pointInTime): int
     {
         return $this->totalSeconds;
     }
@@ -167,8 +168,8 @@ final class TimeZoneOffset extends TimeZone
     /**
      * @deprecated please use toNativeDateTimeZone instead
      */
-    public function toDateTimeZone() : \DateTimeZone
+    public function toDateTimeZone(): DateTimeZone
     {
-        return new \DateTimeZone($this->getId());
+        return new DateTimeZone($this->getId());
     }
 }

--- a/src/TimeZoneRegion.php
+++ b/src/TimeZoneRegion.php
@@ -8,7 +8,12 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
+use DateTime;
 use DateTimeZone;
+use Exception;
+
+use function assert;
+use function is_array;
 
 /**
  * A geographical region where the same time-zone rules apply, such as `Europe/London`.
@@ -19,8 +24,6 @@ final class TimeZoneRegion extends TimeZone
 
     /**
      * Private constructor. Use a factory method to obtain an instance.
-     *
-     * @param DateTimeZone $zone
      */
     private function __construct(DateTimeZone $zone)
     {
@@ -32,7 +35,7 @@ final class TimeZoneRegion extends TimeZone
      *
      * @throws DateTimeException If the region id is invalid.
      */
-    public static function of(string $id) : TimeZoneRegion
+    public static function of(string $id): TimeZoneRegion
     {
         if ($id === '' || $id === 'Z' || $id === 'z' || $id[0] === '+' || $id[0] === '-') {
             // DateTimeZone would accept offsets, but TimeZoneRegion targets regions only.
@@ -41,7 +44,7 @@ final class TimeZoneRegion extends TimeZone
 
         try {
             return new TimeZoneRegion(new DateTimeZone($id));
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             throw DateTimeException::unknownTimeZoneRegion($id);
         }
     }
@@ -50,7 +53,7 @@ final class TimeZoneRegion extends TimeZone
      * @throws DateTimeException      If the region is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : TimeZoneRegion
+    public static function from(DateTimeParseResult $result): TimeZoneRegion
     {
         $region = $result->getField(Field\TimeZoneRegion::NAME);
 
@@ -64,7 +67,7 @@ final class TimeZoneRegion extends TimeZone
      *
      * @return string[] An array of time-zone identifiers.
      */
-    public static function getAllIdentifiers(bool $includeObsolete = false) : array
+    public static function getAllIdentifiers(bool $includeObsolete = false): array
     {
         $identifiers = DateTimeZone::listIdentifiers(
             $includeObsolete
@@ -72,7 +75,7 @@ final class TimeZoneRegion extends TimeZone
                 : DateTimeZone::ALL
         );
 
-        \assert(\is_array($identifiers));
+        assert(is_array($identifiers));
 
         return $identifiers;
     }
@@ -86,11 +89,11 @@ final class TimeZoneRegion extends TimeZone
      *
      * @return string[] An array of time-zone identifiers.
      */
-    public static function getIdentifiersForCountry(string $countryCode) : array
+    public static function getIdentifiersForCountry(string $countryCode): array
     {
         $identifiers = DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, $countryCode);
 
-        \assert(\is_array($identifiers));
+        assert(is_array($identifiers));
 
         return $identifiers;
     }
@@ -100,7 +103,7 @@ final class TimeZoneRegion extends TimeZone
      *
      * @throws DateTimeParseException
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : TimeZoneRegion
+    public static function parse(string $text, ?DateTimeParser $parser = null): TimeZoneRegion
     {
         if (! $parser) {
             $parser = IsoParsers::timeZoneRegion();
@@ -109,14 +112,14 @@ final class TimeZoneRegion extends TimeZone
         return TimeZoneRegion::from($parser->parse($text));
     }
 
-    public function getId() : string
+    public function getId(): string
     {
         return $this->zone->getName();
     }
 
-    public function getOffset(Instant $pointInTime) : int
+    public function getOffset(Instant $pointInTime): int
     {
-        $dateTime = new \DateTime('@' . $pointInTime->getEpochSecond(), new DateTimeZone('UTC'));
+        $dateTime = new DateTime('@' . $pointInTime->getEpochSecond(), new DateTimeZone('UTC'));
 
         return $this->zone->getOffset($dateTime);
     }
@@ -124,7 +127,7 @@ final class TimeZoneRegion extends TimeZone
     /**
      * @deprecated please use toNativeDateTimeZone instead
      */
-    public function toDateTimeZone() : DateTimeZone
+    public function toDateTimeZone(): DateTimeZone
     {
         return clone $this->zone;
     }

--- a/src/Utility/Math.php
+++ b/src/Utility/Math.php
@@ -6,6 +6,9 @@ namespace Brick\DateTime\Utility;
 
 use ArithmeticError;
 
+use function intdiv;
+use function is_float;
+
 /**
  * Internal utility class for calculations on integers.
  *
@@ -16,7 +19,7 @@ final class Math
     /**
      * @throws ArithmeticError
      */
-    public static function addExact(int $a, int $b) : int
+    public static function addExact(int $a, int $b): int
     {
         $result = $a + $b;
 
@@ -30,7 +33,7 @@ final class Math
     /**
      * @throws ArithmeticError
      */
-    public static function multiplyExact(int $a, int $b) : int
+    public static function multiplyExact(int $a, int $b): int
     {
         $result = $a * $b;
 
@@ -47,9 +50,9 @@ final class Math
      * @param int $a The first argument.
      * @param int $b The second argument, non-zero.
      */
-    public static function floorDiv(int $a, int $b) : int
+    public static function floorDiv(int $a, int $b): int
     {
-        $r = \intdiv($a, $b);
+        $r = intdiv($a, $b);
 
         // If the signs are different and modulo not zero, round down.
         if (($a ^ $b) < 0 && ($r * $b !== $a)) {
@@ -68,7 +71,7 @@ final class Math
      * @param int $a The first argument.
      * @param int $b The second argument, non-zero.
      */
-    public static function floorMod(int $a, int $b) : int
+    public static function floorMod(int $a, int $b): int
     {
         return (($a % $b) + $b) % $b;
     }

--- a/src/Year.php
+++ b/src/Year.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
-use Brick\DateTime\Field;
+use JsonSerializable;
 
 /**
  * Represents a year in the proleptic calendar.
  */
-final class Year implements \JsonSerializable
+final class Year implements JsonSerializable
 {
     public const MIN_VALUE = LocalDate::MIN_YEAR;
     public const MAX_VALUE = LocalDate::MAX_YEAR;
@@ -30,7 +30,7 @@ final class Year implements \JsonSerializable
     /**
      * @throws DateTimeException If the year is out of range.
      */
-    public static function of(int $year) : Year
+    public static function of(int $year): Year
     {
         Field\Year::check($year);
 
@@ -42,12 +42,12 @@ final class Year implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : Year
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): Year
     {
         return new Year(LocalDate::now($timeZone, $clock)->getYear());
     }
 
-    public function getValue() : int
+    public function getValue(): int
     {
         return $this->year;
     }
@@ -63,12 +63,12 @@ final class Year implements \JsonSerializable
      * The calculation is proleptic - applying the same rules into the far future and far past.
      * This is historically inaccurate, but is correct for the ISO-8601 standard.
      */
-    public function isLeap() : bool
+    public function isLeap(): bool
     {
         return Field\Year::isLeap($this->year);
     }
 
-    public function isValidMonthDay(MonthDay $monthDay) : bool
+    public function isValidMonthDay(MonthDay $monthDay): bool
     {
         return $monthDay->isValidYear($this->year);
     }
@@ -78,7 +78,7 @@ final class Year implements \JsonSerializable
      *
      * @return int The length of this year in days, 365 or 366.
      */
-    public function getLength() : int
+    public function getLength(): int
     {
         return $this->isLeap() ? 366 : 365;
     }
@@ -94,7 +94,7 @@ final class Year implements \JsonSerializable
      *
      * @throws DateTimeException If the resulting year exceeds the supported range.
      */
-    public function plus(int $years) : Year
+    public function plus(int $years): Year
     {
         if ($years === 0) {
             return $this;
@@ -118,7 +118,7 @@ final class Year implements \JsonSerializable
      *
      * @throws DateTimeException If the resulting year exceeds the supported range.
      */
-    public function minus(int $years) : Year
+    public function minus(int $years): Year
     {
         if ($years === 0) {
             return $this;
@@ -138,7 +138,7 @@ final class Year implements \JsonSerializable
      *
      * @return int [-1, 0, 1] If this year is before, equal to, or after the given year.
      */
-    public function compareTo(Year $that) : int
+    public function compareTo(Year $that): int
     {
         if ($this->year > $that->year) {
             return 1;
@@ -158,7 +158,7 @@ final class Year implements \JsonSerializable
      *
      * @return bool True if this year is equal to the given year, false otherwise.
      */
-    public function isEqualTo(Year $that) : bool
+    public function isEqualTo(Year $that): bool
     {
         return $this->year === $that->year;
     }
@@ -170,7 +170,7 @@ final class Year implements \JsonSerializable
      *
      * @return bool True if this year is after the given year, false otherwise.
      */
-    public function isAfter(Year $that) : bool
+    public function isAfter(Year $that): bool
     {
         return $this->year > $that->year;
     }
@@ -182,7 +182,7 @@ final class Year implements \JsonSerializable
      *
      * @return bool True if this year is before the given year, false otherwise.
      */
-    public function isBefore(Year $that) : bool
+    public function isBefore(Year $that): bool
     {
         return $this->year < $that->year;
     }
@@ -192,11 +192,9 @@ final class Year implements \JsonSerializable
      *
      * @param int $dayOfYear The day-of-year to use, from 1 to 366.
      *
-     * @return LocalDate
-     *
      * @throws DateTimeException If the day-of-year is invalid for this year.
      */
-    public function atDay(int $dayOfYear) : LocalDate
+    public function atDay(int $dayOfYear): LocalDate
     {
         return LocalDate::ofYearDay($this->year, $dayOfYear);
     }
@@ -206,11 +204,9 @@ final class Year implements \JsonSerializable
      *
      * @param int $month The month-of-year to use, from 1 to 12.
      *
-     * @return YearMonth
-     *
      * @throws DateTimeException If the month is invalid.
      */
-    public function atMonth(int $month) : YearMonth
+    public function atMonth(int $month): YearMonth
     {
         return YearMonth::of($this->year, $month);
     }
@@ -223,16 +219,15 @@ final class Year implements \JsonSerializable
      *
      * @param MonthDay $monthDay The month-day to use.
      */
-    public function atMonthDay(MonthDay $monthDay) : LocalDate
+    public function atMonthDay(MonthDay $monthDay): LocalDate
     {
         return $monthDay->atYear($this->year);
     }
 
     /**
-     * Returns LocalDateRange that contains all days of this year
-     * @return LocalDateRange
+     * Returns LocalDateRange that contains all days of this year.
      */
-    public function toLocalDateRange() : LocalDateRange
+    public function toLocalDateRange(): LocalDateRange
     {
         return LocalDateRange::of(
             $this->atMonth(1)->getFirstDay(),
@@ -243,12 +238,12 @@ final class Year implements \JsonSerializable
     /**
      * Serializes as a string using {@see Year::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return (string) $this->year;
     }

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -9,11 +9,14 @@ use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
 use Brick\DateTime\Utility\Math;
+use JsonSerializable;
+
+use function sprintf;
 
 /**
  * Represents the combination of a year and a month.
  */
-final class YearMonth implements \JsonSerializable
+final class YearMonth implements JsonSerializable
 {
     /**
      * The year, from MIN_YEAR to MAX_YEAR.
@@ -31,7 +34,7 @@ final class YearMonth implements \JsonSerializable
      */
     private function __construct(int $year, int $month)
     {
-        $this->year  = $year;
+        $this->year = $year;
         $this->month = $month;
     }
 
@@ -43,7 +46,7 @@ final class YearMonth implements \JsonSerializable
      *
      * @throws DateTimeException
      */
-    public static function of(int $year, int $month) : YearMonth
+    public static function of(int $year, int $month): YearMonth
     {
         Field\Year::check($year);
         Field\MonthOfYear::check($month);
@@ -55,7 +58,7 @@ final class YearMonth implements \JsonSerializable
      * @throws DateTimeException      If the year-month is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : YearMonth
+    public static function from(DateTimeParseResult $result): YearMonth
     {
         return YearMonth::of(
             (int) $result->getField(Field\Year::NAME),
@@ -72,7 +75,7 @@ final class YearMonth implements \JsonSerializable
      * @throws DateTimeException      If the date is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : YearMonth
+    public static function parse(string $text, ?DateTimeParser $parser = null): YearMonth
     {
         if (! $parser) {
             $parser = IsoParsers::yearMonth();
@@ -85,25 +88,20 @@ final class YearMonth implements \JsonSerializable
      * Returns the current year-month in the given time-zone, according to the given clock.
      *
      * If no clock is provided, the system clock is used.
-     *
-     * @param TimeZone   $timeZone
-     * @param Clock|null $clock
-     *
-     * @return YearMonth
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : YearMonth
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): YearMonth
     {
         $localDate = LocalDate::now($timeZone, $clock);
 
         return new YearMonth($localDate->getYear(), $localDate->getMonth());
     }
 
-    public function getYear() : int
+    public function getYear(): int
     {
         return $this->year;
     }
 
-    public function getMonth() : int
+    public function getMonth(): int
     {
         return $this->month;
     }
@@ -111,7 +109,7 @@ final class YearMonth implements \JsonSerializable
     /**
      * Returns whether the year is a leap year.
      */
-    public function isLeapYear() : bool
+    public function isLeapYear(): bool
     {
         return Year::of($this->year)->isLeap();
     }
@@ -119,7 +117,7 @@ final class YearMonth implements \JsonSerializable
     /**
      * Returns the length of the month in days, taking account of the year.
      */
-    public function getLengthOfMonth() : int
+    public function getLengthOfMonth(): int
     {
         return Month::of($this->month)->getLength($this->isLeapYear());
     }
@@ -127,15 +125,15 @@ final class YearMonth implements \JsonSerializable
     /**
      * Returns the length of the year in days, either 365 or 366.
      */
-    public function getLengthOfYear() : int
+    public function getLengthOfYear(): int
     {
-        return $this->isLeapYear() ? 366: 365;
+        return $this->isLeapYear() ? 366 : 365;
     }
 
     /**
      * @return int [-1,0,1] If this year-month is before, on, or after the given year-month.
      */
-    public function compareTo(YearMonth $that) : int
+    public function compareTo(YearMonth $that): int
     {
         if ($this->year < $that->year) {
             return -1;
@@ -153,27 +151,27 @@ final class YearMonth implements \JsonSerializable
         return 0;
     }
 
-    public function isEqualTo(YearMonth $that) : bool
+    public function isEqualTo(YearMonth $that): bool
     {
         return $this->compareTo($that) === 0;
     }
 
-    public function isBefore(YearMonth $that) : bool
+    public function isBefore(YearMonth $that): bool
     {
         return $this->compareTo($that) === -1;
     }
 
-    public function isBeforeOrEqualTo(YearMonth $that) : bool
+    public function isBeforeOrEqualTo(YearMonth $that): bool
     {
         return $this->compareTo($that) <= 0;
     }
 
-    public function isAfter(YearMonth $that) : bool
+    public function isAfter(YearMonth $that): bool
     {
         return $this->compareTo($that) === 1;
     }
 
-    public function isAfterOrEqualTo(YearMonth $that) : bool
+    public function isAfterOrEqualTo(YearMonth $that): bool
     {
         return $this->compareTo($that) >= 0;
     }
@@ -183,7 +181,7 @@ final class YearMonth implements \JsonSerializable
      *
      * @throws DateTimeException If the year is not valid.
      */
-    public function withYear(int $year) : YearMonth
+    public function withYear(int $year): YearMonth
     {
         if ($year === $this->year) {
             return $this;
@@ -199,7 +197,7 @@ final class YearMonth implements \JsonSerializable
      *
      * @throws DateTimeException If the month-of-year is not valid.
      */
-    public function withMonth(int $month) : YearMonth
+    public function withMonth(int $month): YearMonth
     {
         if ($month === $this->month) {
             return $this;
@@ -210,12 +208,12 @@ final class YearMonth implements \JsonSerializable
         return new YearMonth($this->year, $month);
     }
 
-    public function getFirstDay() : LocalDate
+    public function getFirstDay(): LocalDate
     {
         return $this->atDay(1);
     }
 
-    public function getLastDay() : LocalDate
+    public function getLastDay(): LocalDate
     {
         return $this->atDay($this->getLengthOfMonth());
     }
@@ -229,7 +227,7 @@ final class YearMonth implements \JsonSerializable
      *
      * @throws DateTimeException If the day is not valid for this year-month.
      */
-    public function atDay(int $day) : LocalDate
+    public function atDay(int $day): LocalDate
     {
         return LocalDate::of($this->year, $this->month, $day);
     }
@@ -237,7 +235,7 @@ final class YearMonth implements \JsonSerializable
     /**
      * Returns a copy of this YearMonth with the specified period in years added.
      */
-    public function plusYears(int $years) : YearMonth
+    public function plusYears(int $years): YearMonth
     {
         if ($years === 0) {
             return $this;
@@ -249,7 +247,7 @@ final class YearMonth implements \JsonSerializable
     /**
      * Returns a copy of this YearMonth with the specified period in months added.
      */
-    public function plusMonths(int $months) : YearMonth
+    public function plusMonths(int $months): YearMonth
     {
         if ($months === 0) {
             return $this;
@@ -268,22 +266,21 @@ final class YearMonth implements \JsonSerializable
     /**
      * Returns a copy of this YearMonth with the specified period in years subtracted.
      */
-    public function minusYears(int $years) : YearMonth
+    public function minusYears(int $years): YearMonth
     {
-        return $this->plusYears(- $years);
+        return $this->plusYears(-$years);
     }
 
     /**
      * Returns a copy of this YearMonth with the specified period in months subtracted.
      */
-    public function minusMonths(int $months) : YearMonth
+    public function minusMonths(int $months): YearMonth
     {
-        return $this->plusMonths(- $months);
+        return $this->plusMonths(-$months);
     }
 
     /**
-     * Returns LocalDateRange that contains all days of this year and month
-     * @return LocalDateRange
+     * Returns LocalDateRange that contains all days of this year and month.
      */
     public function toLocalDateRange(): LocalDateRange
     {
@@ -293,7 +290,7 @@ final class YearMonth implements \JsonSerializable
     /**
      * Serializes as a string using {@see YearMonth::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
@@ -301,8 +298,8 @@ final class YearMonth implements \JsonSerializable
     /**
      * Returns the ISO 8601 representation of this YearMonth.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
-        return \sprintf('%02u-%02u', $this->year, $this->month);
+        return sprintf('%02u-%02u', $this->year, $this->month);
     }
 }

--- a/src/YearMonthRange.php
+++ b/src/YearMonthRange.php
@@ -8,6 +8,10 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
+use Countable;
+use Generator;
+use IteratorAggregate;
+use JsonSerializable;
 
 /**
  * Represents an inclusive range of year-months.
@@ -15,7 +19,7 @@ use Brick\DateTime\Parser\IsoParsers;
  * This object is iterable and countable: the iterator returns all the YearMonth objects contained
  * in the range, while `count()` returns the total number of year-months contained in the range.
  */
-class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializable
+class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable
 {
     /**
      * The start year-month, inclusive.
@@ -34,7 +38,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
     private function __construct(YearMonth $start, YearMonth $end)
     {
         $this->start = $start;
-        $this->end   = $end;
+        $this->end = $end;
     }
 
     /**
@@ -45,7 +49,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
      *
      * @throws DateTimeException If the end year-month is before the start year-month.
      */
-    public static function of(YearMonth $start, YearMonth $end) : YearMonthRange
+    public static function of(YearMonth $start, YearMonth $end): YearMonthRange
     {
         if ($end->isBefore($start)) {
             throw new DateTimeException('The end year-month must not be before the start year-month.');
@@ -62,7 +66,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
      * @throws DateTimeException      If the year-month range is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : YearMonthRange
+    public static function from(DateTimeParseResult $result): YearMonthRange
     {
         $start = YearMonth::from($result);
 
@@ -89,7 +93,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
      * @throws DateTimeException      If either of the year-months is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : YearMonthRange
+    public static function parse(string $text, ?DateTimeParser $parser = null): YearMonthRange
     {
         if (! $parser) {
             $parser = IsoParsers::yearMonthRange();
@@ -101,7 +105,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
     /**
      * Returns the start year-month, inclusive.
      */
-    public function getStart() : YearMonth
+    public function getStart(): YearMonth
     {
         return $this->start;
     }
@@ -109,7 +113,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
     /**
      * Returns the end year-month, inclusive.
      */
-    public function getEnd() : YearMonth
+    public function getEnd(): YearMonth
     {
         return $this->end;
     }
@@ -121,7 +125,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
      *
      * @return bool True if this range equals the given one, false otherwise.
      */
-    public function isEqualTo(YearMonthRange $that) : bool
+    public function isEqualTo(YearMonthRange $that): bool
     {
         return $this->start->isEqualTo($that->start) && $this->end->isEqualTo($that->end);
     }
@@ -133,7 +137,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
      *
      * @return bool True if this range contains the given year-month, false otherwise.
      */
-    public function contains(YearMonth $yearMonth) : bool
+    public function contains(YearMonth $yearMonth): bool
     {
         return $yearMonth->isAfterOrEqualTo($this->start) && $yearMonth->isBeforeOrEqualTo($this->end);
     }
@@ -141,9 +145,9 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
     /**
      * Returns an iterator for all the year-months contained in this range.
      *
-     * @return \Generator<YearMonth>
+     * @return Generator<YearMonth>
      */
-    public function getIterator() : \Generator
+    public function getIterator(): Generator
     {
         for ($current = $this->start; $current->isBeforeOrEqualTo($this->end); $current = $current->plusMonths(1)) {
             yield $current;
@@ -155,7 +159,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
      *
      * @return int The number of year-months, >= 1.
      */
-    public function count() : int
+    public function count(): int
     {
         return 12 * ($this->end->getYear() - $this->start->getYear())
             + ($this->end->getMonth() - $this->start->getMonth())
@@ -163,8 +167,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
     }
 
     /**
-     * Returns LocalDateRange that contains all days of this year-months range
-     * @return LocalDateRange
+     * Returns LocalDateRange that contains all days of this year-months range.
      */
     public function toLocalDateRange(): LocalDateRange
     {
@@ -177,7 +180,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
     /**
      * Serializes as a string using {@see YearMonthRange::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
@@ -188,7 +191,7 @@ class YearMonthRange implements \IteratorAggregate, \Countable, \JsonSerializabl
      * ISO 8601 does not seem to provide a standard notation for year-month ranges, but we're using the same format as
      * date ranges.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->start . '/' . $this->end;
     }

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Brick\DateTime;
 
+use JsonSerializable;
+
+use function sprintf;
+
 /**
  * Represents the combination of a year and a week.
  */
-final class YearWeek implements \JsonSerializable
+final class YearWeek implements JsonSerializable
 {
     /**
      * The year, from MIN_YEAR to MAX_YEAR.
@@ -37,7 +41,7 @@ final class YearWeek implements \JsonSerializable
      *
      * @throws DateTimeException
      */
-    public static function of(int $year, int $week) : YearWeek
+    public static function of(int $year, int $week): YearWeek
     {
         Field\Year::check($year);
         Field\WeekOfYear::check($week, $year);
@@ -45,17 +49,17 @@ final class YearWeek implements \JsonSerializable
         return new YearWeek($year, $week);
     }
 
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : YearWeek
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): YearWeek
     {
         return LocalDate::now($timeZone, $clock)->getYearWeek();
     }
 
-    public function getYear() : int
+    public function getYear(): int
     {
         return $this->year;
     }
 
-    public function getWeek() : int
+    public function getWeek(): int
     {
         return $this->week;
     }
@@ -63,7 +67,7 @@ final class YearWeek implements \JsonSerializable
     /**
      * @return int [-1,0,1] If this year-week is before, on, or after the given year-week.
      */
-    public function compareTo(YearWeek $that) : int
+    public function compareTo(YearWeek $that): int
     {
         if ($this->year < $that->year) {
             return -1;
@@ -81,27 +85,27 @@ final class YearWeek implements \JsonSerializable
         return 0;
     }
 
-    public function isEqualTo(YearWeek $that) : bool
+    public function isEqualTo(YearWeek $that): bool
     {
         return $this->compareTo($that) === 0;
     }
 
-    public function isBefore(YearWeek $that) : bool
+    public function isBefore(YearWeek $that): bool
     {
         return $this->compareTo($that) === -1;
     }
 
-    public function isBeforeOrEqualTo(YearWeek $that) : bool
+    public function isBeforeOrEqualTo(YearWeek $that): bool
     {
         return $this->compareTo($that) <= 0;
     }
 
-    public function isAfter(YearWeek $that) : bool
+    public function isAfter(YearWeek $that): bool
     {
         return $this->compareTo($that) === 1;
     }
 
-    public function isAfterOrEqualTo(YearWeek $that) : bool
+    public function isAfterOrEqualTo(YearWeek $that): bool
     {
         return $this->compareTo($that) >= 0;
     }
@@ -113,7 +117,7 @@ final class YearWeek implements \JsonSerializable
      *
      * @throws DateTimeException If the year is not valid.
      */
-    public function withYear(int $year) : YearWeek
+    public function withYear(int $year): YearWeek
     {
         if ($year === $this->year) {
             return $this;
@@ -137,7 +141,7 @@ final class YearWeek implements \JsonSerializable
      *
      * @throws DateTimeException If the week is not valid.
      */
-    public function withWeek(int $week) : YearWeek
+    public function withWeek(int $week): YearWeek
     {
         if ($week === $this->week) {
             return $this;
@@ -158,7 +162,7 @@ final class YearWeek implements \JsonSerializable
     /**
      * Combines this year-week with a day-of-week to create a LocalDate.
      */
-    public function atDay(int $dayOfWeek) : LocalDate
+    public function atDay(int $dayOfWeek): LocalDate
     {
         Field\DayOfWeek::check($dayOfWeek);
 
@@ -182,7 +186,7 @@ final class YearWeek implements \JsonSerializable
     /**
      * Returns the first day of this week.
      */
-    public function getFirstDay() : LocalDate
+    public function getFirstDay(): LocalDate
     {
         return $this->atDay(DayOfWeek::MONDAY);
     }
@@ -190,7 +194,7 @@ final class YearWeek implements \JsonSerializable
     /**
      * Returns the last day of this week.
      */
-    public function getLastDay() : LocalDate
+    public function getLastDay(): LocalDate
     {
         return $this->atDay(DayOfWeek::SUNDAY);
     }
@@ -200,7 +204,7 @@ final class YearWeek implements \JsonSerializable
      *
      * If the week is 53 and the new year does not have 53 weeks, the week will be adjusted to be 52.
      */
-    public function plusYears(int $years) : YearWeek
+    public function plusYears(int $years): YearWeek
     {
         if ($years === 0) {
             return $this;
@@ -212,7 +216,7 @@ final class YearWeek implements \JsonSerializable
     /**
      * Returns a copy of this YearWeek with the specified period in weeks added.
      */
-    public function plusWeeks(int $weeks) : YearWeek
+    public function plusWeeks(int $weeks): YearWeek
     {
         if ($weeks === 0) {
             return $this;
@@ -228,30 +232,29 @@ final class YearWeek implements \JsonSerializable
      *
      * If the week is 53 and the new year does not have 53 weeks, the week will be adjusted to be 52.
      */
-    public function minusYears(int $years) : YearWeek
+    public function minusYears(int $years): YearWeek
     {
-        return $this->plusYears(- $years);
+        return $this->plusYears(-$years);
     }
 
     /**
      * Returns a copy of this YearWeek with the specified period in weeks subtracted.
      */
-    public function minusWeeks(int $weeks) : YearWeek
+    public function minusWeeks(int $weeks): YearWeek
     {
-        return $this->plusWeeks(- $weeks);
+        return $this->plusWeeks(-$weeks);
     }
 
     /**
      * Returns whether this year has 53 weeks.
      */
-    public function is53WeekYear() : bool
+    public function is53WeekYear(): bool
     {
         return Field\WeekOfYear::is53WeekYear($this->year);
     }
 
     /**
-     * Returns LocalDateRange that contains all days of this year week
-     * @return LocalDateRange
+     * Returns LocalDateRange that contains all days of this year week.
      */
     public function toLocalDateRange(): LocalDateRange
     {
@@ -261,15 +264,15 @@ final class YearWeek implements \JsonSerializable
     /**
      * Serializes as a string using {@see YearWeek::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         $pattern = ($this->year < 0 ? '%05d' : '%04d') . '-W%02d';
 
-        return \sprintf($pattern, $this->year, $this->week);
+        return sprintf($pattern, $this->year, $this->week);
     }
 }

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -8,6 +8,12 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Parser\DateTimeParser;
 use Brick\DateTime\Parser\DateTimeParseResult;
 use Brick\DateTime\Parser\IsoParsers;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonSerializable;
+
+use function intdiv;
 
 /**
  * A date-time with a time-zone in the ISO-8601 calendar system.
@@ -15,7 +21,7 @@ use Brick\DateTime\Parser\IsoParsers;
  * A ZonedDateTime can be viewed as a LocalDateTime along with a time zone
  * and targets a specific point in time.
  */
-class ZonedDateTime implements \JsonSerializable
+class ZonedDateTime implements JsonSerializable
 {
     /**
      * The local date-time.
@@ -42,18 +48,13 @@ class ZonedDateTime implements \JsonSerializable
 
     /**
      * Private constructor. Use a factory method to obtain an instance.
-     *
-     * @param LocalDateTime  $localDateTime
-     * @param TimeZoneOffset $offset
-     * @param TimeZone       $zone
-     * @param Instant        $instant
      */
     private function __construct(LocalDateTime $localDateTime, TimeZoneOffset $offset, TimeZone $zone, Instant $instant)
     {
-        $this->localDateTime  = $localDateTime;
-        $this->timeZone       = $zone;
+        $this->localDateTime = $localDateTime;
+        $this->timeZone = $zone;
         $this->timeZoneOffset = $offset;
-        $this->instant        = $instant;
+        $this->instant = $instant;
     }
 
     /**
@@ -82,10 +83,10 @@ class ZonedDateTime implements \JsonSerializable
      *   by the length of the gap, and the later offset, typically "summer" time, will be used.
      * - If the local date-time falls in the middle of an overlap, then the offset closest to UTC will be used.
      */
-    public static function of(LocalDateTime $dateTime, TimeZone $timeZone) : ZonedDateTime
+    public static function of(LocalDateTime $dateTime, TimeZone $timeZone): ZonedDateTime
     {
         $dtz = $timeZone->toNativeDateTimeZone();
-        $dt = new \DateTime((string) $dateTime->withNano(0), $dtz);
+        $dt = new DateTime((string) $dateTime->withNano(0), $dtz);
 
         $instant = Instant::of($dt->getTimestamp(), $dateTime->getNano());
 
@@ -108,12 +109,12 @@ class ZonedDateTime implements \JsonSerializable
      *
      * This resolves the instant to a date and time without ambiguity.
      */
-    public static function ofInstant(Instant $instant, TimeZone $timeZone) : ZonedDateTime
+    public static function ofInstant(Instant $instant, TimeZone $timeZone): ZonedDateTime
     {
         $dateTimeZone = $timeZone->toNativeDateTimeZone();
 
         // We need to pass a DateTimeZone to avoid a PHP warning...
-        $dateTime = new \DateTime('@' . $instant->getEpochSecond(), $dateTimeZone);
+        $dateTime = new DateTime('@' . $instant->getEpochSecond(), $dateTimeZone);
 
         // ... but this DateTimeZone is ignored because of the timestamp, so we set it again.
         $dateTime->setTimezone($dateTimeZone);
@@ -135,7 +136,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public static function now(TimeZone $timeZone, ?Clock $clock = null) : ZonedDateTime
+    public static function now(TimeZone $timeZone, ?Clock $clock = null): ZonedDateTime
     {
         return ZonedDateTime::ofInstant(Instant::now($clock), $timeZone);
     }
@@ -148,7 +149,7 @@ class ZonedDateTime implements \JsonSerializable
      * @throws DateTimeException      If the zoned date-time is not valid.
      * @throws DateTimeParseException If required fields are missing from the result.
      */
-    public static function from(DateTimeParseResult $result) : ZonedDateTime
+    public static function from(DateTimeParseResult $result): ZonedDateTime
     {
         $localDateTime = LocalDateTime::from($result);
 
@@ -180,7 +181,7 @@ class ZonedDateTime implements \JsonSerializable
      * @throws DateTimeException      If the date is not valid.
      * @throws DateTimeParseException If the text string does not follow the expected format.
      */
-    public static function parse(string $text, ?DateTimeParser $parser = null) : ZonedDateTime
+    public static function parse(string $text, ?DateTimeParser $parser = null): ZonedDateTime
     {
         if (! $parser) {
             $parser = IsoParsers::zonedDateTime();
@@ -194,7 +195,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * @throws DateTimeException If the DateTime object has no timezone.
      */
-    public static function fromDateTime(\DateTimeInterface $dateTime) : ZonedDateTime
+    public static function fromDateTime(DateTimeInterface $dateTime): ZonedDateTime
     {
         $localDateTime = LocalDateTime::fromDateTime($dateTime);
 
@@ -220,7 +221,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns the `LocalDateTime` part of this `ZonedDateTime`.
      */
-    public function getDateTime() : LocalDateTime
+    public function getDateTime(): LocalDateTime
     {
         return $this->localDateTime;
     }
@@ -228,7 +229,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns the `LocalDate` part of this `ZonedDateTime`.
      */
-    public function getDate() : LocalDate
+    public function getDate(): LocalDate
     {
         return $this->localDateTime->getDate();
     }
@@ -236,57 +237,57 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns the `LocalTime` part of this `ZonedDateTime`.
      */
-    public function getTime() : LocalTime
+    public function getTime(): LocalTime
     {
         return $this->localDateTime->getTime();
     }
 
-    public function getYear() : int
+    public function getYear(): int
     {
         return $this->localDateTime->getYear();
     }
 
-    public function getMonth() : int
+    public function getMonth(): int
     {
         return $this->localDateTime->getMonth();
     }
 
-    public function getDay() : int
+    public function getDay(): int
     {
         return $this->localDateTime->getDay();
     }
 
-    public function getDayOfWeek() : DayOfWeek
+    public function getDayOfWeek(): DayOfWeek
     {
         return $this->localDateTime->getDayOfWeek();
     }
 
-    public function getDayOfYear() : int
+    public function getDayOfYear(): int
     {
         return $this->localDateTime->getDayOfYear();
     }
 
-    public function getHour() : int
+    public function getHour(): int
     {
         return $this->localDateTime->getHour();
     }
 
-    public function getMinute() : int
+    public function getMinute(): int
     {
         return $this->localDateTime->getMinute();
     }
 
-    public function getSecond() : int
+    public function getSecond(): int
     {
         return $this->localDateTime->getSecond();
     }
 
-    public function getEpochSecond() : int
+    public function getEpochSecond(): int
     {
         return $this->instant->getEpochSecond();
     }
 
-    public function getNano() : int
+    public function getNano(): int
     {
         return $this->instant->getNano();
     }
@@ -294,7 +295,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns the time-zone, region or offset.
      */
-    public function getTimeZone() : TimeZone
+    public function getTimeZone(): TimeZone
     {
         return $this->timeZone;
     }
@@ -302,12 +303,12 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns the time-zone offset.
      */
-    public function getTimeZoneOffset() : TimeZoneOffset
+    public function getTimeZoneOffset(): TimeZoneOffset
     {
         return $this->timeZoneOffset;
     }
 
-    public function getInstant() : Instant
+    public function getInstant(): Instant
     {
         return $this->instant;
     }
@@ -315,7 +316,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with a different date.
      */
-    public function withDate(LocalDate $date) : ZonedDateTime
+    public function withDate(LocalDate $date): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withDate($date), $this->timeZone);
     }
@@ -323,7 +324,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with a different time.
      */
-    public function withTime(LocalTime $time) : ZonedDateTime
+    public function withTime(LocalTime $time): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withTime($time), $this->timeZone);
     }
@@ -331,7 +332,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the year altered.
      */
-    public function withYear(int $year) : ZonedDateTime
+    public function withYear(int $year): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withYear($year), $this->timeZone);
     }
@@ -339,7 +340,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the month-of-year altered.
      */
-    public function withMonth(int $month) : ZonedDateTime
+    public function withMonth(int $month): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withMonth($month), $this->timeZone);
     }
@@ -347,7 +348,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the day-of-month altered.
      */
-    public function withDay(int $day) : ZonedDateTime
+    public function withDay(int $day): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withDay($day), $this->timeZone);
     }
@@ -355,7 +356,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the hour-of-day altered.
      */
-    public function withHour(int $hour) : ZonedDateTime
+    public function withHour(int $hour): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withHour($hour), $this->timeZone);
     }
@@ -363,7 +364,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the minute-of-hour altered.
      */
-    public function withMinute(int $minute) : ZonedDateTime
+    public function withMinute(int $minute): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withMinute($minute), $this->timeZone);
     }
@@ -371,7 +372,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the second-of-minute altered.
      */
-    public function withSecond(int $second) : ZonedDateTime
+    public function withSecond(int $second): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withSecond($second), $this->timeZone);
     }
@@ -379,7 +380,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the nano-of-second altered.
      */
-    public function withNano(int $nano) : ZonedDateTime
+    public function withNano(int $nano): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->withNano($nano), $this->timeZone);
     }
@@ -388,7 +389,7 @@ class ZonedDateTime implements \JsonSerializable
      * Returns a copy of this `ZonedDateTime` with a different time-zone,
      * retaining the local date-time if possible.
      */
-    public function withTimeZoneSameLocal(TimeZone $timeZone) : ZonedDateTime
+    public function withTimeZoneSameLocal(TimeZone $timeZone): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime, $timeZone);
     }
@@ -396,7 +397,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this date-time with a different time-zone, retaining the instant.
      */
-    public function withTimeZoneSameInstant(TimeZone $timeZone) : ZonedDateTime
+    public function withTimeZoneSameInstant(TimeZone $timeZone): ZonedDateTime
     {
         return ZonedDateTime::ofInstant($this->instant, $timeZone);
     }
@@ -413,7 +414,7 @@ class ZonedDateTime implements \JsonSerializable
      * This might also be useful when sending a zoned date-time across a network,
      * as most protocols, such as ISO-8601, only handle offsets, and not region-based time zones.
      */
-    public function withFixedOffsetTimeZone() : ZonedDateTime
+    public function withFixedOffsetTimeZone(): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime, $this->timeZoneOffset);
     }
@@ -421,7 +422,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified Period added.
      */
-    public function plusPeriod(Period $period) : ZonedDateTime
+    public function plusPeriod(Period $period): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusPeriod($period), $this->timeZone);
     }
@@ -429,7 +430,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified Duration added.
      */
-    public function plusDuration(Duration $duration) : ZonedDateTime
+    public function plusDuration(Duration $duration): ZonedDateTime
     {
         return ZonedDateTime::ofInstant($this->instant->plus($duration), $this->timeZone);
     }
@@ -437,7 +438,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in years added.
      */
-    public function plusYears(int $years) : ZonedDateTime
+    public function plusYears(int $years): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusYears($years), $this->timeZone);
     }
@@ -445,7 +446,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in months added.
      */
-    public function plusMonths(int $months) : ZonedDateTime
+    public function plusMonths(int $months): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusMonths($months), $this->timeZone);
     }
@@ -453,7 +454,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in weeks added.
      */
-    public function plusWeeks(int $weeks) : ZonedDateTime
+    public function plusWeeks(int $weeks): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusWeeks($weeks), $this->timeZone);
     }
@@ -461,7 +462,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in days added.
      */
-    public function plusDays(int $days) : ZonedDateTime
+    public function plusDays(int $days): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusDays($days), $this->timeZone);
     }
@@ -469,7 +470,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in hours added.
      */
-    public function plusHours(int $hours) : ZonedDateTime
+    public function plusHours(int $hours): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusHours($hours), $this->timeZone);
     }
@@ -477,7 +478,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in minutes added.
      */
-    public function plusMinutes(int $minutes) : ZonedDateTime
+    public function plusMinutes(int $minutes): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusMinutes($minutes), $this->timeZone);
     }
@@ -485,7 +486,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in seconds added.
      */
-    public function plusSeconds(int $seconds) : ZonedDateTime
+    public function plusSeconds(int $seconds): ZonedDateTime
     {
         return ZonedDateTime::of($this->localDateTime->plusSeconds($seconds), $this->timeZone);
     }
@@ -493,7 +494,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified Period subtracted.
      */
-    public function minusPeriod(Period $period) : ZonedDateTime
+    public function minusPeriod(Period $period): ZonedDateTime
     {
         return $this->plusPeriod($period->negated());
     }
@@ -501,7 +502,7 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified Duration subtracted.
      */
-    public function minusDuration(Duration $duration) : ZonedDateTime
+    public function minusDuration(Duration $duration): ZonedDateTime
     {
         return $this->plusDuration($duration->negated());
     }
@@ -509,57 +510,57 @@ class ZonedDateTime implements \JsonSerializable
     /**
      * Returns a copy of this ZonedDateTime with the specified period in years subtracted.
      */
-    public function minusYears(int $years) : ZonedDateTime
+    public function minusYears(int $years): ZonedDateTime
     {
-        return $this->plusYears(- $years);
+        return $this->plusYears(-$years);
     }
 
     /**
      * Returns a copy of this ZonedDateTime with the specified period in months subtracted.
      */
-    public function minusMonths(int $months) : ZonedDateTime
+    public function minusMonths(int $months): ZonedDateTime
     {
-        return $this->plusMonths(- $months);
+        return $this->plusMonths(-$months);
     }
 
     /**
      * Returns a copy of this ZonedDateTime with the specified period in weeks subtracted.
      */
-    public function minusWeeks(int $weeks) : ZonedDateTime
+    public function minusWeeks(int $weeks): ZonedDateTime
     {
-        return $this->plusWeeks(- $weeks);
+        return $this->plusWeeks(-$weeks);
     }
 
     /**
      * Returns a copy of this ZonedDateTime with the specified period in days subtracted.
      */
-    public function minusDays(int $days) : ZonedDateTime
+    public function minusDays(int $days): ZonedDateTime
     {
-        return $this->plusDays(- $days);
+        return $this->plusDays(-$days);
     }
 
     /**
      * Returns a copy of this ZonedDateTime with the specified period in hours subtracted.
      */
-    public function minusHours(int $hours) : ZonedDateTime
+    public function minusHours(int $hours): ZonedDateTime
     {
-        return $this->plusHours(- $hours);
+        return $this->plusHours(-$hours);
     }
 
     /**
      * Returns a copy of this ZonedDateTime with the specified period in minutes subtracted.
      */
-    public function minusMinutes(int $minutes) : ZonedDateTime
+    public function minusMinutes(int $minutes): ZonedDateTime
     {
-        return $this->plusMinutes(- $minutes);
+        return $this->plusMinutes(-$minutes);
     }
 
     /**
      * Returns a copy of this ZonedDateTime with the specified period in seconds subtracted.
      */
-    public function minusSeconds(int $seconds) : ZonedDateTime
+    public function minusSeconds(int $seconds): ZonedDateTime
     {
-        return $this->plusSeconds(- $seconds);
+        return $this->plusSeconds(-$seconds);
     }
 
     /**
@@ -569,7 +570,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * @return int [-1,0,1] If this zoned date-time is before, on, or after the given one.
      */
-    public function compareTo(ZonedDateTime $that) : int
+    public function compareTo(ZonedDateTime $that): int
     {
         return $this->instant->compareTo($that->instant);
     }
@@ -579,7 +580,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * The comparison is performed on the instant.
      */
-    public function isEqualTo(ZonedDateTime $that) : bool
+    public function isEqualTo(ZonedDateTime $that): bool
     {
         return $this->compareTo($that) === 0;
     }
@@ -589,7 +590,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * The comparison is performed on the instant.
      */
-    public function isAfter(ZonedDateTime $that) : bool
+    public function isAfter(ZonedDateTime $that): bool
     {
         return $this->compareTo($that) === 1;
     }
@@ -599,7 +600,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * The comparison is performed on the instant.
      */
-    public function isAfterOrEqualTo(ZonedDateTime $that) : bool
+    public function isAfterOrEqualTo(ZonedDateTime $that): bool
     {
         return $this->compareTo($that) >= 0;
     }
@@ -609,7 +610,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * The comparison is performed on the instant.
      */
-    public function isBefore(ZonedDateTime $that) : bool
+    public function isBefore(ZonedDateTime $that): bool
     {
         return $this->compareTo($that) === -1;
     }
@@ -619,17 +620,17 @@ class ZonedDateTime implements \JsonSerializable
      *
      * The comparison is performed on the instant.
      */
-    public function isBeforeOrEqualTo(ZonedDateTime $that) : bool
+    public function isBeforeOrEqualTo(ZonedDateTime $that): bool
     {
         return $this->compareTo($that) <= 0;
     }
 
-    public function isBetweenInclusive(ZonedDateTime $from, ZonedDateTime $to) : bool
+    public function isBetweenInclusive(ZonedDateTime $from, ZonedDateTime $to): bool
     {
         return $this->isAfterOrEqualTo($from) && $this->isBeforeOrEqualTo($to);
     }
 
-    public function isBetweenExclusive(ZonedDateTime $from, ZonedDateTime $to) : bool
+    public function isBetweenExclusive(ZonedDateTime $from, ZonedDateTime $to): bool
     {
         return $this->isAfter($from) && $this->isBefore($to);
     }
@@ -639,7 +640,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public function isFuture(?Clock $clock = null) : bool
+    public function isFuture(?Clock $clock = null): bool
     {
         return $this->instant->isFuture($clock);
     }
@@ -649,7 +650,7 @@ class ZonedDateTime implements \JsonSerializable
      *
      * If no clock is provided, the system clock is used.
      */
-    public function isPast(?Clock $clock = null) : bool
+    public function isPast(?Clock $clock = null): bool
     {
         return $this->instant->isPast($clock);
     }
@@ -660,7 +661,7 @@ class ZonedDateTime implements \JsonSerializable
      * Note that the native DateTime object supports a precision up to the microsecond,
      * so the nanoseconds are rounded down to the nearest microsecond.
      */
-    public function toDateTime() : \DateTime
+    public function toDateTime(): DateTime
     {
         $second = $this->localDateTime->getSecond();
 
@@ -681,23 +682,23 @@ class ZonedDateTime implements \JsonSerializable
             }
         }
 
-        return \DateTime::createFromFormat($format, $dateTime, $dateTimeZone);
+        return DateTime::createFromFormat($format, $dateTime, $dateTimeZone);
     }
 
-    public function toDateTimeImmutable() : \DateTimeImmutable
+    public function toDateTimeImmutable(): DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromMutable($this->toDateTime());
+        return DateTimeImmutable::createFromMutable($this->toDateTime());
     }
 
     /**
      * Serializes as a string using {@see ZonedDateTime::__toString()}.
      */
-    public function jsonSerialize() : string
+    public function jsonSerialize(): string
     {
         return (string) $this;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         $string = $this->localDateTime . $this->timeZoneOffset;
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -20,8 +20,10 @@ use Brick\DateTime\Year;
 use Brick\DateTime\YearMonth;
 use Brick\DateTime\YearMonthRange;
 use Brick\DateTime\YearWeek;
-
 use PHPUnit\Framework\TestCase;
+
+use function implode;
+use function var_export;
 
 /**
  * Base class for DateTime tests.
@@ -33,7 +35,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $expectedString The expected string representation.
      * @param object $object         The object to test.
      */
-    protected function assertIs(string $className, string $expectedString, $object): void
+    protected function assertIs(string $className, string $expectedString, object $object): void
     {
         $this->assertInstanceOf($className, $object);
         $this->assertSame($expectedString, (string) $object);
@@ -116,10 +118,6 @@ abstract class AbstractTestCase extends TestCase
         $this->assertTrue($actual->isEqualTo($expected), "$actual != $expected");
     }
 
-    /**
-     * @param int  $yearValue
-     * @param Year $year
-     */
     protected function assertYearIs(int $yearValue, Year $year): void
     {
         $this->compare([$yearValue], [
@@ -202,10 +200,10 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @param int     $years  The expected number of years in the period.
-     * @param int     $months The expected number of months in the period.
-     * @param int     $days   The expected number of days in the period.
-     * @param Period  $period The period to test.
+     * @param int    $years  The expected number of years in the period.
+     * @param int    $months The expected number of months in the period.
+     * @param int    $days   The expected number of days in the period.
+     * @param Period $period The period to test.
      */
     protected function assertPeriodIs(int $years, int $months, int $days, Period $period): void
     {
@@ -281,15 +279,13 @@ abstract class AbstractTestCase extends TestCase
      * Exports the given values as a string.
      *
      * @param array $values The values to export.
-     *
-     * @return string
      */
-    private function export(array $values) : string
+    private function export(array $values): string
     {
-        foreach ($values as & $value) {
-            $value = \var_export($value, true);
+        foreach ($values as &$value) {
+            $value = var_export($value, true);
         }
 
-        return '(' . \implode(', ', $values) . ')';
+        return '(' . implode(', ', $values) . ')';
     }
 }

--- a/tests/Clock/FixedClockTest.php
+++ b/tests/Clock/FixedClockTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Tests\Clock;
 
-use Brick\DateTime\Tests\AbstractTestCase;
 use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\Instant;
+use Brick\DateTime\Tests\AbstractTestCase;
 
 /**
  * Unit tests for class FixedClock.

--- a/tests/Clock/OffsetClockTest.php
+++ b/tests/Clock/OffsetClockTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Tests\Clock;
 
-use Brick\DateTime\Tests\AbstractTestCase;
 use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\Clock\OffsetClock;
 use Brick\DateTime\Duration;
 use Brick\DateTime\Instant;
+use Brick\DateTime\Tests\AbstractTestCase;
 
 /**
  * Unit tests for class OffsetClock.
@@ -32,7 +32,7 @@ class OffsetClockTest extends AbstractTestCase
         $this->assertInstantIs($expectedSecond, $expectedNano, $clock->getTime());
     }
 
-    public function providerOffsetClock() : array
+    public function providerOffsetClock(): array
     {
         return [
             [1000, 0, 'PT0.5S', 1000, 500000000],

--- a/tests/Clock/ScaleClockTest.php
+++ b/tests/Clock/ScaleClockTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Tests\Clock;
 
-use Brick\DateTime\Clock\ScaleClock;
-use Brick\DateTime\Tests\AbstractTestCase;
 use Brick\DateTime\Clock\FixedClock;
+use Brick\DateTime\Clock\ScaleClock;
 use Brick\DateTime\Duration;
 use Brick\DateTime\Instant;
+use Brick\DateTime\Tests\AbstractTestCase;
 
 /**
  * Unit tests for class ScaleClock.
@@ -39,7 +39,7 @@ class ScaleClockTest extends AbstractTestCase
         $this->assertSame($expectedInstant, $actualTime->toDecimal());
     }
 
-    public function providerScaleClock() : array
+    public function providerScaleClock(): array
     {
         return [
             [1000, 0, 'PT0.5S', 50, '1025'],

--- a/tests/Clock/SystemClockTest.php
+++ b/tests/Clock/SystemClockTest.php
@@ -8,15 +8,16 @@ namespace Brick\DateTime\Clock
      * Re-declare microtime() in the namespace of the SystemClock,
      * to trick it into thinking it's the native PHP function.
      */
-    function microtime(): string {
+    function microtime(): string
+    {
         return '0.55527600 14079491701';
     }
 }
 
 namespace Brick\DateTime\Tests\Clock
 {
-    use Brick\DateTime\Tests\AbstractTestCase;
     use Brick\DateTime\Clock\SystemClock;
+    use Brick\DateTime\Tests\AbstractTestCase;
 
     /**
      * Unit tests for class SystemClock.

--- a/tests/DayOfWeekTest.php
+++ b/tests/DayOfWeekTest.php
@@ -10,6 +10,9 @@ use Brick\DateTime\DayOfWeek;
 use Brick\DateTime\Instant;
 use Brick\DateTime\LocalDate;
 use Brick\DateTime\TimeZone;
+use Generator;
+
+use function json_encode;
 
 /**
  * Unit tests for class DayOfWeek.
@@ -27,7 +30,7 @@ class DayOfWeekTest extends AbstractTestCase
         $this->assertSame($expectedValue, $dayOfWeekConstant);
     }
 
-    public function providerConstants() : array
+    public function providerConstants(): array
     {
         return [
             [1, DayOfWeek::MONDAY],
@@ -54,7 +57,7 @@ class DayOfWeekTest extends AbstractTestCase
         DayOfWeek::of($dayOfWeek);
     }
 
-    public function providerOfInvalidDayOfWeekThrowsException() : array
+    public function providerOfInvalidDayOfWeekThrowsException(): array
     {
         return [
             [-1],
@@ -76,7 +79,7 @@ class DayOfWeekTest extends AbstractTestCase
         $this->assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::now(TimeZone::parse($timeZone), $clock));
     }
 
-    public function providerNow() : array
+    public function providerNow(): array
     {
         return [
             [1388534399, '-01:00', DayOfWeek::TUESDAY],
@@ -219,7 +222,7 @@ class DayOfWeekTest extends AbstractTestCase
         $this->assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::of($dayOfWeek)->minus(-$plusDays));
     }
 
-    public function providerPlus() : \Generator
+    public function providerPlus(): Generator
     {
         for ($dayOfWeek = DayOfWeek::MONDAY; $dayOfWeek <= DayOfWeek::SUNDAY; $dayOfWeek++) {
             for ($plusDays = -15; $plusDays <= 15; $plusDays++) {
@@ -253,7 +256,7 @@ class DayOfWeekTest extends AbstractTestCase
         $this->assertTrue($localDate->getDayOfWeek()->isEqualTo($dayOfWeek));
     }
 
-    public function providerGetDayOfWeekFromLocalDate() : array
+    public function providerGetDayOfWeekFromLocalDate(): array
     {
         return [
             ['2000-01-01', DayOfWeek::SATURDAY],
@@ -294,10 +297,7 @@ class DayOfWeekTest extends AbstractTestCase
         $this->assertSame($expectedName, (string) DayOfWeek::of($dayOfWeek));
     }
 
-    /**
-     * @return array
-     */
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [DayOfWeek::MONDAY,    'Monday'],

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -10,6 +10,14 @@ use Brick\DateTime\Duration;
 use Brick\DateTime\Instant;
 use Brick\DateTime\Parser\DateTimeParseException;
 
+use function abs;
+use function count;
+use function intdiv;
+use function json_encode;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
 /**
  * Unit tests for class Duration.
  */
@@ -34,7 +42,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
-    public function providerOfSeconds() : array
+    public function providerOfSeconds(): array
     {
         return [
             [3, 1, 3, 1],
@@ -77,14 +85,14 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
-    public function providerOfNanos() : array
+    public function providerOfNanos(): array
     {
         return [
             [1, 0, 1],
             [1000000002, 1, 2],
             [-2000000001, -3, 999999999],
-            [PHP_INT_MAX, \intdiv(PHP_INT_MAX, 1000000000), PHP_INT_MAX % 1000000000],
-            [PHP_INT_MIN, \intdiv(PHP_INT_MIN, 1000000000) -1, PHP_INT_MIN % 1000000000 + 1000000000]
+            [PHP_INT_MAX, intdiv(PHP_INT_MAX, 1000000000), PHP_INT_MAX % 1000000000],
+            [PHP_INT_MIN, intdiv(PHP_INT_MIN, 1000000000) - 1, PHP_INT_MIN % 1000000000 + 1000000000]
         ];
     }
 
@@ -120,7 +128,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($seconds, $nanos, Duration::between($i1, $i2));
     }
 
-    public function providerBetween() : array
+    public function providerBetween(): array
     {
         return [
             [0, 0, 0, 0, 0, 0],
@@ -153,7 +161,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($seconds, $nanos, Duration::parse($text));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['PT0S', 0, 0],
@@ -252,7 +260,7 @@ class DurationTest extends AbstractTestCase
         Duration::parse($text);
     }
 
-    public function providerParseFailureThrowsException() : array
+    public function providerParseFailureThrowsException(): array
     {
         return [
             [''],
@@ -351,18 +359,18 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($cmp <= 0, Duration::ofSeconds($seconds, $nanos)->isNegativeOrZero());
     }
 
-    public function providerCompareToZero() : array
+    public function providerCompareToZero(): array
     {
         return [
             [-1, -1, -1],
             [-1,  0, -1],
             [-1,  1, -1],
-            [ 0, -1, -1],
-            [ 0,  0,  0],
-            [ 0,  1,  1],
-            [ 1, -1,  1],
-            [ 1,  0,  1],
-            [ 1,  1,  1]
+            [0, -1, -1],
+            [0,  0,  0],
+            [0,  1,  1],
+            [1, -1,  1],
+            [1,  0,  1],
+            [1,  1,  1]
         ];
     }
 
@@ -383,7 +391,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($expected, $duration1->compareTo($duration2));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             [-1, -1, -1, -1, 0],
@@ -474,7 +482,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($s, $n, $duration1->minus($duration2));
     }
 
-    public function providerPlus() : array
+    public function providerPlus(): array
     {
         return [
             [-1, -1, -1, -1, -3, 999999998],
@@ -543,7 +551,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
-    public function providerPlusSeconds() : array
+    public function providerPlusSeconds(): array
     {
         return [
             [-1, 0, -1, -2, 0],
@@ -560,29 +568,25 @@ class DurationTest extends AbstractTestCase
             [1, 0,  0,  1, 0],
             [1, 0,  1,  2, 0],
 
-            [\PHP_INT_MIN, 0, \PHP_INT_MAX, -1, 0],
-            [\PHP_INT_MAX, 0, \PHP_INT_MIN, -1, 0],
-            [\PHP_INT_MAX, 0, 0, \PHP_INT_MAX, 0],
+            [PHP_INT_MIN, 0, PHP_INT_MAX, -1, 0],
+            [PHP_INT_MAX, 0, PHP_INT_MIN, -1, 0],
+            [PHP_INT_MAX, 0, 0, PHP_INT_MAX, 0],
 
             [-1, -5,  2, 0,  999999995],
-            [ 1,  5, -2, -1, 5],
+            [1,  5, -2, -1, 5],
         ];
     }
 
     /**
      * @dataProvider providerPlusMinutes
-     *
-     * @param int $seconds
-     * @param int $minutesToAdd
-     * @param int $expectedSeconds
      */
-    public function testPlusMinutes(int $seconds, int $minutesToAdd, int $expectedSeconds)
+    public function testPlusMinutes(int $seconds, int $minutesToAdd, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->plusMinutes($minutesToAdd);
         $this->assertDurationIs($expectedSeconds, 0, $duration);
     }
 
-    public function providerPlusMinutes() : array
+    public function providerPlusMinutes(): array
     {
         return [
             [-1, -1, -61],
@@ -610,7 +614,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, 0, $duration);
     }
 
-    public function providerPlusHours() : array
+    public function providerPlusHours(): array
     {
         return [
             [-1, -1, -3601],
@@ -638,7 +642,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, 0, $duration);
     }
 
-    public function providerPlusDays() : array
+    public function providerPlusDays(): array
     {
         return [
             [-1, -1, -86401],
@@ -666,25 +670,25 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, 0, $duration);
     }
 
-    public function providerMinusSeconds() : array
+    public function providerMinusSeconds(): array
     {
         return [
             [0, 0, 0],
             [0, 1, -1],
             [0, -1, 1],
-            [0, \PHP_INT_MAX, - \PHP_INT_MAX],
-            [0, \PHP_INT_MIN + 1, \PHP_INT_MAX],
+            [0, PHP_INT_MAX, -PHP_INT_MAX],
+            [0, PHP_INT_MIN + 1, PHP_INT_MAX],
             [1, 0, 1],
             [1, 1, 0],
             [1, -1, 2],
-            [1, \PHP_INT_MAX - 1, - \PHP_INT_MAX + 2],
-            [1, \PHP_INT_MIN + 2, \PHP_INT_MAX],
-            [1, \PHP_INT_MAX, - \PHP_INT_MAX + 1],
+            [1, PHP_INT_MAX - 1, -PHP_INT_MAX + 2],
+            [1, PHP_INT_MIN + 2, PHP_INT_MAX],
+            [1, PHP_INT_MAX, -PHP_INT_MAX + 1],
             [-1, 0, -1],
             [-1, 1, -2],
             [-1, -1, 0],
-            [-1, \PHP_INT_MAX, \PHP_INT_MIN],
-            [-1, \PHP_INT_MIN + 1, \PHP_INT_MAX - 1]
+            [-1, PHP_INT_MAX, PHP_INT_MIN],
+            [-1, PHP_INT_MIN + 1, PHP_INT_MAX - 1]
         ];
     }
 
@@ -697,7 +701,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, 0, $duration);
     }
 
-    public function providerMinusMinutes() : array
+    public function providerMinusMinutes(): array
     {
         return [
             [-1, -1, 59],
@@ -725,7 +729,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, 0, $duration);
     }
 
-    public function providerMinusHours() : array
+    public function providerMinusHours(): array
     {
         return [
             [-1, -1, 3599],
@@ -753,7 +757,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, 0, $duration);
     }
 
-    public function providerMinusDays() : array
+    public function providerMinusDays(): array
     {
         return [
             [-1, -1, 86399],
@@ -783,7 +787,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSecond, $expectedNano, $duration);
     }
 
-    public function providerMultipliedBy() : array
+    public function providerMultipliedBy(): array
     {
         return [
             [-3, 0, -3, 9, 0],
@@ -861,8 +865,8 @@ class DurationTest extends AbstractTestCase
             [3, 0, 3, 9, 0],
             [3, 1000, 3, 9, 3000],
             [3, 999999999, 3, 11, 999999997],
-            [1, 0,  \PHP_INT_MAX, \PHP_INT_MAX, 0],
-            [1, 0, \PHP_INT_MIN, \PHP_INT_MIN, 0],
+            [1, 0,  PHP_INT_MAX, PHP_INT_MAX, 0],
+            [1, 0, PHP_INT_MIN, PHP_INT_MIN, 0],
         ];
     }
 
@@ -875,7 +879,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
-    public function providerDividedBy() : array
+    public function providerDividedBy(): array
     {
         return [
             [3, 0, 1, 3, 0],
@@ -951,7 +955,7 @@ class DurationTest extends AbstractTestCase
         $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration->negated());
     }
 
-    public function providerNegated() : array
+    public function providerNegated(): array
     {
         return [
             [0, 0, 0, 0],
@@ -968,7 +972,7 @@ class DurationTest extends AbstractTestCase
     {
         for ($seconds = -3; $seconds <= 3; $seconds++) {
             $duration = Duration::ofSeconds($seconds)->abs();
-            $this->assertDurationIs(\abs($seconds), 0, $duration);
+            $this->assertDurationIs(abs($seconds), 0, $duration);
         }
     }
 
@@ -991,48 +995,6 @@ class DurationTest extends AbstractTestCase
             Duration::ofHours(2),
             Duration::ofDays(1),
         ]);
-    }
-
-    /**
-     * @param Duration[] $durations
-     */
-    private function doTestComparisons(array $durations): void
-    {
-        $count = \count($durations);
-
-        for ($i = 0; $i < $count; $i++) {
-            $a = $durations[$i];
-            for ($j = 0; $j < $count; $j++) {
-                $b = $durations[$j];
-                if ($i < $j) {
-                    $this->assertLessThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertTrue($a->isLessThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
-                }
-                elseif ($i > $j) {
-                    $this->assertGreaterThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
-                    $this->assertTrue($a->isGreaterThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
-                }
-                else {
-                    $this->assertSame(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
-                    $this->assertTrue($a->isEqualTo($b), $a . ' <=> ' . $b);
-                }
-
-                if ($i <= $j) {
-                    $this->assertLessThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
-                }
-                if ($i >= $j) {
-                    $this->assertGreaterThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
-                }
-            }
-        }
     }
 
     public function testEquals(): void
@@ -1076,13 +1038,13 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($expectedMillis, $duration->getTotalMillis());
     }
 
-    public function providerGetTotalMillis() : array
+    public function providerGetTotalMillis(): array
     {
         return [
             [-123, 456000001, -122544],
             [-123, 456999999, -122544],
-            [ 123, 456000001,  123456],
-            [ 123, 456999999,  123456]
+            [123, 456000001,  123456],
+            [123, 456999999,  123456]
         ];
     }
 
@@ -1099,13 +1061,13 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($expectedMicros, $duration->getTotalMicros());
     }
 
-    public function providerGetTotalMicros() : array
+    public function providerGetTotalMicros(): array
     {
         return [
             [-123, 456789001, -122543211],
             [-123, 456789999, -122543211],
-            [ 123, 456789001,  123456789],
-            [ 123, 456789999,  123456789]
+            [123, 456789001,  123456789],
+            [123, 456789999,  123456789]
         ];
     }
 
@@ -1122,13 +1084,13 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($expectedNanos, $duration->getTotalNanos());
     }
 
-    public function providerGetTotalNanos() : array
+    public function providerGetTotalNanos(): array
     {
         return [
             [-2, 000000001, -1999999999],
             [-2, 999999999, -1000000001],
-            [ 1, 000000001,  1000000001],
-            [ 1, 999999999,  1999999999]
+            [1, 000000001,  1000000001],
+            [1, 999999999,  1999999999]
         ];
     }
 
@@ -1140,7 +1102,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($days, $duration->toDaysPart());
     }
 
-    public function providerToDaysPart() : array
+    public function providerToDaysPart(): array
     {
         return [
             [Duration::ofSeconds(365 * 86400 + 5 * 3600 + 48 * 60 + 46, 123456789), 365],
@@ -1160,7 +1122,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($hours, $duration->toHoursPart());
     }
 
-    public function providerToHoursPart() : array
+    public function providerToHoursPart(): array
     {
         return [
             [Duration::ofSeconds(365 * 86400 + 5 * 3600 + 48 * 60 + 46, 123456789), 5],
@@ -1179,7 +1141,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($minutes, $duration->toMinutesPart());
     }
 
-    public function providerToMinutesPart() : array
+    public function providerToMinutesPart(): array
     {
         return [
             [Duration::ofSeconds(365 * 86400 + 5 * 3600 + 48 * 60 + 46, 123456789), 48],
@@ -1198,7 +1160,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($seconds, $duration->toSecondsPart());
     }
 
-    public function providerToSecondsPart() : array
+    public function providerToSecondsPart(): array
     {
         return [
             [Duration::ofSeconds(365 * 86400 + 5 * 3600 + 48 * 60 + 46, 123456789), 46],
@@ -1218,14 +1180,14 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($millis, $duration->toMillis());
     }
 
-    public function providerToMillis() : array
+    public function providerToMillis(): array
     {
         return [
             [Duration::ofSeconds(321, 123456789), 321000 + 123],
             [Duration::ofMillis(PHP_INT_MAX), PHP_INT_MAX],
             [Duration::ofMillis(PHP_INT_MIN), PHP_INT_MIN],
-            [Duration::ofSeconds(\intdiv(PHP_INT_MAX, 1000), (PHP_INT_MAX % 1000) * 1000000), PHP_INT_MAX],
-            [Duration::ofSeconds(\intdiv(PHP_INT_MIN, 1000), (PHP_INT_MIN % 1000) * 1000000), PHP_INT_MIN],
+            [Duration::ofSeconds(intdiv(PHP_INT_MAX, 1000), (PHP_INT_MAX % 1000) * 1000000), PHP_INT_MAX],
+            [Duration::ofSeconds(intdiv(PHP_INT_MIN, 1000), (PHP_INT_MIN % 1000) * 1000000), PHP_INT_MIN],
         ];
     }
 
@@ -1238,11 +1200,11 @@ class DurationTest extends AbstractTestCase
         $duration->toMillis();
     }
 
-    public function providerToMillisOutOfRange() : array
+    public function providerToMillisOutOfRange(): array
     {
         return [
-            [Duration::ofSeconds(\intdiv(PHP_INT_MAX, 1000), ((PHP_INT_MAX % 1000) + 1) * 1000000)],
-            [Duration::ofSeconds(\intdiv(PHP_INT_MIN, 1000), ((PHP_INT_MIN % 1000) - 1) * 1000000)],
+            [Duration::ofSeconds(intdiv(PHP_INT_MAX, 1000), ((PHP_INT_MAX % 1000) + 1) * 1000000)],
+            [Duration::ofSeconds(intdiv(PHP_INT_MIN, 1000), ((PHP_INT_MIN % 1000) - 1) * 1000000)],
         ];
     }
 
@@ -1254,7 +1216,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($millis, $duration->toMillisPart());
     }
 
-    public function providerToMillisPart() : array
+    public function providerToMillisPart(): array
     {
         return [
             [Duration::ofSeconds(365 * 86400 + 5 * 3600 + 48 * 60 + 46, 123456789), 123],
@@ -1274,7 +1236,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($nanos, $duration->toNanos());
     }
 
-    public function providerToNanos() : array
+    public function providerToNanos(): array
     {
         return [
             [Duration::ofSeconds(321, 123456789), 321123456789],
@@ -1292,7 +1254,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($nanos, $duration->toNanosPart());
     }
 
-    public function providerToNanosPart() : array
+    public function providerToNanosPart(): array
     {
         return [
             [Duration::ofSeconds(365 * 86400 + 5 * 3600 + 48 * 60 + 46, 123456789), 123456789],
@@ -1320,7 +1282,7 @@ class DurationTest extends AbstractTestCase
         $this->assertSame($expected, (string) Duration::ofSeconds($seconds, $nanos));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [0, 0, 'PT0S'],
@@ -1383,5 +1345,45 @@ class DurationTest extends AbstractTestCase
             [-90061, 0, 'PT-25H-1M-1S'],
             [-90061, 1, 'PT-25H-1M-0.999999999S'],
         ];
+    }
+
+    /**
+     * @param Duration[] $durations
+     */
+    private function doTestComparisons(array $durations): void
+    {
+        $count = count($durations);
+
+        for ($i = 0; $i < $count; $i++) {
+            $a = $durations[$i];
+            for ($j = 0; $j < $count; $j++) {
+                $b = $durations[$j];
+                if ($i < $j) {
+                    $this->assertLessThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    $this->assertTrue($a->isLessThan($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
+                } elseif ($i > $j) {
+                    $this->assertGreaterThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
+                    $this->assertTrue($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
+                } else {
+                    $this->assertSame(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                    $this->assertTrue($a->isEqualTo($b), $a . ' <=> ' . $b);
+                }
+
+                if ($i <= $j) {
+                    $this->assertLessThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                }
+                if ($i >= $j) {
+                    $this->assertGreaterThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
+                }
+            }
+        }
     }
 }

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -10,6 +10,11 @@ use Brick\DateTime\Duration;
 use Brick\DateTime\Instant;
 use Brick\DateTime\TimeZone;
 
+use function json_encode;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
 /**
  * Unit tests for class Instant.
  */
@@ -31,7 +36,7 @@ class InstantTest extends AbstractTestCase
         $this->assertSame($expectedNanos, $duration->getNano());
     }
 
-    public function providerOf() : array
+    public function providerOf(): array
     {
         return [
             [3, 1, 3, 1],
@@ -58,12 +63,12 @@ class InstantTest extends AbstractTestCase
 
     public function testMin(): void
     {
-        $this->assertInstantIs(\PHP_INT_MIN, 0, Instant::min());
+        $this->assertInstantIs(PHP_INT_MIN, 0, Instant::min());
     }
 
     public function testMax(): void
     {
-        $this->assertInstantIs(\PHP_INT_MAX, 999999999, Instant::max());
+        $this->assertInstantIs(PHP_INT_MAX, 999999999, Instant::max());
     }
 
     /**
@@ -98,7 +103,7 @@ class InstantTest extends AbstractTestCase
         $this->assertInstantIs($expectedSecond, $expectedNano, $result);
     }
 
-    public function providerPlus() : array
+    public function providerPlus(): array
     {
         return [
             [123456, 789, 0, 0, 123456, 789],
@@ -137,7 +142,7 @@ class InstantTest extends AbstractTestCase
         $this->assertInstantIs($expectedSecond, $nano, $result);
     }
 
-    public function providerPlusSeconds() : array
+    public function providerPlusSeconds(): array
     {
         return [
             [123456, 789, 0, 123456, 789],
@@ -178,7 +183,7 @@ class InstantTest extends AbstractTestCase
         $this->assertInstantIs($expectedSecond, $nano, $result);
     }
 
-    public function providerPlusMinutes() : array
+    public function providerPlusMinutes(): array
     {
         return [
             [123456, 789, 0, 123456, 789],
@@ -199,7 +204,7 @@ class InstantTest extends AbstractTestCase
      * @param int $plusHours      The number of hours to add.
      * @param int $expectedSecond The expected second of the result.
      */
-    public function testPlusHours(int $second, int $nano, int $plusHours, int $expectedSecond)
+    public function testPlusHours(int $second, int $nano, int $plusHours, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->plusHours($plusHours);
         $this->assertInstantIs($expectedSecond, $nano, $result);
@@ -219,7 +224,7 @@ class InstantTest extends AbstractTestCase
         $this->assertInstantIs($expectedSecond, $nano, $result);
     }
 
-    public function providerPlusHours() : array
+    public function providerPlusHours(): array
     {
         return [
             [123456, 789, 0, 123456, 789],
@@ -260,7 +265,7 @@ class InstantTest extends AbstractTestCase
         $this->assertInstantIs($expectedSecond, $nano, $result);
     }
 
-    public function providerPlusDays() : array
+    public function providerPlusDays(): array
     {
         return [
             [123456, 789, 0, 123456, 789],
@@ -296,7 +301,7 @@ class InstantTest extends AbstractTestCase
         $instant->withNano($nano);
     }
 
-    public function providerWithInvalidNanoThrowsException() : array
+    public function providerWithInvalidNanoThrowsException(): array
     {
         return [
             [-1],
@@ -418,7 +423,7 @@ class InstantTest extends AbstractTestCase
         $this->assertSame($cmp === -1, Instant::of($testSecond, $testNano)->isPast($clock));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             [-1, -1, -1, -1,  0],
@@ -448,60 +453,60 @@ class InstantTest extends AbstractTestCase
             [-1,  1,  1, -1, -1],
             [-1,  1,  1,  0, -1],
             [-1,  1,  1,  1, -1],
-            [ 0, -1, -1, -1,  1],
-            [ 0, -1, -1,  0,  1],
-            [ 0, -1, -1,  1,  1],
-            [ 0, -1,  0, -1,  0],
-            [ 0, -1,  0,  0, -1],
-            [ 0, -1,  0,  1, -1],
-            [ 0, -1,  1, -1, -1],
-            [ 0, -1,  1,  0, -1],
-            [ 0, -1,  1,  1, -1],
-            [ 0,  0, -1, -1,  1],
-            [ 0,  0, -1,  0,  1],
-            [ 0,  0, -1,  1,  1],
-            [ 0,  0,  0, -1,  1],
-            [ 0,  0,  0,  0,  0],
-            [ 0,  0,  0,  1, -1],
-            [ 0,  0,  1, -1, -1],
-            [ 0,  0,  1,  0, -1],
-            [ 0,  0,  1,  1, -1],
-            [ 0,  1, -1, -1,  1],
-            [ 0,  1, -1,  0,  1],
-            [ 0,  1, -1,  1,  1],
-            [ 0,  1,  0, -1,  1],
-            [ 0,  1,  0,  0,  1],
-            [ 0,  1,  0,  1,  0],
-            [ 0,  1,  1, -1, -1],
-            [ 0,  1,  1,  0, -1],
-            [ 0,  1,  1,  1, -1],
-            [ 1, -1, -1, -1,  1],
-            [ 1, -1, -1,  0,  1],
-            [ 1, -1, -1,  1,  1],
-            [ 1, -1,  0, -1,  1],
-            [ 1, -1,  0,  0,  1],
-            [ 1, -1,  0,  1,  1],
-            [ 1, -1,  1, -1,  0],
-            [ 1, -1,  1,  0, -1],
-            [ 1, -1,  1,  1, -1],
-            [ 1,  0, -1, -1,  1],
-            [ 1,  0, -1,  0,  1],
-            [ 1,  0, -1,  1,  1],
-            [ 1,  0,  0, -1,  1],
-            [ 1,  0,  0,  0,  1],
-            [ 1,  0,  0,  1,  1],
-            [ 1,  0,  1, -1,  1],
-            [ 1,  0,  1,  0,  0],
-            [ 1,  0,  1,  1, -1],
-            [ 1,  1, -1, -1,  1],
-            [ 1,  1, -1,  0,  1],
-            [ 1,  1, -1,  1,  1],
-            [ 1,  1,  0, -1,  1],
-            [ 1,  1,  0,  0,  1],
-            [ 1,  1,  0,  1,  1],
-            [ 1,  1,  1, -1,  1],
-            [ 1,  1,  1,  0,  1],
-            [ 1,  1,  1,  1,  0],
+            [0, -1, -1, -1,  1],
+            [0, -1, -1,  0,  1],
+            [0, -1, -1,  1,  1],
+            [0, -1,  0, -1,  0],
+            [0, -1,  0,  0, -1],
+            [0, -1,  0,  1, -1],
+            [0, -1,  1, -1, -1],
+            [0, -1,  1,  0, -1],
+            [0, -1,  1,  1, -1],
+            [0,  0, -1, -1,  1],
+            [0,  0, -1,  0,  1],
+            [0,  0, -1,  1,  1],
+            [0,  0,  0, -1,  1],
+            [0,  0,  0,  0,  0],
+            [0,  0,  0,  1, -1],
+            [0,  0,  1, -1, -1],
+            [0,  0,  1,  0, -1],
+            [0,  0,  1,  1, -1],
+            [0,  1, -1, -1,  1],
+            [0,  1, -1,  0,  1],
+            [0,  1, -1,  1,  1],
+            [0,  1,  0, -1,  1],
+            [0,  1,  0,  0,  1],
+            [0,  1,  0,  1,  0],
+            [0,  1,  1, -1, -1],
+            [0,  1,  1,  0, -1],
+            [0,  1,  1,  1, -1],
+            [1, -1, -1, -1,  1],
+            [1, -1, -1,  0,  1],
+            [1, -1, -1,  1,  1],
+            [1, -1,  0, -1,  1],
+            [1, -1,  0,  0,  1],
+            [1, -1,  0,  1,  1],
+            [1, -1,  1, -1,  0],
+            [1, -1,  1,  0, -1],
+            [1, -1,  1,  1, -1],
+            [1,  0, -1, -1,  1],
+            [1,  0, -1,  0,  1],
+            [1,  0, -1,  1,  1],
+            [1,  0,  0, -1,  1],
+            [1,  0,  0,  0,  1],
+            [1,  0,  0,  1,  1],
+            [1,  0,  1, -1,  1],
+            [1,  0,  1,  0,  0],
+            [1,  0,  1,  1, -1],
+            [1,  1, -1, -1,  1],
+            [1,  1, -1,  0,  1],
+            [1,  1, -1,  1,  1],
+            [1,  1,  0, -1,  1],
+            [1,  1,  0,  0,  1],
+            [1,  1,  0,  1,  1],
+            [1,  1,  1, -1,  1],
+            [1,  1,  1,  0,  1],
+            [1,  1,  1,  1,  0],
         ];
     }
 
@@ -512,7 +517,7 @@ class InstantTest extends AbstractTestCase
      * @param int  $nanos     The nano seconds value.
      * @param bool $isBetween Check the secs and nanos are between.
      */
-    public function testIsBetweenInclusive(int $seconds, int $nanos, $isBetween): void
+    public function testIsBetweenInclusive(int $seconds, int $nanos, bool $isBetween): void
     {
         $this->assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenInclusive(
             Instant::of(-1, -1),
@@ -527,7 +532,7 @@ class InstantTest extends AbstractTestCase
      * @param int  $nanos     The nano seconds value.
      * @param bool $isBetween Check the secs and nanos are between.
      */
-    public function testIsBetweenExclusive(int $seconds, int $nanos, $isBetween): void
+    public function testIsBetweenExclusive(int $seconds, int $nanos, bool $isBetween): void
     {
         $this->assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenExclusive(
             Instant::of(-1, -1),
@@ -535,7 +540,7 @@ class InstantTest extends AbstractTestCase
         ));
     }
 
-    public function providerIsBetweenExclusive() : array
+    public function providerIsBetweenExclusive(): array
     {
         return [
             [-1, -2, false],
@@ -552,10 +557,7 @@ class InstantTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerIsBetweenInclusive() : array
+    public function providerIsBetweenInclusive(): array
     {
         return [
             [-1, -2, false],
@@ -625,7 +627,7 @@ class InstantTest extends AbstractTestCase
         $this->assertSame($expectedString, (string) Instant::of($epochSecond, $nano));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [-2000000000, 0, '1906-08-16T20:26:40Z'],

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -8,6 +8,8 @@ use Brick\DateTime\DateTimeException;
 use Brick\DateTime\Instant;
 use Brick\DateTime\Interval;
 
+use function json_encode;
+
 /**
  * Unit tests for class Interval.
  */

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -9,6 +9,11 @@ use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalDateRange;
 use Brick\DateTime\Parser\DateTimeParseException;
 
+use function array_map;
+use function iterator_count;
+use function iterator_to_array;
+use function json_encode;
+
 /**
  * Unit tests for class LocalDateRange.
  */
@@ -48,7 +53,7 @@ class LocalDateRangeTest extends AbstractTestCase
         $this->assertLocalDateRangeIs($y1, $m1, $d1, $y2, $m2, $d2, LocalDateRange::parse($text));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['2001-02-03/04', 2001, 2, 3, 2001, 2, 4],
@@ -68,7 +73,7 @@ class LocalDateRangeTest extends AbstractTestCase
         LocalDateRange::parse($text);
     }
 
-    public function providerParseInvalidRangeThrowsException() : array
+    public function providerParseInvalidRangeThrowsException(): array
     {
         return [
             ['2001-02-03'],
@@ -98,7 +103,7 @@ class LocalDateRangeTest extends AbstractTestCase
         )->isEqualTo(LocalDateRange::parse($testRange)));
     }
 
-    public function providerIsEqualTo() : array
+    public function providerIsEqualTo(): array
     {
         return [
             ['2001-02-03/2004-05-06', true],
@@ -119,7 +124,7 @@ class LocalDateRangeTest extends AbstractTestCase
         $this->assertSame($contains, LocalDateRange::parse($range)->contains(LocalDate::parse($date)));
     }
 
-    public function providerContains() : array
+    public function providerContains(): array
     {
         return [
             ['2001-02-03/2004-05-06', '2001-02-02', false],
@@ -137,7 +142,7 @@ class LocalDateRangeTest extends AbstractTestCase
     public function testIterator(): void
     {
         $start = LocalDate::of(2013, 12, 29);
-        $end   = LocalDate::of(2014, 1, 3);
+        $end = LocalDate::of(2014, 1, 3);
 
         $range = LocalDateRange::of($start, $end);
 
@@ -172,7 +177,7 @@ class LocalDateRangeTest extends AbstractTestCase
         $this->assertCount($count, LocalDateRange::parse($range));
     }
 
-    public function providerCount() : array
+    public function providerCount(): array
     {
         return [
             ['2010-01-01/2010-01-01', 1],
@@ -273,7 +278,7 @@ class LocalDateRangeTest extends AbstractTestCase
         $this->assertSame($expectedResult, $bRange->intersectsWith($aRange));
     }
 
-    public function providerIntersectsWith() : array
+    public function providerIntersectsWith(): array
     {
         return [
             ['2010-01-01/2010-01-01', '2010-01-01/2010-01-01', true],
@@ -296,11 +301,11 @@ class LocalDateRangeTest extends AbstractTestCase
         $aRange = LocalDateRange::parse($a);
         $bRange = LocalDateRange::parse($b);
 
-        $this->assertSame($expectedIntersection, (string)$aRange->getIntersectionWith($bRange));
-        $this->assertSame($expectedIntersection, (string)$bRange->getIntersectionWith($aRange));
+        $this->assertSame($expectedIntersection, (string) $aRange->getIntersectionWith($bRange));
+        $this->assertSame($expectedIntersection, (string) $bRange->getIntersectionWith($aRange));
     }
 
-    public function providerGetIntersectionWith() : array
+    public function providerGetIntersectionWith(): array
     {
         return [
             ['2010-01-01/2010-01-01', '2010-01-01/2010-01-01', '2010-01-01/2010-01-01'],

--- a/tests/LocalDateTest.php
+++ b/tests/LocalDateTest.php
@@ -12,6 +12,13 @@ use Brick\DateTime\LocalTime;
 use Brick\DateTime\Period;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\Year;
+use DateTime;
+use DateTimeImmutable;
+
+use function json_encode;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
 
 /**
  * Unit tests for class LocalDate.
@@ -36,7 +43,7 @@ class LocalDateTest extends AbstractTestCase
         LocalDate::of($year, $month, $day);
     }
 
-    public function providerOfInvalidDateThrowsException() : array
+    public function providerOfInvalidDateThrowsException(): array
     {
         return [
             [2007, 2, 29],
@@ -45,8 +52,8 @@ class LocalDateTest extends AbstractTestCase
             [2007, 1, 32],
             [2007, 0, 1],
             [2007, 13, 1],
-            [\PHP_INT_MIN, 1, 1],
-            [\PHP_INT_MAX, 1, 1]
+            [PHP_INT_MIN, 1, 1],
+            [PHP_INT_MAX, 1, 1]
         ];
     }
 
@@ -62,14 +69,14 @@ class LocalDateTest extends AbstractTestCase
         LocalDate::ofYearDay($year, $dayOfYear);
     }
 
-    public function providerOfInvalidYearDayThrowsException() : array
+    public function providerOfInvalidYearDayThrowsException(): array
     {
         return [
             [2007, 366],
             [2007, 0],
             [2007, 367],
-            [~ \PHP_INT_MAX, 1],
-            [\PHP_INT_MAX, 1],
+            [~PHP_INT_MAX, 1],
+            [PHP_INT_MAX, 1],
         ];
     }
 
@@ -105,36 +112,36 @@ class LocalDateTest extends AbstractTestCase
         $this->assertSame($epochDay, LocalDate::of($year, $month, $day)->toEpochDay());
     }
 
-    public function providerEpochDay() : array
+    public function providerEpochDay(): array
     {
         return [
             [-1000000, -768,  2,  4],
-            [ -100000, 1696,  3, 17],
-            [  -10000, 1942,  8, 16],
-            [   -1000, 1967,  4,  7],
-            [    -100, 1969,  9, 23],
-            [     -10, 1969, 12, 22],
-            [      -1, 1969, 12, 31],
-            [       0, 1970,  1,  1],
-            [       1, 1970,  1,  2],
-            [      10, 1970,  1, 11],
-            [     100, 1970,  4, 11],
-            [    1000, 1972,  9, 27],
-            [   10000, 1997,  5, 19],
-            [  100000, 2243, 10, 17],
-            [ 1000000, 4707, 11, 29]
+            [-100000, 1696,  3, 17],
+            [-10000, 1942,  8, 16],
+            [-1000, 1967,  4,  7],
+            [-100, 1969,  9, 23],
+            [-10, 1969, 12, 22],
+            [-1, 1969, 12, 31],
+            [0, 1970,  1,  1],
+            [1, 1970,  1,  2],
+            [10, 1970,  1, 11],
+            [100, 1970,  4, 11],
+            [1000, 1972,  9, 27],
+            [10000, 1997,  5, 19],
+            [100000, 2243, 10, 17],
+            [1000000, 4707, 11, 29]
         ];
     }
 
     public function testFromDateTime(): void
     {
-        $dateTime = new \DateTime('2018-07-21');
+        $dateTime = new DateTime('2018-07-21');
         $this->assertLocalDateIs(2018, 7, 21, LocalDate::fromDateTime($dateTime));
     }
 
     public function testFromNativeDateTime(): void
     {
-        $dateTime = new \DateTime('2018-07-21');
+        $dateTime = new DateTime('2018-07-21');
         $this->assertLocalDateIs(2018, 7, 21, LocalDate::fromNativeDateTime($dateTime));
     }
 
@@ -153,7 +160,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $month, $day, LocalDate::now(TimeZone::parse($timeZone), $clock));
     }
 
-    public function providerNow() : array
+    public function providerNow(): array
     {
         return [
             [0, '-01:00', 1969, 12, 31],
@@ -181,7 +188,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertYearMonthIs($year, $month, LocalDate::of($year, $month, $day)->getYearMonth());
     }
 
-    public function providerGetYearMonth() : array
+    public function providerGetYearMonth(): array
     {
         return [
             [2001, 2, 28],
@@ -203,7 +210,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertDayOfWeekIs($dayOfWeek, LocalDate::of($year, $month, $day)->getDayOfWeek());
     }
 
-    public function providerDayOfWeek() : array
+    public function providerDayOfWeek(): array
     {
         return [
             [2000, 1, 3, 1],
@@ -259,7 +266,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertSame($dayOfYear, LocalDate::of($year, $month, $day)->getDayOfYear());
     }
 
-    public function providerDayOfYear() : array
+    public function providerDayOfYear(): array
     {
         return [
             [2000, 1, 1, 1],
@@ -313,7 +320,7 @@ class LocalDateTest extends AbstractTestCase
         ];
     }
 
-    public function providerGetYearWeek() : array
+    public function providerGetYearWeek(): array
     {
         return [
             [2000,  1,  1, 1999, 52],
@@ -479,7 +486,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($newYear, $month, $expectedDay, $localDate);
     }
 
-    public function providerWithYear() : array
+    public function providerWithYear(): array
     {
         return [
             [2007, 3, 31, 2008, 31],
@@ -502,7 +509,7 @@ class LocalDateTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->withYear($invalidYear);
     }
 
-    public function providerWithInvalidYearThrowsException() : array
+    public function providerWithInvalidYearThrowsException(): array
     {
         return [
             [-1000000],
@@ -525,7 +532,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $newMonth, $expectedDay, $localDate);
     }
 
-    public function providerWithMonth() : array
+    public function providerWithMonth(): array
     {
         return [
             [2007, 3, 31, 2, 28],
@@ -556,7 +563,7 @@ class LocalDateTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6))->withMonth($invalidMonth);
     }
 
-    public function providerWithInvalidMonthThrowsException() : array
+    public function providerWithInvalidMonthThrowsException(): array
     {
         return [
             [0],
@@ -578,7 +585,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $month, $newDay, $localDate);
     }
 
-    public function providerWithDay() : array
+    public function providerWithDay(): array
     {
         return [
             [2007, 6, 2, 2],
@@ -602,7 +609,7 @@ class LocalDateTest extends AbstractTestCase
         LocalDate::of($year, $month, $day)->withDay($newDay);
     }
 
-    public function providerWithInvalidDayThrowsException() : array
+    public function providerWithInvalidDayThrowsException(): array
     {
         return [
             [2007, 1, 1, 0],
@@ -655,7 +662,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, $date->minusPeriod($period));
     }
 
-    public function providerPeriod() : array
+    public function providerPeriod(): array
     {
         return [
             [2001, 2, 3,  0,   0,   0, 2001,  2,  3],
@@ -688,14 +695,14 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusYears($ay));
     }
 
-    public function providerPlusYears() : array
+    public function providerPlusYears(): array
     {
         return [
             [2014, 1, 2, 0, 2014, 1, 2],
             [2015, 2, 3, 1, 2016, 2, 3],
             [2016, 3, 4, -1, 2015, 3, 4],
             [2000, 2, 29, 1, 2001, 2, 28],
-            [2000, 2, 29, -1, 1999,2, 28]
+            [2000, 2, 29, -1, 1999, 2, 28]
         ];
     }
 
@@ -715,7 +722,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusMonths($am));
     }
 
-    public function providerPlusMonths() : array
+    public function providerPlusMonths(): array
     {
         return [
             [2014, 1, 2, 0, 2014, 1, 2],
@@ -751,7 +758,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusWeeks($aw));
     }
 
-    public function providerPlusWeeks() : array
+    public function providerPlusWeeks(): array
     {
         return [
             [2014, 7, 31, 0, 2014, 7, 31],
@@ -780,7 +787,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusDays($ad));
     }
 
-    public function providerPlusDays() : array
+    public function providerPlusDays(): array
     {
         return [
             [2014, 1, 2, 0, 2014, 1, 2],
@@ -988,14 +995,14 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusYears($sy));
     }
 
-    public function providerMinusYears() : array
+    public function providerMinusYears(): array
     {
         return [
             [2014, 1, 2, 0, 2014, 1, 2],
             [2015, 2, 3, 1, 2014, 2, 3],
             [2016, 3, 4, -1, 2015, 3, 4],
             [2000, 2, 29, 1, 1999, 2, 28],
-            [2000, 2, 29, -1, 2001,2, 28]
+            [2000, 2, 29, -1, 2001, 2, 28]
         ];
     }
 
@@ -1015,7 +1022,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusMonths($sm));
     }
 
-    public function providerMinusMonths() : array
+    public function providerMinusMonths(): array
     {
         return [
             [2014, 1, 2, 0, 2014, 1, 2],
@@ -1051,7 +1058,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusWeeks($sw));
     }
 
-    public function providerMinusWeeks() : array
+    public function providerMinusWeeks(): array
     {
         return [
             [2014, 7, 31, 0, 2014, 7, 31],
@@ -1080,7 +1087,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusDays($sd));
     }
 
-    public function providerMinusDays() : array
+    public function providerMinusDays(): array
     {
         return [
             [2014, 1, 2, 0, 2014, 1, 2],
@@ -1115,7 +1122,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertPeriodIs($y, $m, $d, $date1->until($date2));
     }
 
-    public function providerUntil() : array
+    public function providerUntil(): array
     {
         return [
             [2010, 1, 15, 2010, 1, 15, 0, 0, 0],
@@ -1222,7 +1229,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertSame($expectedDays, $date1->daysUntil($date2));
     }
 
-    public function providerDaysUntil() : array
+    public function providerDaysUntil(): array
     {
         return [
             ['2018-01-01', '2020-01-01', 730],
@@ -1265,7 +1272,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertSame($isLeap ? 366 : 365, LocalDate::of($y, $m, $d)->getLengthOfYear());
     }
 
-    public function providerIsLeapYear() : array
+    public function providerIsLeapYear(): array
     {
         return [
             [1600, 1, 11, true],
@@ -1293,7 +1300,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertSame($length, LocalDate::of($y, $m, $d)->getLengthOfMonth());
     }
 
-    public function providerGetLengthOfMonth() : array
+    public function providerGetLengthOfMonth(): array
     {
         return [
             [2000,  1,  2, 31],
@@ -1332,7 +1339,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertSame($cmp >= 0, $date1->isAfterOrEqualTo($date2));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             ['2015-01-01', '2014-12-31', 1],
@@ -1373,7 +1380,7 @@ class LocalDateTest extends AbstractTestCase
         $this->assertSame($expected, (string) LocalDate::of($year, $month, $day));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [999, 1, 2, '0999-01-02'],
@@ -1414,7 +1421,7 @@ class LocalDateTest extends AbstractTestCase
         $zonedDateTime = LocalDate::parse($dateTime);
         $dateTime = $zonedDateTime->toNativeDateTime();
 
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
+        $this->assertInstanceOf(DateTime::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1429,7 +1436,7 @@ class LocalDateTest extends AbstractTestCase
         $zonedDateTime = LocalDate::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTime();
 
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
+        $this->assertInstanceOf(DateTime::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1444,7 +1451,7 @@ class LocalDateTest extends AbstractTestCase
         $zonedDateTime = LocalDate::parse($dateTime);
         $dateTime = $zonedDateTime->toNativeDateTimeImmutable();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1459,7 +1466,7 @@ class LocalDateTest extends AbstractTestCase
         $zonedDateTime = LocalDate::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTimeImmutable();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 

--- a/tests/LocalDateTimeTest.php
+++ b/tests/LocalDateTimeTest.php
@@ -16,6 +16,10 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Period;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\TimeZoneOffset;
+use DateTime;
+use DateTimeImmutable;
+
+use function json_encode;
 
 /**
  * Unit tests for class LocalDateTime.
@@ -32,7 +36,7 @@ class LocalDateTimeTest extends AbstractTestCase
 
     public function testFromDateTime(): void
     {
-        $dateTime = new \DateTime('2018-07-21 14:09:10.23456');
+        $dateTime = new DateTime('2018-07-21 14:09:10.23456');
         $this->assertLocalDateTimeIs(2018, 7, 21, 14, 9, 10, 234560000, LocalDateTime::fromDateTime($dateTime));
     }
 
@@ -43,7 +47,7 @@ class LocalDateTimeTest extends AbstractTestCase
      * @param int $nano   The nanosecond adjustment to the clock.
      * @param int $offset The time-zone offset to get the time at.
      * @param int $y      The expected year.
-     * @param int $m      The expected month
+     * @param int $m      The expected month.
      * @param int $d      The expected day.
      * @param int $h      The expected hour.
      * @param int $i      The expected minute.
@@ -57,7 +61,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, LocalDateTime::now($timeZone, $clock));
     }
 
-    public function providerNow() : array
+    public function providerNow(): array
     {
         return [
             [1409574896, 0,         0, 2014, 9, 1, 12, 34, 56,      0],
@@ -84,7 +88,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, LocalDateTime::parse($t));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['0999-02-28T12:34', 999, 2, 28, 12, 34, 0, 0],
@@ -103,7 +107,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDateTime::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             [' 2014-02-28T12:34'],
@@ -139,7 +143,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDateTime::parse($text);
     }
 
-    public function providerParseInvalidDateTimeThrowsException() : array
+    public function providerParseInvalidDateTimeThrowsException(): array
     {
         return [
             ['2014-00-15T12:34'],
@@ -199,7 +203,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertDayOfWeekIs($dayOfWeek, $dateTime->getDayOfWeek());
     }
 
-    public function providerGetDayOfWeek() : array
+    public function providerGetDayOfWeek(): array
     {
         return [
             [2000, 1, 3, 1],
@@ -233,7 +237,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($dayOfYear, $dateTime->getDayOfYear());
     }
 
-    public function providerGetDayOfYear() : array
+    public function providerGetDayOfYear(): array
     {
         return [
             [2000, 1, 1, 1],
@@ -258,7 +262,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($y, $m, $d, 4, 5, 6, 789, $dateTime->withDate($newDate));
     }
 
-    public function providerWithDate() : array
+    public function providerWithDate(): array
     {
         return [
             [2001, 2, 3],
@@ -281,7 +285,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs(2001, 2, 3, $h, $m, $s, $n, $dateTime->withTime($newTime));
     }
 
-    public function providerWithTime() : array
+    public function providerWithTime(): array
     {
         return [
             [4, 5, 6, 789],
@@ -306,7 +310,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($newYear, $month, $expectedDay, 1, 2, 3, 123456789, $localDateTime);
     }
 
-    public function providerWithYear() : array
+    public function providerWithYear(): array
     {
         return [
             [2007, 3, 31, 2008, 31],
@@ -329,7 +333,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6))->withYear($invalidYear);
     }
 
-    public function providerWithInvalidYearThrowsException() : array
+    public function providerWithInvalidYearThrowsException(): array
     {
         return [
             [-1000000],
@@ -354,7 +358,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($year, $newMonth, $expectedDay, 1, 2, 3, 123456789, $localDateTime);
     }
 
-    public function providerWithMonth() : array
+    public function providerWithMonth(): array
     {
         return [
             [2007, 3, 31, 2, 28],
@@ -385,7 +389,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6))->withMonth($invalidMonth);
     }
 
-    public function providerWithInvalidMonthThrowsException() : array
+    public function providerWithInvalidMonthThrowsException(): array
     {
         return [
             [0],
@@ -409,7 +413,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($year, $month, $newDay, 1, 2, 3, 123456789, $localDateTime);
     }
 
-    public function providerWithDay() : array
+    public function providerWithDay(): array
     {
         return [
             [2007, 6, 2, 2],
@@ -433,7 +437,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDate::of($year, $month, $day)->atTime(LocalTime::midnight())->withDay($newDay);
     }
 
-    public function providerWithInvalidDayThrowsException() : array
+    public function providerWithInvalidDayThrowsException(): array
     {
         return [
             [2007, 1, 1, 0],
@@ -455,7 +459,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs(2001, 2, 3, $hour, 34, 56, 123456789, $localDateTime->withHour($hour));
     }
 
-    public function providerWithHour() : array
+    public function providerWithHour(): array
     {
         return [
             [12],
@@ -465,8 +469,6 @@ class LocalDateTimeTest extends AbstractTestCase
 
     /**
      * @dataProvider providerWithInvalidHourThrowsException
-     *
-     * @param int $invalidHour
      */
     public function testWithInvalidHourThrowsException(int $invalidHour): void
     {
@@ -474,7 +476,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6))->withHour($invalidHour);
     }
 
-    public function providerWithInvalidHourThrowsException() : array
+    public function providerWithInvalidHourThrowsException(): array
     {
         return [
             [-1],
@@ -493,7 +495,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs(2001, 2, 3, 12, $minute, 56, 123456789, $localDateTime->withMinute($minute));
     }
 
-    public function providerWithMinute() : array
+    public function providerWithMinute(): array
     {
         return [
             [34],
@@ -510,7 +512,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6))->withMinute($invalidMinute);
     }
 
-    public function providerWithInvalidMinuteThrowsException() : array
+    public function providerWithInvalidMinuteThrowsException(): array
     {
         return [
             [-1],
@@ -529,7 +531,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs(2001, 2, 3, 12, 34, $second, 123456789, $localDateTime->withSecond($second));
     }
 
-    public function providerWithSecond() : array
+    public function providerWithSecond(): array
     {
         return [
             [56],
@@ -546,7 +548,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6))->withSecond($invalidSecond);
     }
 
-    public function providerWithInvalidSecondThrowsException() : array
+    public function providerWithInvalidSecondThrowsException(): array
     {
         return [
             [-1],
@@ -565,7 +567,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs(2001, 2, 3, 12, 34, 56, $nano, $localDateTime->withNano($nano));
     }
 
-    public function providerWithNano() : array
+    public function providerWithNano(): array
     {
         return [
             [789],
@@ -582,7 +584,7 @@ class LocalDateTimeTest extends AbstractTestCase
         LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6))->withNano($invalidNano);
     }
 
-    public function providerWithInvalidNanoThrowsException() : array
+    public function providerWithInvalidNanoThrowsException(): array
     {
         return [
             [-1],
@@ -632,7 +634,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($ey, $em, $ed, 12, 34, 56, 123456789, $dateTime->minusPeriod($period->negated()));
     }
 
-    public function providerPeriod() : array
+    public function providerPeriod(): array
     {
         return [
             [2001, 2, 3,  0,   0,   0, 2001,  2,  3],
@@ -689,7 +691,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, $localDateTime->minusDuration($duration));
     }
 
-    public function providerDuration() : array
+    public function providerDuration(): array
     {
         return [
             [71692, 2000000000, 2001, 2, 4, 0, 0, 0, 123456789],
@@ -713,7 +715,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerPlusYears() : array
+    public function providerPlusYears(): array
     {
         return [
             ['2000-02-29T12:34', 0, '2000-02-29T12:34'],
@@ -735,7 +737,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerPlusMonths() : array
+    public function providerPlusMonths(): array
     {
         return [
             ['2001-01-31T12:34:56', 0, '2001-01-31T12:34:56'],
@@ -757,7 +759,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerPlusWeeks() : array
+    public function providerPlusWeeks(): array
     {
         return [
             ['1999-11-30T12:34', 0, '1999-11-30T12:34'],
@@ -779,7 +781,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerPlusDays() : array
+    public function providerPlusDays(): array
     {
         return [
             ['1999-11-30T12:34', 0, '1999-11-30T12:34'],
@@ -801,7 +803,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerPlusHours() : array
+    public function providerPlusHours(): array
     {
         return [
             ['1999-11-30T12:34:56', 0, '1999-11-30T12:34:56'],
@@ -817,16 +819,13 @@ class LocalDateTimeTest extends AbstractTestCase
      * @param int    $minutes          The number of minutes to add.
      * @param string $expectedDateTime The expected resulting date-time string.
      */
-    public function testPlusMinutes(string $dateTime, int $minutes, string $expectedDateTime)
+    public function testPlusMinutes(string $dateTime, int $minutes, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusMinutes($minutes);
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    /**
-     * @return array
-     */
-    public function providerPlusMinutes() : array
+    public function providerPlusMinutes(): array
     {
         return [
             ['1999-11-30T12:34:56', 0, '1999-11-30T12:34:56'],
@@ -848,7 +847,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerPlusSeconds() : array
+    public function providerPlusSeconds(): array
     {
         return [
             ['1999-11-30T12:34:56', 0, '1999-11-30T12:34:56'],
@@ -870,7 +869,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerPlusNanos() : array
+    public function providerPlusNanos(): array
     {
         return [
             ['2000-03-01T00:00', 0, '2000-03-01T00:00'],
@@ -893,7 +892,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusYears() : array
+    public function providerMinusYears(): array
     {
         return [
             ['2000-02-29T12:34', 0, '2000-02-29T12:34'],
@@ -915,7 +914,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusMonths() : array
+    public function providerMinusMonths(): array
     {
         return [
             ['2001-01-31T12:34:56', 0, '2001-01-31T12:34:56'],
@@ -937,7 +936,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusWeeks() : array
+    public function providerMinusWeeks(): array
     {
         return [
             ['1999-11-30T12:34', 0, '1999-11-30T12:34'],
@@ -959,7 +958,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusDays() : array
+    public function providerMinusDays(): array
     {
         return [
             ['1999-11-30T12:34', 0, '1999-11-30T12:34'],
@@ -981,7 +980,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusHours() : array
+    public function providerMinusHours(): array
     {
         return [
             ['1999-11-30T12:34:56', 0, '1999-11-30T12:34:56'],
@@ -1003,7 +1002,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusMinutes() : array
+    public function providerMinusMinutes(): array
     {
         return [
             ['1999-11-30T12:34:56', 0, '1999-11-30T12:34:56'],
@@ -1025,7 +1024,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusSeconds() : array
+    public function providerMinusSeconds(): array
     {
         return [
             ['1999-11-30T12:34:56', 0, '1999-11-30T12:34:56'],
@@ -1047,7 +1046,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
-    public function providerMinusNanos() : array
+    public function providerMinusNanos(): array
     {
         return [
             ['2000-03-01T00:00', 0, '2000-03-01T00:00'],
@@ -1071,7 +1070,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertInstantIs($epochSeconds, $nanos, $zonedDateTime->getInstant());
     }
 
-    public function providerAtTimeZone() : array
+    public function providerAtTimeZone(): array
     {
         return [
             ['2001-03-28T23:23:23', '-06:00', 985843403, 0],
@@ -1102,7 +1101,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($result <= 0, $dateTime1->isBeforeOrEqualTo($dateTime2));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             ['2000-01-01T11:11:11.1', '2000-01-01T11:11:11.1',  0],
@@ -1166,7 +1165,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $zonedDateTime = LocalDateTime::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTime();
 
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
+        $this->assertInstanceOf(DateTime::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1181,7 +1180,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $zonedDateTime = LocalDateTime::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTimeImmutable();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1232,7 +1231,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $this->assertSame($expected, (string) LocalDateTime::of($year, $month, $day, $hour, $minute, $second, $nano));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [999, 1, 2, 1, 2, 0, 0, '0999-01-02T01:02'],

--- a/tests/LocalTimeTest.php
+++ b/tests/LocalTimeTest.php
@@ -12,6 +12,10 @@ use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalTime;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\TimeZoneOffset;
+use DateTime;
+use DateTimeImmutable;
+
+use function json_encode;
 
 /**
  * Unit tests for class LocalTime.
@@ -32,7 +36,7 @@ class LocalTimeTest extends AbstractTestCase
         LocalTime::of($hour, $minute, $second);
     }
 
-    public function providerOfInvalidTimeThrowsException() : array
+    public function providerOfInvalidTimeThrowsException(): array
     {
         return [
             [-1, 0, 0],
@@ -47,10 +51,10 @@ class LocalTimeTest extends AbstractTestCase
     /**
      * @dataProvider providerOfSecondOfDay
      *
-     * @param int $secondOfDay  The second-of-day to test.
-     * @param int $hour         The expected resulting hour.
-     * @param int $minute       The expected resulting minute.
-     * @param int $second       The expected resulting second.
+     * @param int $secondOfDay The second-of-day to test.
+     * @param int $hour        The expected resulting hour.
+     * @param int $minute      The expected resulting minute.
+     * @param int $second      The expected resulting second.
      */
     public function testOfSecondOfDay(int $secondOfDay, int $hour, int $minute, int $second): void
     {
@@ -58,7 +62,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($hour, $minute, $second, 123, $localTime);
     }
 
-    public function providerOfSecondOfDay() : array
+    public function providerOfSecondOfDay(): array
     {
         return [
             [0, 0, 0, 0],
@@ -88,7 +92,7 @@ class LocalTimeTest extends AbstractTestCase
         LocalTime::ofSecondOfDay($secondOfDay, $nanoOfSecond);
     }
 
-    public function providerOfInvalidSecondOfDayThrowsException() : array
+    public function providerOfInvalidSecondOfDayThrowsException(): array
     {
         return [
             [-1, 0],
@@ -111,7 +115,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertSame($nano, $time->getNano());
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['01:02', 1, 2, 0, 0],
@@ -130,7 +134,7 @@ class LocalTimeTest extends AbstractTestCase
         LocalTime::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             ['12'],
@@ -150,13 +154,13 @@ class LocalTimeTest extends AbstractTestCase
 
     public function testFromDateTime(): void
     {
-        $dateTime = new \DateTime('2018-07-21 14:09:10.23456');
+        $dateTime = new DateTime('2018-07-21 14:09:10.23456');
         $this->assertLocalTimeIs(14, 9, 10, 234560000, LocalTime::fromDateTime($dateTime));
     }
 
     public function testFromNativeDateTime(): void
     {
-        $dateTime = new \DateTime('2018-07-21 14:09:10.23456');
+        $dateTime = new DateTime('2018-07-21 14:09:10.23456');
         $this->assertLocalTimeIs(14, 9, 10, 234560000, LocalTime::fromNativeDateTime($dateTime));
     }
 
@@ -178,7 +182,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($h, $m, $s, $n, LocalTime::now($timeZone, $clock));
     }
 
-    public function providerNow() : array
+    public function providerNow(): array
     {
         return [
             [1409574896, 0, 0, 12, 34, 56, 0],
@@ -218,7 +222,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($hour, 34, 56, 789, LocalTime::of(12, 34, 56, 789)->withHour($hour));
     }
 
-    public function providerWithHour() : array
+    public function providerWithHour(): array
     {
         return [
             [12],
@@ -235,7 +239,7 @@ class LocalTimeTest extends AbstractTestCase
         LocalTime::of(12, 34, 56)->withHour($invalidHour);
     }
 
-    public function providerWithInvalidHourThrowsException() : array
+    public function providerWithInvalidHourThrowsException(): array
     {
         return [
             [-1],
@@ -253,7 +257,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs(12, $minute, 56, 789, LocalTime::of(12, 34, 56, 789)->withMinute($minute));
     }
 
-    public function providerWithMinute() : array
+    public function providerWithMinute(): array
     {
         return [
             [34],
@@ -270,7 +274,7 @@ class LocalTimeTest extends AbstractTestCase
         LocalTime::of(12, 34, 56)->withMinute($invalidMinute);
     }
 
-    public function providerWithInvalidMinuteThrowsException() : array
+    public function providerWithInvalidMinuteThrowsException(): array
     {
         return [
             [-1],
@@ -288,7 +292,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs(12, 34, $second, 789, LocalTime::of(12, 34, 56, 789)->withSecond($second));
     }
 
-    public function providerWithSecond() : array
+    public function providerWithSecond(): array
     {
         return [
             [56],
@@ -305,7 +309,7 @@ class LocalTimeTest extends AbstractTestCase
         LocalTime::of(12, 34, 56)->withSecond($invalidSecond);
     }
 
-    public function providerWithInvalidSecondThrowsException() : array
+    public function providerWithInvalidSecondThrowsException(): array
     {
         return [
             [-1],
@@ -323,7 +327,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs(12, 34, 56, $nano, LocalTime::of(12, 34, 56, 789)->withNano($nano));
     }
 
-    public function providerWithNano() : array
+    public function providerWithNano(): array
     {
         return [
             [789],
@@ -340,7 +344,7 @@ class LocalTimeTest extends AbstractTestCase
         LocalTime::of(12, 34, 56)->withNano($invalidNano);
     }
 
-    public function providerWithInvalidNanoThrowsException() : array
+    public function providerWithInvalidNanoThrowsException(): array
     {
         return [
             [-1],
@@ -390,7 +394,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($eh, $em, $es, $en, $localTime->minusDuration($duration));
     }
 
-    public function providerDuration() : array
+    public function providerDuration(): array
     {
         return [
             [12, 34, 56, 123456789, 123, 456, 12, 36, 59, 123457245],
@@ -426,7 +430,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($eh, 34, 56, 789, $result);
     }
 
-    public function providerPlusHours() : array
+    public function providerPlusHours(): array
     {
         return [
             [0, -25, 23],
@@ -489,7 +493,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($eh, $em, 56, 789, $result);
     }
 
-    public function providerPlusMinutes() : array
+    public function providerPlusMinutes(): array
     {
         return [
             [0, 0, -1441, 23, 59],
@@ -574,7 +578,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($eh, $em, $es, 123456789, $result);
     }
 
-    public function providerPlusSeconds() : array
+    public function providerPlusSeconds(): array
     {
         return [
             [0, 0, 0, -86401, 23, 59, 59],
@@ -675,7 +679,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertLocalTimeIs($eh, $em, $es, $en, $result);
     }
 
-    public function providerPlusNanos() : array
+    public function providerPlusNanos(): array
     {
         return [
             [0, 0, 1, 123, -2100000123, 23, 59, 58, 900000000],
@@ -728,7 +732,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertSame($cmp >= 0, $t1->isAfterOrEqualTo($t2));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             [0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -1009,7 +1013,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertSame($result, $time->withNano(123)->toSecondOfDay());
     }
 
-    public function providerToSecondOfDay() : array
+    public function providerToSecondOfDay(): array
     {
         return [
             [0, 0, 0, 0],
@@ -1049,7 +1053,7 @@ class LocalTimeTest extends AbstractTestCase
         $this->assertSame($r, (string) LocalTime::of($h, $m, $s, $n));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [1, 2, 0, 0, '01:02'],
@@ -1094,7 +1098,7 @@ class LocalTimeTest extends AbstractTestCase
         $zonedDateTime = LocalTime::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTime();
 
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
+        $this->assertInstanceOf(DateTime::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1109,7 +1113,7 @@ class LocalTimeTest extends AbstractTestCase
         $zonedDateTime = LocalTime::parse($dateTime);
         $dateTime = $zonedDateTime->toNativeDateTime();
 
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
+        $this->assertInstanceOf(DateTime::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1124,7 +1128,7 @@ class LocalTimeTest extends AbstractTestCase
         $zonedDateTime = LocalTime::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTimeImmutable();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -1139,7 +1143,7 @@ class LocalTimeTest extends AbstractTestCase
         $zonedDateTime = LocalTime::parse($dateTime);
         $dateTime = $zonedDateTime->toNativeDateTimeImmutable();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 

--- a/tests/MonthDayTest.php
+++ b/tests/MonthDayTest.php
@@ -11,6 +11,8 @@ use Brick\DateTime\MonthDay;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\TimeZone;
 
+use function json_encode;
+
 /**
  * Unit tests for class MonthDay.
  */
@@ -24,7 +26,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertMonthDayIs($month, $day, MonthDay::of($month, $day));
     }
 
-    public function providerOf() : array
+    public function providerOf(): array
     {
         return [
             [1, 1],
@@ -52,7 +54,7 @@ class MonthDayTest extends AbstractTestCase
         MonthDay::of($month, $day);
     }
 
-    public function providerOfThrowsExceptionOnInvalidMonthDay() : array
+    public function providerOfThrowsExceptionOnInvalidMonthDay(): array
     {
         return [
             [0, 1],
@@ -85,7 +87,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertMonthDayIs($month, $day, MonthDay::parse($text));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['--01-01', 1, 1],
@@ -103,7 +105,7 @@ class MonthDayTest extends AbstractTestCase
         MonthDay::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             ['01-01'],
@@ -130,7 +132,7 @@ class MonthDayTest extends AbstractTestCase
         MonthDay::parse($text);
     }
 
-    public function providerParseInvalidDateThrowsException() : array
+    public function providerParseInvalidDateThrowsException(): array
     {
         return [
             ['--00-01'],
@@ -154,7 +156,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertMonthDayIs($month, $day, MonthDay::now(TimeZone::parse($timeZone), $clock));
     }
 
-    public function providerNow() : array
+    public function providerNow(): array
     {
         return [
             [946684799, '+00:00', 12, 31],
@@ -189,7 +191,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testIsEqualTo(int $m1, int $d1, int $m2, int $d2, int $result): void
     {
-        $this->assertSame($result == 0, MonthDay::of($m1, $d1)->isEqualTo(MonthDay::of($m2, $d2)));
+        $this->assertSame($result === 0, MonthDay::of($m1, $d1)->isEqualTo(MonthDay::of($m2, $d2)));
     }
 
     /**
@@ -203,7 +205,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testIsBefore(int $m1, int $d1, int $m2, int $d2, int $result): void
     {
-        $this->assertSame($result == -1, MonthDay::of($m1, $d1)->isBefore(MonthDay::of($m2, $d2)));
+        $this->assertSame($result === -1, MonthDay::of($m1, $d1)->isBefore(MonthDay::of($m2, $d2)));
     }
 
     /**
@@ -217,10 +219,10 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testIsAfter(int $m1, int $d1, int $m2, int $d2, int $result): void
     {
-        $this->assertSame($result == 1, MonthDay::of($m1, $d1)->isAfter(MonthDay::of($m2, $d2)));
+        $this->assertSame($result === 1, MonthDay::of($m1, $d1)->isAfter(MonthDay::of($m2, $d2)));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             [1, 1, 1, 1,  0],
@@ -255,7 +257,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertSame($isValid, MonthDay::of($month, $day)->isValidYear($year));
     }
 
-    public function providerIsValidYear() : array
+    public function providerIsValidYear(): array
     {
         return [
             [1, 1, 2000, true],
@@ -295,7 +297,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertMonthDayIs($newMonth, $expectedDay, $newMonthDay);
     }
 
-    public function providerWithMonth() : array
+    public function providerWithMonth(): array
     {
         return [
             [1, 1, 1, 1],
@@ -330,7 +332,7 @@ class MonthDayTest extends AbstractTestCase
         MonthDay::of($month, $day)->withMonth($newMonth);
     }
 
-    public function providerWithInvalidMonthThrowsException() : array
+    public function providerWithInvalidMonthThrowsException(): array
     {
         return [
             [1, 1, 0],
@@ -365,7 +367,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertMonthDayIs($month, $newDay, $newMonthDay);
     }
 
-    public function providerWithDay() : array
+    public function providerWithDay(): array
     {
         return [
             [1, 1, 31],
@@ -380,9 +382,9 @@ class MonthDayTest extends AbstractTestCase
     /**
      * @dataProvider providerWithInvalidDayThrowsException
      *
-     * @param int $month    The month of the base month-day to test.
-     * @param int $day      The day of base the month-day to test.
-     * @param int $newDay   The new day to apply.
+     * @param int $month  The month of the base month-day to test.
+     * @param int $day    The day of base the month-day to test.
+     * @param int $newDay The new day to apply.
      */
     public function testWithInvalidDayThrowsException(int $month, int $day, int $newDay): void
     {
@@ -390,7 +392,7 @@ class MonthDayTest extends AbstractTestCase
         MonthDay::of($month, $day)->withDay($newDay);
     }
 
-    public function providerWithInvalidDayThrowsException() : array
+    public function providerWithInvalidDayThrowsException(): array
     {
         return [
             [12, 31, 32],
@@ -433,7 +435,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $month, $expectedDay, MonthDay::of($month, $day)->atYear($year));
     }
 
-    public function providerAtYear() : array
+    public function providerAtYear(): array
     {
         return [
             [1, 31, 2000, 31],
@@ -454,7 +456,7 @@ class MonthDayTest extends AbstractTestCase
         MonthDay::of(1, 1)->atYear($year);
     }
 
-    public function providerAtInvalidYearThrowsException() : array
+    public function providerAtInvalidYearThrowsException(): array
     {
         return [
             [-1234567890],
@@ -486,7 +488,7 @@ class MonthDayTest extends AbstractTestCase
         $this->assertSame($string, (string) MonthDay::of($month, $day));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [1, 1, '--01-01'],

--- a/tests/MonthTest.php
+++ b/tests/MonthTest.php
@@ -6,6 +6,9 @@ namespace Brick\DateTime\Tests;
 
 use Brick\DateTime\DateTimeException;
 use Brick\DateTime\Month;
+use Generator;
+
+use function json_encode;
 
 /**
  * Unit tests for class Month.
@@ -23,18 +26,18 @@ class MonthTest extends AbstractTestCase
         $this->assertSame($expectedValue, $monthConstant);
     }
 
-    public function providerConstants() : array
+    public function providerConstants(): array
     {
         return [
-            [ 1, Month::JANUARY],
-            [ 2, Month::FEBRUARY],
-            [ 3, Month::MARCH],
-            [ 4, Month::APRIL],
-            [ 5, Month::MAY],
-            [ 6, Month::JUNE],
-            [ 7, Month::JULY],
-            [ 8, Month::AUGUST],
-            [ 9, Month::SEPTEMBER],
+            [1, Month::JANUARY],
+            [2, Month::FEBRUARY],
+            [3, Month::MARCH],
+            [4, Month::APRIL],
+            [5, Month::MAY],
+            [6, Month::JUNE],
+            [7, Month::JULY],
+            [8, Month::AUGUST],
+            [9, Month::SEPTEMBER],
             [10, Month::OCTOBER],
             [11, Month::NOVEMBER],
             [12, Month::DECEMBER]
@@ -55,7 +58,7 @@ class MonthTest extends AbstractTestCase
         Month::of($invalidMonth);
     }
 
-    public function providerOfInvalidMonthThrowsException() : array
+    public function providerOfInvalidMonthThrowsException(): array
     {
         return [
             [-1],
@@ -103,18 +106,18 @@ class MonthTest extends AbstractTestCase
         $this->assertSame($minLength, Month::of($month)->getMinLength());
     }
 
-    public function minLengthProvider() : array
+    public function minLengthProvider(): array
     {
         return [
-            [ 1, 31],
-            [ 2, 28],
-            [ 3, 31],
-            [ 4, 30],
-            [ 5, 31],
-            [ 6, 30],
-            [ 7, 31],
-            [ 8, 31],
-            [ 9, 30],
+            [1, 31],
+            [2, 28],
+            [3, 31],
+            [4, 30],
+            [5, 31],
+            [6, 30],
+            [7, 31],
+            [8, 31],
+            [9, 30],
             [10, 31],
             [11, 30],
             [12, 31]
@@ -132,18 +135,18 @@ class MonthTest extends AbstractTestCase
         $this->assertSame($minLength, Month::of($month)->getMaxLength());
     }
 
-    public function maxLengthProvider() : array
+    public function maxLengthProvider(): array
     {
         return [
-            [ 1, 31],
-            [ 2, 29],
-            [ 3, 31],
-            [ 4, 30],
-            [ 5, 31],
-            [ 6, 30],
-            [ 7, 31],
-            [ 8, 31],
-            [ 9, 30],
+            [1, 31],
+            [2, 29],
+            [3, 31],
+            [4, 30],
+            [5, 31],
+            [6, 30],
+            [7, 31],
+            [8, 31],
+            [9, 30],
             [10, 31],
             [11, 30],
             [12, 31]
@@ -162,31 +165,31 @@ class MonthTest extends AbstractTestCase
         $this->assertSame($firstDayOfYear, Month::of($month)->getFirstDayOfYear($leapYear));
     }
 
-    public function providerFirstDayOfYear() : array
+    public function providerFirstDayOfYear(): array
     {
         return [
-            [ 1, false, 1],
-            [ 2, false, 1 + 31],
-            [ 3, false, 1 + 31 + 28],
-            [ 4, false, 1 + 31 + 28 + 31],
-            [ 5, false, 1 + 31 + 28 + 31 + 30],
-            [ 6, false, 1 + 31 + 28 + 31 + 30 + 31],
-            [ 7, false, 1 + 31 + 28 + 31 + 30 + 31 + 30],
-            [ 8, false, 1 + 31 + 28 + 31 + 30 + 31 + 30 + 31],
-            [ 9, false, 1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31],
+            [1, false, 1],
+            [2, false, 1 + 31],
+            [3, false, 1 + 31 + 28],
+            [4, false, 1 + 31 + 28 + 31],
+            [5, false, 1 + 31 + 28 + 31 + 30],
+            [6, false, 1 + 31 + 28 + 31 + 30 + 31],
+            [7, false, 1 + 31 + 28 + 31 + 30 + 31 + 30],
+            [8, false, 1 + 31 + 28 + 31 + 30 + 31 + 30 + 31],
+            [9, false, 1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31],
             [10, false, 1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30],
             [11, false, 1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31],
             [12, false, 1 + 31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30],
 
-            [ 1, true, 1],
-            [ 2, true, 1 + 31],
-            [ 3, true, 1 + 31 + 29],
-            [ 4, true, 1 + 31 + 29 + 31],
-            [ 5, true, 1 + 31 + 29 + 31 + 30],
-            [ 6, true, 1 + 31 + 29 + 31 + 30 + 31],
-            [ 7, true, 1 + 31 + 29 + 31 + 30 + 31 + 30],
-            [ 8, true, 1 + 31 + 29 + 31 + 30 + 31 + 30 + 31],
-            [ 9, true, 1 + 31 + 29 + 31 + 30 + 31 + 30 + 31 + 31],
+            [1, true, 1],
+            [2, true, 1 + 31],
+            [3, true, 1 + 31 + 29],
+            [4, true, 1 + 31 + 29 + 31],
+            [5, true, 1 + 31 + 29 + 31 + 30],
+            [6, true, 1 + 31 + 29 + 31 + 30 + 31],
+            [7, true, 1 + 31 + 29 + 31 + 30 + 31 + 30],
+            [8, true, 1 + 31 + 29 + 31 + 30 + 31 + 30 + 31],
+            [9, true, 1 + 31 + 29 + 31 + 30 + 31 + 30 + 31 + 31],
             [10, true, 1 + 31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30],
             [11, true, 1 + 31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31],
             [12, true, 1 + 31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30],
@@ -208,28 +211,28 @@ class MonthTest extends AbstractTestCase
     public function providerGetLength()
     {
         return [
-            [ 1, false, 31],
-            [ 2, false, 28],
-            [ 3, false, 31],
-            [ 4, false, 30],
-            [ 5, false, 31],
-            [ 6, false, 30],
-            [ 7, false, 31],
-            [ 8, false, 31],
-            [ 9, false, 30],
+            [1, false, 31],
+            [2, false, 28],
+            [3, false, 31],
+            [4, false, 30],
+            [5, false, 31],
+            [6, false, 30],
+            [7, false, 31],
+            [8, false, 31],
+            [9, false, 30],
             [10, false, 31],
             [11, false, 30],
             [12, false, 31],
 
-            [ 1, true, 31],
-            [ 2, true, 29],
-            [ 3, true, 31],
-            [ 4, true, 30],
-            [ 5, true, 31],
-            [ 6, true, 30],
-            [ 7, true, 31],
-            [ 8, true, 31],
-            [ 9, true, 30],
+            [1, true, 31],
+            [2, true, 29],
+            [3, true, 31],
+            [4, true, 30],
+            [5, true, 31],
+            [6, true, 30],
+            [7, true, 31],
+            [8, true, 31],
+            [9, true, 30],
             [10, true, 31],
             [11, true, 30],
             [12, true, 31],
@@ -270,7 +273,7 @@ class MonthTest extends AbstractTestCase
         $this->assertMonthIs($expectedMonth, Month::of($month)->minus(-$plusMonths));
     }
 
-    public function providerPlus() : \Generator
+    public function providerPlus(): Generator
     {
         for ($month = Month::JANUARY; $month <= Month::DECEMBER; $month++) {
             for ($plusMonths = -25; $plusMonths <= 25; $plusMonths++) {
@@ -310,18 +313,18 @@ class MonthTest extends AbstractTestCase
         $this->assertSame($expectedName, (string) Month::of($month));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
-            [ 1, 'January'],
-            [ 2, 'February'],
-            [ 3, 'March'],
-            [ 4, 'April'],
-            [ 5, 'May'],
-            [ 6, 'June'],
-            [ 7, 'July'],
-            [ 8, 'August'],
-            [ 9, 'September'],
+            [1, 'January'],
+            [2, 'February'],
+            [3, 'March'],
+            [4, 'April'],
+            [5, 'May'],
+            [6, 'June'],
+            [7, 'July'],
+            [8, 'August'],
+            [9, 'September'],
             [10, 'October'],
             [11, 'November'],
             [12, 'December']

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Brick\DateTime\Tests;
 
 use Brick\DateTime\DateTimeException;
+use Brick\DateTime\LocalDate;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Period;
-use Brick\DateTime\LocalDate;
+use DateInterval;
+use DateTimeImmutable;
+use Generator;
+
+use function json_encode;
 
 /**
  * Unit tests for class Period.
@@ -57,7 +62,7 @@ class PeriodTest extends AbstractTestCase
         $this->assertPeriodIs($years, $months, $days, Period::parse($text));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['P0Y', 0, 0, 0],
@@ -86,7 +91,7 @@ class PeriodTest extends AbstractTestCase
         Period::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             [' P0D'],
@@ -107,7 +112,7 @@ class PeriodTest extends AbstractTestCase
     /**
      * @dataProvider providerFromDateInterval
      */
-    public function testFromDateInterval(\DateInterval $dateInterval, int $years, int $months, int $days): void
+    public function testFromDateInterval(DateInterval $dateInterval, int $years, int $months, int $days): void
     {
         $period = Period::fromDateInterval($dateInterval);
         self::assertPeriodIs($years, $months, $days, $period);
@@ -116,14 +121,13 @@ class PeriodTest extends AbstractTestCase
     /**
      * @dataProvider providerFromDateInterval
      */
-    public function testFromNativeDateInterval(\DateInterval $dateInterval, int $years, int $months, int $days): void
+    public function testFromNativeDateInterval(DateInterval $dateInterval, int $years, int $months, int $days): void
     {
         $period = Period::fromNativeDateInterval($dateInterval);
         self::assertPeriodIs($years, $months, $days, $period);
     }
 
-
-    public function providerFromDateInterval(): \Generator
+    public function providerFromDateInterval(): Generator
     {
         $withConstructor = [
             ['P0Y', 0, 0, 0],
@@ -137,7 +141,7 @@ class PeriodTest extends AbstractTestCase
         ];
 
         foreach ($withConstructor as [$dateIntervalAsString, $years, $months, $days]) {
-            $dateInterval = new \DateInterval($dateIntervalAsString);
+            $dateInterval = new DateInterval($dateIntervalAsString);
 
             yield [$dateInterval, $years, $months, $days];
         }
@@ -152,8 +156,8 @@ class PeriodTest extends AbstractTestCase
         ];
 
         foreach ($withDateTimeDiff as [$dateTime1, $dateTime2, $years, $months, $days]) {
-            $dateTime1 = new \DateTimeImmutable($dateTime1);
-            $dateTime2 = new \DateTimeImmutable($dateTime2);
+            $dateTime1 = new DateTimeImmutable($dateTime1);
+            $dateTime2 = new DateTimeImmutable($dateTime2);
 
             yield [$dateTime1->diff($dateTime2), $years, $months, $days];
             yield [$dateTime2->diff($dateTime1), -$years, -$months, -$days];
@@ -165,8 +169,8 @@ class PeriodTest extends AbstractTestCase
      */
     public function testFromInvalidDateInterval(string $dateTime1, string $dateTime2, string $expectedMessage): void
     {
-        $dateTime1 = new \DateTimeImmutable($dateTime1);
-        $dateTime2 = new \DateTimeImmutable($dateTime2);
+        $dateTime1 = new DateTimeImmutable($dateTime1);
+        $dateTime2 = new DateTimeImmutable($dateTime2);
 
         $dateInterval = $dateTime1->diff($dateTime2);
 
@@ -303,7 +307,7 @@ class PeriodTest extends AbstractTestCase
         $this->assertPeriodIs($ny, $nm, $d, Period::of($y, $m, $d)->normalized());
     }
 
-    public function providerNormalized() : array
+    public function providerNormalized(): array
     {
         return [
             [1, 2, 3, 1, 2],
@@ -330,7 +334,7 @@ class PeriodTest extends AbstractTestCase
         $this->assertSame($isZero, Period::of($years, $months, $days)->isZero());
     }
 
-    public function providerIsZero() : array
+    public function providerIsZero(): array
     {
         return [
             [0, 0, 0, true],
@@ -360,7 +364,7 @@ class PeriodTest extends AbstractTestCase
         $this->assertSame($isEqual, $p2->isEqualTo($p1));
     }
 
-    public function providerIsEqualTo() : array
+    public function providerIsEqualTo(): array
     {
         return [
             [0, 0, 0, 0, 0, 0, true],
@@ -403,7 +407,7 @@ class PeriodTest extends AbstractTestCase
         $this->assertSame($days, $dateInterval->d);
     }
 
-    public function providerToDateInterval() : array
+    public function providerToDateInterval(): array
     {
         return [
             [1, -2, 3],
@@ -437,7 +441,7 @@ class PeriodTest extends AbstractTestCase
         $this->assertSame($expected, (string) Period::of($years, $months, $days));
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [0, 0, 0, 'P0D'],

--- a/tests/StopwatchTest.php
+++ b/tests/StopwatchTest.php
@@ -13,19 +13,11 @@ use Brick\DateTime\Stopwatch;
  */
 class StopwatchTest extends AbstractTestCase
 {
-    /**
-     * @var FixedClock
-     */
-    private static $clock;
+    private static FixedClock $clock;
 
     public static function setUpBeforeClass(): void
     {
         self::$clock = new FixedClock(Instant::of(0));
-    }
-
-    private static function setClockTime(int $second, int $nano) : void
-    {
-        self::$clock->setTime(Instant::of($second, $nano));
     }
 
     public function testConstructorWithNullClock(): void
@@ -37,7 +29,7 @@ class StopwatchTest extends AbstractTestCase
         $this->assertDurationIs(0, 0, $stopwatch->getElapsedTime());
     }
 
-    public function testNew() : Stopwatch
+    public function testNew(): Stopwatch
     {
         $stopwatch = new Stopwatch(self::$clock);
 
@@ -51,7 +43,7 @@ class StopwatchTest extends AbstractTestCase
     /**
      * @depends testNew
      */
-    public function testStart(Stopwatch $stopwatch) : Stopwatch
+    public function testStart(Stopwatch $stopwatch): Stopwatch
     {
         self::setClockTime(1000, 1);
 
@@ -67,7 +59,7 @@ class StopwatchTest extends AbstractTestCase
     /**
      * @depends testStart
      */
-    public function testElapsedTimeWhileRunning(Stopwatch $stopwatch) : Stopwatch
+    public function testElapsedTimeWhileRunning(Stopwatch $stopwatch): Stopwatch
     {
         self::setClockTime(2000, 0);
 
@@ -91,7 +83,7 @@ class StopwatchTest extends AbstractTestCase
     /**
      * @depends testElapsedTimeWhileRunning
      */
-    public function testStop(Stopwatch $stopwatch) : Stopwatch
+    public function testStop(Stopwatch $stopwatch): Stopwatch
     {
         self::setClockTime(3000, 2);
 
@@ -107,7 +99,7 @@ class StopwatchTest extends AbstractTestCase
     /**
      * @depends testStop
      */
-    public function testFrozenAfterStop(Stopwatch $stopwatch) : Stopwatch
+    public function testFrozenAfterStop(Stopwatch $stopwatch): Stopwatch
     {
         self::setClockTime(4000, 9);
 
@@ -121,7 +113,7 @@ class StopwatchTest extends AbstractTestCase
     /**
      * @depends testFrozenAfterStop
      */
-    public function testRestart(Stopwatch $stopwatch) : Stopwatch
+    public function testRestart(Stopwatch $stopwatch): Stopwatch
     {
         self::setClockTime(5000, 9);
 
@@ -137,7 +129,7 @@ class StopwatchTest extends AbstractTestCase
     /**
      * @depends testRestart
      */
-    public function testElapsedTimeWhileRunningAfterRestart(Stopwatch $stopwatch) : Stopwatch
+    public function testElapsedTimeWhileRunningAfterRestart(Stopwatch $stopwatch): Stopwatch
     {
         self::setClockTime(5001, 10);
 
@@ -151,7 +143,7 @@ class StopwatchTest extends AbstractTestCase
     /**
      * @depends testElapsedTimeWhileRunningAfterRestart
      */
-    public function testStopAgain(Stopwatch $stopwatch) : Stopwatch
+    public function testStopAgain(Stopwatch $stopwatch): Stopwatch
     {
         self::setClockTime(5002, 20);
 
@@ -174,5 +166,10 @@ class StopwatchTest extends AbstractTestCase
         $this->assertNull($stopwatch->getStartTime());
         $this->assertFalse($stopwatch->isRunning());
         $this->assertDurationIs(2002, 12, $stopwatch->getElapsedTime());
+    }
+
+    private static function setClockTime(int $second, int $nano): void
+    {
+        self::$clock->setTime(Instant::of($second, $nano));
     }
 }

--- a/tests/TimeZoneOffsetTest.php
+++ b/tests/TimeZoneOffsetTest.php
@@ -8,6 +8,7 @@ use Brick\DateTime\DateTimeException;
 use Brick\DateTime\Instant;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\TimeZoneOffset;
+use DateTimeZone;
 
 /**
  * Units tests for class TimeZoneOffset.
@@ -26,7 +27,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         $this->assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::of($hours, $minutes));
     }
 
-    public function providerOf() : array
+    public function providerOf(): array
     {
         return [
             [0, 0, 0],
@@ -52,7 +53,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         TimeZoneOffset::of($hours, $minutes);
     }
 
-    public function providerOfInvalidValuesThrowsException() : array
+    public function providerOfInvalidValuesThrowsException(): array
     {
         return [
             [0, 60],
@@ -72,7 +73,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         $this->assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::ofTotalSeconds($totalSeconds));
     }
 
-    public function providerTotalSeconds() : array
+    public function providerTotalSeconds(): array
     {
         return [
             [-64800],
@@ -94,7 +95,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         TimeZoneOffset::ofTotalSeconds($totalSeconds);
     }
 
-    public function providerOfInvalidTotalSecondsThrowsException() : array
+    public function providerOfInvalidTotalSecondsThrowsException(): array
     {
         return [
             [-1],
@@ -120,7 +121,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         $this->assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::parse($text));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['+00:00', 0],
@@ -143,7 +144,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         TimeZoneOffset::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             [''],
@@ -166,7 +167,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         TimeZoneOffset::parse($text);
     }
 
-    public function providerParseValueStringThrowsException() : array
+    public function providerParseValueStringThrowsException(): array
     {
         return [
             ['+18:00:01'],
@@ -200,7 +201,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         $this->assertSame($string, (string) TimeZoneOffset::ofTotalSeconds($totalSeconds));
     }
 
-    public function providerGetId() : array
+    public function providerGetId(): array
     {
         return [
             [0, 'Z'],
@@ -229,7 +230,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
     {
         $dateTimeZone = TimeZoneOffset::ofTotalSeconds(-18000)->toDateTimeZone();
 
-        $this->assertInstanceOf(\DateTimeZone::class, $dateTimeZone);
+        $this->assertInstanceOf(DateTimeZone::class, $dateTimeZone);
         $this->assertSame('-05:00', $dateTimeZone->getName());
     }
 
@@ -237,7 +238,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
     {
         $dateTimeZone = TimeZoneOffset::ofTotalSeconds(-18000)->toNativeDateTimeZone();
 
-        $this->assertInstanceOf(\DateTimeZone::class, $dateTimeZone);
+        $this->assertInstanceOf(DateTimeZone::class, $dateTimeZone);
         $this->assertSame('-05:00', $dateTimeZone->getName());
     }
 }

--- a/tests/TimeZoneRegionTest.php
+++ b/tests/TimeZoneRegionTest.php
@@ -8,6 +8,9 @@ use Brick\DateTime\DateTimeException;
 use Brick\DateTime\Instant;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\TimeZoneRegion;
+use DateTimeZone;
+
+use function count;
 
 /**
  * Unit tests for class TimeZoneRegion.
@@ -28,7 +31,7 @@ class TimeZoneRegionTest extends AbstractTestCase
         TimeZoneRegion::of($region);
     }
 
-    public function providerOfInvalidRegionThrowsException() : array
+    public function providerOfInvalidRegionThrowsException(): array
     {
         return [
             [''],
@@ -54,7 +57,7 @@ class TimeZoneRegionTest extends AbstractTestCase
         TimeZoneRegion::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             [''],
@@ -68,7 +71,7 @@ class TimeZoneRegionTest extends AbstractTestCase
     public function testGetAllTimeZones(bool $includeObsolete): void
     {
         $identifiers = TimeZoneRegion::getAllIdentifiers($includeObsolete);
-        $this->assertGreaterThan(1, \count($identifiers));
+        $this->assertGreaterThan(1, count($identifiers));
 
         $expectedIdentifiers = [
             'UTC',
@@ -95,7 +98,7 @@ class TimeZoneRegionTest extends AbstractTestCase
         }
     }
 
-    public function providerGetAllTimeZones() : array
+    public function providerGetAllTimeZones(): array
     {
         return [
             [false],
@@ -113,7 +116,7 @@ class TimeZoneRegionTest extends AbstractTestCase
         $this->assertSame($expectedIdentifiers, $identifiers);
     }
 
-    public function providerGetTimeZonesForCountry() : array
+    public function providerGetTimeZonesForCountry(): array
     {
         return [
             ['FR', 'Europe/Paris'],
@@ -141,7 +144,7 @@ class TimeZoneRegionTest extends AbstractTestCase
         $this->assertSame($expectedOffset, $actualOffset);
     }
 
-    public function providerGetOffset() : array
+    public function providerGetOffset(): array
     {
         return [
             ['Europe/London', 1419984000,    0],
@@ -155,7 +158,7 @@ class TimeZoneRegionTest extends AbstractTestCase
     {
         $dateTimeZone = TimeZoneRegion::of('Europe/London')->toDateTimeZone();
 
-        $this->assertInstanceOf(\DateTimeZone::class, $dateTimeZone);
+        $this->assertInstanceOf(DateTimeZone::class, $dateTimeZone);
         $this->assertSame('Europe/London', $dateTimeZone->getName());
     }
 
@@ -163,7 +166,7 @@ class TimeZoneRegionTest extends AbstractTestCase
     {
         $dateTimeZone = TimeZoneRegion::of('Europe/London')->toNativeDateTimeZone();
 
-        $this->assertInstanceOf(\DateTimeZone::class, $dateTimeZone);
+        $this->assertInstanceOf(DateTimeZone::class, $dateTimeZone);
         $this->assertSame('Europe/London', $dateTimeZone->getName());
     }
 

--- a/tests/TimeZoneTest.php
+++ b/tests/TimeZoneTest.php
@@ -8,6 +8,7 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\TimeZoneOffset;
 use Brick\DateTime\TimeZoneRegion;
+use DateTimeZone;
 
 /**
  * Unit tests for class TimeZone.
@@ -29,7 +30,7 @@ class TimeZoneTest extends AbstractTestCase
         $this->assertSame($id, $timeZone->getId());
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['Z', TimeZoneOffset::class, 'Z'],
@@ -50,7 +51,7 @@ class TimeZoneTest extends AbstractTestCase
         TimeZone::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             [''],
@@ -77,7 +78,7 @@ class TimeZoneTest extends AbstractTestCase
      */
     public function testFromDateTimeZone(string $tz): void
     {
-        $dateTimeZone = new \DateTimeZone($tz);
+        $dateTimeZone = new DateTimeZone($tz);
         $this->assertSame($tz, TimeZone::fromDateTimeZone($dateTimeZone)->getId());
     }
 
@@ -88,11 +89,11 @@ class TimeZoneTest extends AbstractTestCase
      */
     public function testFromNativeDateTimeZone(string $tz): void
     {
-        $dateTimeZone = new \DateTimeZone($tz);
+        $dateTimeZone = new DateTimeZone($tz);
         $this->assertSame($tz, TimeZone::fromNativeDateTimeZone($dateTimeZone)->getId());
     }
 
-    public function providerFromDateTimeZone() : array
+    public function providerFromDateTimeZone(): array
     {
         return [
             ['Z'],

--- a/tests/Utility/MathTest.php
+++ b/tests/Utility/MathTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Brick\DateTime\Tests\Utility;
 
 use Brick\DateTime\Utility\Math;
-
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,11 +24,11 @@ class MathTest extends TestCase
         $this->assertSame($expected, Math::floorDiv($a, $b));
     }
 
-    public function providerFloorDiv() : array
+    public function providerFloorDiv(): array
     {
         return [
-            [ 3,  2,  1],
-            [ 3, -2, -2],
+            [3,  2,  1],
+            [3, -2, -2],
             [-3,  2, -2],
             [-3, -2,  1]
         ];
@@ -47,11 +46,11 @@ class MathTest extends TestCase
         $this->assertSame($expected, Math::floorMod($a, $b));
     }
 
-    public function providerFloorMod() : array
+    public function providerFloorMod(): array
     {
         return [
-            [ 3,  2,  1],
-            [ 3, -2, -1],
+            [3,  2,  1],
+            [3, -2, -1],
             [-3,  2,  1],
             [-3, -2, -1]
         ];

--- a/tests/YearMonthRangeTest.php
+++ b/tests/YearMonthRangeTest.php
@@ -9,6 +9,8 @@ use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\YearMonth;
 use Brick\DateTime\YearMonthRange;
 
+use function json_encode;
+
 /**
  * Unit tests for class YearMonthRange.
  */
@@ -46,7 +48,7 @@ class YearMonthRangeTest extends AbstractTestCase
         $this->assertYearMonthRangeIs($y1, $m1, $y2, $m2, YearMonthRange::parse($text));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['2001-02/04', 2001, 2, 2001, 4],
@@ -65,7 +67,7 @@ class YearMonthRangeTest extends AbstractTestCase
         YearMonthRange::parse($text);
     }
 
-    public function providerParseInvalidRangeThrowsException() : array
+    public function providerParseInvalidRangeThrowsException(): array
     {
         return [
             ['2001-02'],
@@ -92,7 +94,7 @@ class YearMonthRangeTest extends AbstractTestCase
         )->isEqualTo(YearMonthRange::parse($testRange)));
     }
 
-    public function providerIsEqualTo() : array
+    public function providerIsEqualTo(): array
     {
         return [
             ['2001-02/2004-05', true],
@@ -111,7 +113,7 @@ class YearMonthRangeTest extends AbstractTestCase
         $this->assertSame($contains, YearMonthRange::parse($range)->contains(YearMonth::parse($yearMonth)));
     }
 
-    public function providerContains() : array
+    public function providerContains(): array
     {
         return [
             ['2001-05/2004-02', '2001-04', false],
@@ -130,7 +132,7 @@ class YearMonthRangeTest extends AbstractTestCase
     public function testIterator(): void
     {
         $start = YearMonth::of(2013, 10);
-        $end   = YearMonth::of(2014, 3);
+        $end = YearMonth::of(2014, 3);
 
         $range = YearMonthRange::of($start, $end);
 
@@ -165,7 +167,7 @@ class YearMonthRangeTest extends AbstractTestCase
         $this->assertCount($count, YearMonthRange::parse($range));
     }
 
-    public function providerCount() : array
+    public function providerCount(): array
     {
         return [
             ['2010-01/2010-01', 1],
@@ -177,14 +179,11 @@ class YearMonthRangeTest extends AbstractTestCase
     }
 
     /**
-     * @param string $yearMonthRange
-     * @param string $expectedRange
-     * @return void
      * @dataProvider providerToLocalDateRange
      */
     public function testToLocalDateRange(string $yearMonthRange, string $expectedRange): void
     {
-        $this->assertSame($expectedRange, (string)YearMonthRange::parse($yearMonthRange)->toLocalDateRange());
+        $this->assertSame($expectedRange, (string) YearMonthRange::parse($yearMonthRange)->toLocalDateRange());
     }
 
     public function providerToLocalDateRange(): array

--- a/tests/YearMonthTest.php
+++ b/tests/YearMonthTest.php
@@ -10,6 +10,8 @@ use Brick\DateTime\Instant;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\YearMonth;
 
+use function json_encode;
+
 /**
  * Unit tests for class YearMonth.
  */
@@ -32,7 +34,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertYearMonthIs($year, $month, YearMonth::parse($text));
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['2011-02', 2011, 02],
@@ -54,7 +56,7 @@ class YearMonthTest extends AbstractTestCase
         YearMonth::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             ['999-01'],
@@ -77,7 +79,7 @@ class YearMonthTest extends AbstractTestCase
         YearMonth::parse($text);
     }
 
-    public function providerParseInvalidYearMonthThrowsException() : array
+    public function providerParseInvalidYearMonthThrowsException(): array
     {
         return [
             ['2000-00'],
@@ -99,7 +101,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertYearMonthIs($year, $month, YearMonth::now(TimeZone::parse($timeZone), $clock));
     }
 
-    public function providerNow() : array
+    public function providerNow(): array
     {
         return [
             [946684799, '+00:00', 1999, 12],
@@ -121,7 +123,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertSame($isLeap, YearMonth::of($year, $month)->isLeapYear());
     }
 
-    public function providerIsLeapYear() : array
+    public function providerIsLeapYear(): array
     {
         return [
             [1999, 1, false],
@@ -145,7 +147,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertSame($length, YearMonth::of($year, $month)->getLengthOfMonth());
     }
 
-    public function providerGetLengthOfMonth() : array
+    public function providerGetLengthOfMonth(): array
     {
         return [
             [1999, 1, 31],
@@ -187,7 +189,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertSame($length, YearMonth::of($year, $month)->getLengthOfYear());
     }
 
-    public function providerGetLengthOfYear() : array
+    public function providerGetLengthOfYear(): array
     {
         return [
             [1999, 1, 365],
@@ -221,7 +223,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsEqualTo(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result == 0, YearMonth::of($y1, $m1)->isEqualTo(YearMonth::of($y2, $m2)));
+        $this->assertSame($result === 0, YearMonth::of($y1, $m1)->isEqualTo(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -235,7 +237,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsBefore(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result == -1, YearMonth::of($y1, $m1)->isBefore(YearMonth::of($y2, $m2)));
+        $this->assertSame($result === -1, YearMonth::of($y1, $m1)->isBefore(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -263,7 +265,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsAfter(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result == 1, YearMonth::of($y1, $m1)->isAfter(YearMonth::of($y2, $m2)));
+        $this->assertSame($result === 1, YearMonth::of($y1, $m1)->isAfter(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -280,7 +282,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertSame($result >= 0, YearMonth::of($y1, $m1)->isAfterOrEqualTo(YearMonth::of($y2, $m2)));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             [2001, 1, 2001, 1,  0],
@@ -335,7 +337,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $month, $day, YearMonth::of($year, $month)->getLastDay());
     }
 
-    public function providerGetLastDay() : array
+    public function providerGetLastDay(): array
     {
         return [
             [2000, 1, 31],
@@ -366,7 +368,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertYearMonthIs(2005, 1, $yearMonth->plusYears(0));
     }
 
-    public function providerPlusYears() : array
+    public function providerPlusYears(): array
     {
         return [
             [2003, 11, 7, 2010, 11],
@@ -383,7 +385,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->minusYears($plusYears));
     }
 
-    public function providerMinusYears() : array
+    public function providerMinusYears(): array
     {
         return [
             [2003, 11, 7, 1996, 11],
@@ -400,7 +402,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->plusMonths($plusMonths));
     }
 
-    public function providerPlusMonths() : array
+    public function providerPlusMonths(): array
     {
         return [
             [2015, 11, -12, 2014, 11],
@@ -424,7 +426,7 @@ class YearMonthTest extends AbstractTestCase
         $this->assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->minusMonths($plusMonths));
     }
 
-    public function providerMinusMonths() : array
+    public function providerMinusMonths(): array
     {
         return [
             [2015, 11, -2, 2016, 1],
@@ -440,15 +442,11 @@ class YearMonthTest extends AbstractTestCase
     }
 
     /**
-     * @param int $year
-     * @param int $month
-     * @param string $expectedRange
-     * @return void
      * @dataProvider providerToLocalDateRange
      */
     public function testToLocalDateRange(int $year, int $month, string $expectedRange): void
     {
-        $this->assertSame($expectedRange, (string)YearMonth::of($year, $month)->toLocalDateRange());
+        $this->assertSame($expectedRange, (string) YearMonth::of($year, $month)->toLocalDateRange());
     }
 
     public function providerToLocalDateRange(): array

--- a/tests/YearTest.php
+++ b/tests/YearTest.php
@@ -11,6 +11,11 @@ use Brick\DateTime\MonthDay;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\Year;
 
+use function json_encode;
+
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
 /**
  * Unit tests for class Year.
  */
@@ -30,11 +35,11 @@ class YearTest extends AbstractTestCase
         Year::of($invalidYear);
     }
 
-    public function providerOfInvalidYearThrowsException() : array
+    public function providerOfInvalidYearThrowsException(): array
     {
         return [
-            [\PHP_INT_MIN],
-            [\PHP_INT_MAX],
+            [PHP_INT_MIN],
+            [PHP_INT_MAX],
             [-1000000000],
             [1000000000]
         ];
@@ -53,7 +58,7 @@ class YearTest extends AbstractTestCase
         $this->assertYearIs($expectedYear, Year::now(TimeZone::parse($timeZone), $clock));
     }
 
-    public function providerNow() : array
+    public function providerNow(): array
     {
         return [
             [1388534399, '-01:00', 2013],
@@ -76,7 +81,7 @@ class YearTest extends AbstractTestCase
         $this->assertSame($isLeap, Year::of($year)->isLeap());
     }
 
-    public function providerIsLeap() : array
+    public function providerIsLeap(): array
     {
         return [
             [1595, false],
@@ -150,7 +155,7 @@ class YearTest extends AbstractTestCase
         $this->assertSame($isValid, Year::of($year)->isValidMonthDay(MonthDay::of($month, $day)));
     }
 
-    public function providerIsValidMonthDay() : array
+    public function providerIsValidMonthDay(): array
     {
         return [
             [1999, 1, 31, true],
@@ -176,7 +181,7 @@ class YearTest extends AbstractTestCase
         $this->assertSame($length, Year::of($year)->getLength());
     }
 
-    public function providerGetLength() : array
+    public function providerGetLength(): array
     {
         return [
             [1595, 365],
@@ -245,7 +250,7 @@ class YearTest extends AbstractTestCase
         $this->assertYearIs($expectedYear, Year::of($year)->plus($plusYears));
     }
 
-    public function providerPlus() : array
+    public function providerPlus(): array
     {
         return [
             [2014, 0, 2014],
@@ -262,7 +267,7 @@ class YearTest extends AbstractTestCase
         $this->assertYearIs($expectedYear, Year::of($year)->minus($minusYears));
     }
 
-    public function providerMinus() : array
+    public function providerMinus(): array
     {
         return [
             [2014, 0, 2014],
@@ -319,7 +324,7 @@ class YearTest extends AbstractTestCase
         $this->assertSame($cmp === -1, Year::of($year1)->isBefore(Year::of($year2)));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             [-1999, -1999, 0],
@@ -363,7 +368,7 @@ class YearTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $month, $day, Year::of($year)->atDay($dayOfYear));
     }
 
-    public function providerAtDay() : array
+    public function providerAtDay(): array
     {
         return [
             [2007, 59, 2, 28],
@@ -397,7 +402,7 @@ class YearTest extends AbstractTestCase
         Year::of(2000)->atMonth($invalidMonth);
     }
 
-    public function providerAtInvalidMonthThrowsException() : array
+    public function providerAtInvalidMonthThrowsException(): array
     {
         return [
             [-1],
@@ -420,7 +425,7 @@ class YearTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $month, $expectedDay, Year::of($year)->atMonthDay($monthDay));
     }
 
-    public function providerAtMonthDay() : array
+    public function providerAtMonthDay(): array
     {
         return [
             [2007, 2, 28, 28],
@@ -434,14 +439,11 @@ class YearTest extends AbstractTestCase
     }
 
     /**
-     * @param int $year
-     * @param string $expectedRange
-     * @return void
      * @dataProvider providerToLocalDateRange
      */
     public function testToLocalDateRange(int $year, string $expectedRange): void
     {
-        $this->assertSame($expectedRange, (string)Year::of($year)->toLocalDateRange());
+        $this->assertSame($expectedRange, (string) Year::of($year)->toLocalDateRange());
     }
 
     public function providerToLocalDateRange(): array

--- a/tests/YearWeekTest.php
+++ b/tests/YearWeekTest.php
@@ -4,21 +4,23 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Tests;
 
+use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\DateTimeException;
 use Brick\DateTime\DayOfWeek;
-use Brick\DateTime\LocalDateRange;
-use Brick\DateTime\YearWeek;
-use Brick\DateTime\TimeZone;
-use Brick\DateTime\LocalDate;
-use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\Instant;
+use Brick\DateTime\LocalDate;
+use Brick\DateTime\LocalDateRange;
+use Brick\DateTime\TimeZone;
+use Brick\DateTime\YearWeek;
+
+use function json_encode;
 
 /**
  * Unit tests for class YearWeek.
  */
 class YearWeekTest extends AbstractTestCase
 {
-    public function provider53WeekYear() : array
+    public function provider53WeekYear(): array
     {
         return [
             [4],
@@ -115,7 +117,7 @@ class YearWeekTest extends AbstractTestCase
         $this->assertLocalDateIs($year, $month, $dayOfMonth, $actual);
     }
 
-    public function providerAtDay() : array
+    public function providerAtDay(): array
     {
         return [
             [2014, 52, DayOfWeek::MONDAY,    2014, 12, 22],
@@ -191,17 +193,7 @@ class YearWeekTest extends AbstractTestCase
         }
     }
 
-    private function assertCompareTo(int $expected, YearWeek $a, YearWeek $b): void
-    {
-        $this->assertSame($expected, $a->compareTo($b));
-        $this->assertSame($expected === -1 || $expected === 0, $a->isBeforeOrEqualTo($b));
-        $this->assertSame($expected === -1, $a->isBefore($b));
-        $this->assertSame($expected === 0, $a->isEqualTo($b));
-        $this->assertSame($expected === 1, $a->isAfter($b));
-        $this->assertSame($expected === 1 || $expected === 0, $a->isAfterOrEqualTo($b));
-    }
-
-    public function providerWithYear() : array
+    public function providerWithYear(): array
     {
         return [
             [2015,  1, 2015, 2015,  1],
@@ -220,7 +212,7 @@ class YearWeekTest extends AbstractTestCase
         $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
-    public function providerWithWeek() : array
+    public function providerWithWeek(): array
     {
         return [
             [2014,  1, 53, 2015,  1],
@@ -238,7 +230,7 @@ class YearWeekTest extends AbstractTestCase
         $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
-    public function providerPlusYears() : array
+    public function providerPlusYears(): array
     {
         return [
             [2015, 1, -2, 2013, 1],
@@ -272,7 +264,7 @@ class YearWeekTest extends AbstractTestCase
         $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
-    public function providerPlusWeeks() : array
+    public function providerPlusWeeks(): array
     {
         return [
             [2015, 1, -261, 2009, 53],
@@ -309,20 +301,20 @@ class YearWeekTest extends AbstractTestCase
         $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
-    public function providerToString() : array
+    public function providerToString(): array
     {
         return [
             [-12345,  1, '-12345-W01'],
-            [ -1234, 12,  '-1234-W12'],
-            [  -123,  3,  '-0123-W03'],
-            [   -12, 10,  '-0012-W10'],
-            [    -1,  9,  '-0001-W09'],
-            [     0, 11,   '0000-W11'],
-            [     1,  7,   '0001-W07'],
-            [    12, 10,   '0012-W10'],
-            [   123,  4,   '0123-W04'],
-            [  1234, 12,   '1234-W12'],
-            [ 12345,  8,  '12345-W08'],
+            [-1234, 12,  '-1234-W12'],
+            [-123,  3,  '-0123-W03'],
+            [-12, 10,  '-0012-W10'],
+            [-1,  9,  '-0001-W09'],
+            [0, 11,   '0000-W11'],
+            [1,  7,   '0001-W07'],
+            [12, 10,   '0012-W10'],
+            [123,  4,   '0123-W04'],
+            [1234, 12,   '1234-W12'],
+            [12345,  8,  '12345-W08'],
         ];
     }
 
@@ -371,22 +363,16 @@ class YearWeekTest extends AbstractTestCase
 
     /**
      * @dataProvider providerGetFirstLastDay
-     *
-     * @param int $year
-     * @param int $week
-     * @param string $firstDay
-     * @param string $lastDay
-     * @return void
      */
     public function testToLocalDateRange(int $year, int $week, string $firstDay, string $lastDay): void
     {
         $yearWeek = YearWeek::of($year, $week);
-        $expectedDateRange = (string)LocalDateRange::parse($firstDay . '/' . $lastDay);
+        $expectedDateRange = (string) LocalDateRange::parse($firstDay . '/' . $lastDay);
 
-        $this->assertEquals($expectedDateRange, (string)$yearWeek->toLocalDateRange());
+        $this->assertSame($expectedDateRange, (string) $yearWeek->toLocalDateRange());
     }
 
-    public function providerGetFirstLastDay() : array
+    public function providerGetFirstLastDay(): array
     {
         return [
             [2000,  1, '2000-01-03', '2000-01-09'],
@@ -474,5 +460,15 @@ class YearWeekTest extends AbstractTestCase
             [2020, 52, '2020-12-21', '2020-12-27'],
             [2020, 53, '2020-12-28', '2021-01-03'],
         ];
+    }
+
+    private function assertCompareTo(int $expected, YearWeek $a, YearWeek $b): void
+    {
+        $this->assertSame($expected, $a->compareTo($b));
+        $this->assertSame($expected === -1 || $expected === 0, $a->isBeforeOrEqualTo($b));
+        $this->assertSame($expected === -1, $a->isBefore($b));
+        $this->assertSame($expected === 0, $a->isEqualTo($b));
+        $this->assertSame($expected === 1, $a->isAfter($b));
+        $this->assertSame($expected === 1 || $expected === 0, $a->isAfterOrEqualTo($b));
     }
 }

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -4,18 +4,23 @@ declare(strict_types=1);
 
 namespace Brick\DateTime\Tests;
 
+use Brick\DateTime\Clock\FixedClock;
+use Brick\DateTime\DayOfWeek;
+use Brick\DateTime\Duration;
 use Brick\DateTime\Instant;
-use Brick\DateTime\LocalDateTime;
 use Brick\DateTime\LocalDate;
+use Brick\DateTime\LocalDateTime;
 use Brick\DateTime\LocalTime;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Period;
-use Brick\DateTime\Duration;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\TimeZoneOffset;
 use Brick\DateTime\ZonedDateTime;
-use Brick\DateTime\DayOfWeek;
-use Brick\DateTime\Clock\FixedClock;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+
+use function json_encode;
 
 /**
  * Unit tests for class ZonedDateTime.
@@ -52,7 +57,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $this->assertSame($nanoOfSecond, $zonedDateTime->getNano());
     }
 
-    public function providerOf() : array
+    public function providerOf(): array
     {
         return [
             // WITH OFFSET FROM UTC
@@ -331,7 +336,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $this->assertSame($formattedDatetime, (string) $zonedDateTime->getDateTime());
     }
 
-    public function providerOfInstant() : array
+    public function providerOfInstant(): array
     {
         return [
             ['2001-09-09T01:46:40', 'UTC'],
@@ -358,7 +363,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $this->assertSame($zone, (string) $zonedDateTime->getTimeZone());
     }
 
-    public function providerParse() : array
+    public function providerParse(): array
     {
         return [
             ['2001-02-03T01:02Z', '2001-02-03', '01:02', 'Z', 'Z'],
@@ -383,7 +388,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         ZonedDateTime::parse($text);
     }
 
-    public function providerParseInvalidStringThrowsException() : array
+    public function providerParseInvalidStringThrowsException(): array
     {
         return [
             [''],
@@ -415,11 +420,11 @@ class ZonedDateTimeTest extends AbstractTestCase
      */
     public function testFromDateTime(string $dateTimeString, string $timeZone, string $expected): void
     {
-        $dateTime = new \DateTime($dateTimeString, new \DateTimeZone($timeZone));
+        $dateTime = new DateTime($dateTimeString, new DateTimeZone($timeZone));
         $this->assertIs(ZonedDateTime::class, $expected, ZonedDateTime::fromDateTime($dateTime));
     }
 
-    public function providerFromDateTime() : array
+    public function providerFromDateTime(): array
     {
         return [
             ['2018-07-21 14:09:10.23456', 'America/Los_Angeles', '2018-07-21T14:09:10.23456-07:00[America/Los_Angeles]'],
@@ -474,7 +479,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $this->assertSame($cmp <= 0, $z2->isAfterOrEqualTo($z1));
     }
 
-    public function providerCompareTo() : array
+    public function providerCompareTo(): array
     {
         return [
             ['2020-06-06T14:30:30Z', '2014-12-31T23:59:59.999Z', 1],
@@ -487,14 +492,6 @@ class ZonedDateTimeTest extends AbstractTestCase
             ['2020-06-06T14:30:30Z', '2020-06-06T15:30:30+02:00', 1],
             ['2020-06-06T14:30:30Z', '2020-06-06T13:30:30-02:00', -1],
         ];
-    }
-
-    private function getTestZonedDateTime() : ZonedDateTime
-    {
-        $timeZone = TimeZone::parse('America/Los_Angeles');
-        $localDateTime = LocalDateTime::parse('2000-01-20T12:34:56.123456789');
-
-        return ZonedDateTime::of($localDateTime, $timeZone);
     }
 
     public function testGetYear(): void
@@ -760,7 +757,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $zonedDateTime = ZonedDateTime::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTime();
 
-        $this->assertInstanceOf(\DateTime::class, $dateTime);
+        $this->assertInstanceOf(DateTime::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -775,7 +772,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $zonedDateTime = ZonedDateTime::parse($dateTime);
         $dateTime = $zonedDateTime->toDateTimeImmutable();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
         $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
@@ -811,5 +808,13 @@ class ZonedDateTimeTest extends AbstractTestCase
         $zonedDateTime = ZonedDateTime::of($localDateTime, $timeZone);
 
         $this->assertSame('2000-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', (string) $zonedDateTime);
+    }
+
+    private function getTestZonedDateTime(): ZonedDateTime
+    {
+        $timeZone = TimeZone::parse('America/Los_Angeles');
+        $localDateTime = LocalDateTime::parse('2000-01-20T12:34:56.123456789');
+
+        return ZonedDateTime::of($localDateTime, $timeZone);
     }
 }

--- a/tools/ecs/composer.json
+++ b/tools/ecs/composer.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "symplify/easy-coding-standard": "^10.3",
+        "slevomat/coding-standard": "^7.2",
+        "squizlabs/php_codesniffer": "^3.7"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}

--- a/tools/ecs/ecs.php
+++ b/tools/ecs/ecs.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentSniff;
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer;
+use PhpCsFixer\Fixer\ArrayNotation\NoTrailingCommaInSinglelineArrayFixer;
+use PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer;
+use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
+use PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer;
+use PhpCsFixer\Fixer\Casing\LowercaseStaticReferenceFixer;
+use PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer;
+use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
+use PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer;
+use PhpCsFixer\Fixer\CastNotation\ModernizeTypesCastingFixer;
+use PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer;
+use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
+use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
+use PhpCsFixer\Fixer\Comment\CommentToPhpdocFixer;
+use PhpCsFixer\Fixer\Comment\SingleLineCommentStyleFixer;
+use PhpCsFixer\Fixer\ConstantNotation\NativeConstantInvocationFixer;
+use PhpCsFixer\Fixer\ControlStructure\IncludeFixer;
+use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
+use PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer;
+use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToParamTypeFixer;
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer;
+use PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer;
+use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
+use PhpCsFixer\Fixer\ListNotation\ListSyntaxFixer;
+use PhpCsFixer\Fixer\NamespaceNotation\SingleBlankLineBeforeNamespaceFixer;
+use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
+use PhpCsFixer\Fixer\Operator\NewWithBracesFixer;
+use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
+use PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer;
+use PhpCsFixer\Fixer\Operator\StandardizeIncrementFixer;
+use PhpCsFixer\Fixer\Operator\TernaryOperatorSpacesFixer;
+use PhpCsFixer\Fixer\Operator\TernaryToNullCoalescingFixer;
+use PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer;
+use PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer;
+use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocNoUselessInheritdocFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderByValueFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocReturnSelfReferenceFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSingleLineVarSpacingFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSummaryFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTagCasingFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesOrderFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer;
+use PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertInternalTypeFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
+use PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer;
+use PhpCsFixer\Fixer\Semicolon\NoSinglelineWhitespaceBeforeSemicolonsFixer;
+use PhpCsFixer\Fixer\Semicolon\SemicolonAfterInstructionFixer;
+use PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
+use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
+use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
+use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
+use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
+use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff;
+use SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff;
+use SlevomatCodingStandard\Sniffs\Namespaces\UseSpacingSniff;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ECSConfig $ecsConfig): void {
+    $libRootPath = __DIR__ . '/../../';
+
+    $ecsConfig->paths(
+        [
+            $libRootPath . '/src',
+            $libRootPath . '/tests',
+            __FILE__
+        ]
+    );
+
+    $ecsConfig->indentation('spaces');
+
+    // PHP-CS-Fixer
+    $ecsConfig->skip([
+        // Allows tree building method chaining syntax for better readability
+        MethodChainingIndentationFixer::class => [$libRootPath . '/src/Parser/IsoParsers.php'],
+
+        // Allows microtime() to be called from class namespace so that it can be overridden
+        // and its return value mocked in SystemClockTest
+        ReferenceUsedNamesOnlySniff::class => [$libRootPath . '/src/Clock/SystemClock.php'],
+
+        // Only interested in FunctionCommentSniff.ParamCommentFullStop, excludes the rest
+        FunctionCommentSniff::class . '.Missing' => null,
+        FunctionCommentSniff::class . '.MissingReturn' => null,
+        FunctionCommentSniff::class . '.MissingParamTag' => null,
+        FunctionCommentSniff::class . '.EmptyThrows' => null,
+        FunctionCommentSniff::class . '.IncorrectParamVarName' => null,
+        FunctionCommentSniff::class . '.IncorrectTypeHint' => null,
+        FunctionCommentSniff::class . '.MissingParamComment' => null,
+        FunctionCommentSniff::class . '.ParamNameNoMatch' => null,
+        FunctionCommentSniff::class . '.InvalidReturn' => null,
+
+        // Keep a line between same use types, spacing around uses is done in other fixers
+        UseSpacingSniff::class . '.IncorrectLinesCountBeforeFirstUse' => null,
+        UseSpacingSniff::class . '.IncorrectLinesCountAfterLastUse' => null,
+    ]);
+
+    $ecsConfig->sets([
+        SetList::PSR_12
+    ]);
+
+    $ecsConfig->rules(
+        [
+            NoUnusedImportsFixer::class,
+            BlankLineBeforeStatementFixer::class,
+            CastSpacesFixer::class,
+            CommentToPhpdocFixer::class,
+            DeclareStrictTypesFixer::class,
+            FunctionTypehintSpaceFixer::class,
+            LinebreakAfterOpeningTagFixer::class,
+            LowercaseStaticReferenceFixer::class,
+            LowercaseCastFixer::class,
+            MethodChainingIndentationFixer::class,
+            NativeFunctionCasingFixer::class,
+            NativeConstantInvocationFixer::class,
+            NewWithBracesFixer::class,
+            ModernizeTypesCastingFixer::class,
+            NoEmptyStatementFixer::class,
+            NoExtraBlankLinesFixer::class,
+            NoMultilineWhitespaceAroundDoubleArrowFixer::class,
+            NoSinglelineWhitespaceBeforeSemicolonsFixer::class,
+            ObjectOperatorWithoutWhitespaceFixer::class,
+            PhpUnitDedicateAssertFixer::class,
+            PhpUnitDedicateAssertInternalTypeFixer::class,
+            PhpUnitExpectationFixer::class,
+            NotOperatorWithSuccessorSpaceFixer::class,
+            PhpUnitStrictFixer::class,
+            PhpdocAddMissingParamAnnotationFixer::class,
+            PhpdocToParamTypeFixer::class,
+            PhpdocToPropertyTypeFixer::class,
+            PhpdocToReturnTypeFixer::class,
+            PhpdocAlignFixer::class,
+            NoEmptyPhpdocFixer::class,
+            PhpdocIndentFixer::class,
+            TrimArraySpacesFixer::class,
+            PhpdocNoEmptyReturnFixer::class,
+            StandardizeIncrementFixer::class,
+            IncludeFixer::class,
+            PhpdocNoUselessInheritdocFixer::class,
+            NoUnneededControlParenthesesFixer::class,
+            NoLeadingImportSlashFixer::class,
+            PhpdocOrderByValueFixer::class,
+            PhpdocReturnSelfReferenceFixer::class,
+            PhpdocScalarFixer::class,
+            PhpdocSeparationFixer::class,
+            PhpdocSingleLineVarSpacingFixer::class,
+            PhpdocTagCasingFixer::class,
+            PhpdocSummaryFixer::class,
+            PhpdocTrimFixer::class,
+            PhpdocTypesFixer::class,
+            PhpdocVarAnnotationCorrectOrderFixer::class,
+            BinaryOperatorSpacesFixer::class,
+            SingleQuoteFixer::class,
+            SemicolonAfterInstructionFixer::class,
+            ReturnTypeDeclarationFixer::class,
+            ShortScalarCastFixer::class,
+            SingleBlankLineBeforeNamespaceFixer::class,
+            SingleLineCommentStyleFixer::class,
+            PsrAutoloadingFixer::class,
+            SpaceAfterSemicolonFixer::class,
+            NoWhitespaceInBlankLineFixer::class,
+            StrictComparisonFixer::class,
+            TernaryOperatorSpacesFixer::class,
+            TernaryToNullCoalescingFixer::class,
+            VoidReturnFixer::class,
+            UnaryOperatorSpacesFixer::class,
+            WhitespaceAfterCommaInArrayFixer::class,
+            NoTrailingCommaInSinglelineArrayFixer::class,
+        ]
+    );
+
+    $ecsConfig->ruleWithConfiguration(ListSyntaxFixer::class, ['syntax' => 'short']);
+    $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, ['on_multiline' => 'ensure_fully_multiline']);
+    $ecsConfig->ruleWithConfiguration(OrderedClassElementsFixer::class, ['order' => ['use_trait', 'case', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'phpunit', 'method_public', 'magic', 'method_protected', 'method_private', 'destruct']]);
+    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, ['syntax' => 'short']);
+    $ecsConfig->ruleWithConfiguration(PhpUnitTestCaseStaticMethodCallsFixer::class, ['call_type' => 'this']);
+    $ecsConfig->ruleWithConfiguration(PhpdocTypesOrderFixer::class, ['null_adjustment' => 'always_last']);
+    $ecsConfig->ruleWithConfiguration(NoSuperfluousPhpdocTagsFixer::class, ['allow_mixed' => true]);
+    $ecsConfig->ruleWithConfiguration(ClassAttributesSeparationFixer::class, ['elements' => ['method' => 'one', 'property' => 'one']]);
+
+    // PHPCS
+
+    $ecsConfig->rules(
+        [
+            FunctionCommentSniff::class,
+        ]
+    );
+
+    $ecsConfig->ruleWithConfiguration(
+        DocCommentSpacingSniff::class,
+        [
+        'linesCountBetweenAnnotationsGroups' => 1,
+        'annotationsGroups' => [
+            '@todo',
+            '@internal,@deprecated',
+            '@link,@see,@uses',
+            '@dataProvider',
+            '@param',
+            '@return',
+            '@throws'
+            ]
+        ]
+    );
+
+    $ecsConfig->ruleWithConfiguration(
+        ReferenceUsedNamesOnlySniff::class,
+        [
+            'allowFallbackGlobalConstants' => false,
+            'allowFallbackGlobalFunctions' => false,
+            'allowFullyQualifiedGlobalClasses' => false,
+            'allowFullyQualifiedGlobalConstants' => false,
+            'allowFullyQualifiedGlobalFunctions' => false,
+            'allowFullyQualifiedNameForCollidingClasses' => true,
+            'allowFullyQualifiedNameForCollidingConstants' => true,
+            'allowFullyQualifiedNameForCollidingFunctions' => true,
+            'searchAnnotations' => true,
+        ]
+    );
+
+    $ecsConfig->ruleWithConfiguration(
+        UseSpacingSniff::class,
+        [
+            'linesCountAfterLastUse' => 0,
+            'linesCountBetweenUseTypes' => 1,
+            'linesCountBeforeFirstUse' => 0,
+        ]
+    );
+};


### PR DESCRIPTION
Hello @BenMorel !

As discussed together, here's the first step towards contributing more and more.

Styling is always subject to preferences and I'm suggesting the ones I'm using in my own libs here. So feel free to make the final decision on each, whether you want to keep them or not.

I've chosen to `allow-risky` because IMO tests should cover any unexpected change of logic while using a formatting tool.

To ease the review, here's the list of the most controversial rules applied here:

- ordered_class_elements
- return_type_declaration (no space before)
- phpdoc_order (throws before return)
- native_function_invocation

You can find them here: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/index.rst
 
I've also split the Psalm and Unit tests into 2 workflows to parallelized the checks and halves execution time.