### PR TITLE
Add ZonedDateTime::getDurationTo method

### DIFF
--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -436,6 +436,15 @@ class ZonedDateTime implements JsonSerializable
     }
 
     /**
+     * Returns Duration between current and second ZonedDataTime
+     * Duration will be negative if second ZonedDateTime before current
+     */
+    public function getDurationTo(ZonedDateTime $secondZonedDateTime): Duration
+    {
+        return Duration::between($this->getInstant(), $secondZonedDateTime->getInstant());
+    }
+
+    /**
      * Returns a copy of this ZonedDateTime with the specified period in years added.
      */
     public function plusYears(int $years): ZonedDateTime

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -436,8 +436,8 @@ class ZonedDateTime implements JsonSerializable
     }
 
     /**
-     * Returns Duration between current and second ZonedDataTime
-     * Duration will be negative if second ZonedDateTime before current
+     * Returns a Duration representing the time elapsed between this ZonedDateTime and the given one.
+     * This method will return a negative duration if the given ZonedDateTime is before the current one.
      */
     public function getDurationTo(ZonedDateTime $secondZonedDateTime): Duration
     {

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -439,9 +439,9 @@ class ZonedDateTime implements JsonSerializable
      * Returns a Duration representing the time elapsed between this ZonedDateTime and the given one.
      * This method will return a negative duration if the given ZonedDateTime is before the current one.
      */
-    public function getDurationTo(ZonedDateTime $secondZonedDateTime): Duration
+    public function getDurationTo(ZonedDateTime $that): Duration
     {
-        return Duration::between($this->getInstant(), $secondZonedDateTime->getInstant());
+        return Duration::between($this->getInstant(), $that->getInstant());
     }
 
     /**

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -834,14 +834,6 @@ class ZonedDateTimeTest extends AbstractTestCase
         $this->assertSame('2000-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', (string) $zonedDateTime);
     }
 
-    private function getTestZonedDateTime(): ZonedDateTime
-    {
-        $timeZone = TimeZone::parse('America/Los_Angeles');
-        $localDateTime = LocalDateTime::parse('2000-01-20T12:34:56.123456789');
-
-        return ZonedDateTime::of($localDateTime, $timeZone);
-    }
-
     /**
      * @dataProvider providerGetDurationTo
      */
@@ -863,5 +855,13 @@ class ZonedDateTimeTest extends AbstractTestCase
             ['2023-01-01T10:00:00Z',            '2023-01-02T10:00:00Z',             Duration::ofSeconds(24 * 60 * 60)],
             ['2023-01-02T10:00:00Z',            '2023-01-01T10:00:00Z',             Duration::ofSeconds(-24 * 60 * 60)],
         ];
+    }
+
+    private function getTestZonedDateTime(): ZonedDateTime
+    {
+        $timeZone = TimeZone::parse('America/Los_Angeles');
+        $localDateTime = LocalDateTime::parse('2000-01-20T12:34:56.123456789');
+
+        return ZonedDateTime::of($localDateTime, $timeZone);
     }
 }

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -841,4 +841,27 @@ class ZonedDateTimeTest extends AbstractTestCase
 
         return ZonedDateTime::of($localDateTime, $timeZone);
     }
+
+    /**
+     * @dataProvider providerGetDurationTo
+     */
+    public function testGetDurationTo(string $firstDate, string $secondDate, Duration $expectedResult): void
+    {
+        $actualResult = ZonedDateTime::parse($firstDate)->getDurationTo(ZonedDateTime::parse($secondDate));
+
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    public function providerGetDurationTo(): array
+    {
+        return [
+            ['2023-01-01T10:00:00Z',            '2023-01-01T10:00:00Z',             Duration::ofSeconds(0)],
+            ['2023-01-01T10:00:00Z',            '2023-01-01T10:00:10Z',             Duration::ofSeconds(10)],
+            ['2023-01-01T10:00:00.001Z',        '2023-01-01T10:00:10.002Z',         Duration::ofSeconds(10, 1000000)],
+            ['2023-01-01T10:00:00.001Z',        '2023-01-01T13:00:10.002+03:00',    Duration::ofSeconds(10, 1000000)],
+            ['2023-01-01T10:00:00.000000001Z',  '2023-01-01T10:00:00.000000009Z',   Duration::ofSeconds(0, 8)],
+            ['2023-01-01T10:00:00Z',            '2023-01-02T10:00:00Z',             Duration::ofSeconds(24*60*60)],
+            ['2023-01-02T10:00:00Z',            '2023-01-01T10:00:00Z',             Duration::ofSeconds(-24*60*60)],
+        ];
+    }
 }

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -849,7 +849,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     {
         $actualResult = ZonedDateTime::parse($firstDate)->getDurationTo(ZonedDateTime::parse($secondDate));
 
-        $this->assertEquals($expectedResult, $actualResult);
+        $this->assertDurationIs($expectedResult->getSeconds(), $expectedResult->getNanos(), $actualResult);
     }
 
     public function providerGetDurationTo(): array
@@ -860,8 +860,8 @@ class ZonedDateTimeTest extends AbstractTestCase
             ['2023-01-01T10:00:00.001Z',        '2023-01-01T10:00:10.002Z',         Duration::ofSeconds(10, 1000000)],
             ['2023-01-01T10:00:00.001Z',        '2023-01-01T13:00:10.002+03:00',    Duration::ofSeconds(10, 1000000)],
             ['2023-01-01T10:00:00.000000001Z',  '2023-01-01T10:00:00.000000009Z',   Duration::ofSeconds(0, 8)],
-            ['2023-01-01T10:00:00Z',            '2023-01-02T10:00:00Z',             Duration::ofSeconds(24*60*60)],
-            ['2023-01-02T10:00:00Z',            '2023-01-01T10:00:00Z',             Duration::ofSeconds(-24*60*60)],
+            ['2023-01-01T10:00:00Z',            '2023-01-02T10:00:00Z',             Duration::ofSeconds(24 * 60 * 60)],
+            ['2023-01-02T10:00:00Z',            '2023-01-01T10:00:00Z',             Duration::ofSeconds(-24 * 60 * 60)],
         ];
     }
 }

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -837,23 +837,23 @@ class ZonedDateTimeTest extends AbstractTestCase
     /**
      * @dataProvider providerGetDurationTo
      */
-    public function testGetDurationTo(string $firstDate, string $secondDate, Duration $expectedResult): void
+    public function testGetDurationTo(string $firstDate, string $secondDate, int $expectedSeconds, int $expectedNanos): void
     {
         $actualResult = ZonedDateTime::parse($firstDate)->getDurationTo(ZonedDateTime::parse($secondDate));
 
-        $this->assertDurationIs($expectedResult->getSeconds(), $expectedResult->getNanos(), $actualResult);
+        $this->assertDurationIs($expectedSeconds, $expectedNanos, $actualResult);
     }
 
     public function providerGetDurationTo(): array
     {
         return [
-            ['2023-01-01T10:00:00Z',            '2023-01-01T10:00:00Z',             Duration::ofSeconds(0)],
-            ['2023-01-01T10:00:00Z',            '2023-01-01T10:00:10Z',             Duration::ofSeconds(10)],
-            ['2023-01-01T10:00:00.001Z',        '2023-01-01T10:00:10.002Z',         Duration::ofSeconds(10, 1000000)],
-            ['2023-01-01T10:00:00.001Z',        '2023-01-01T13:00:10.002+03:00',    Duration::ofSeconds(10, 1000000)],
-            ['2023-01-01T10:00:00.000000001Z',  '2023-01-01T10:00:00.000000009Z',   Duration::ofSeconds(0, 8)],
-            ['2023-01-01T10:00:00Z',            '2023-01-02T10:00:00Z',             Duration::ofSeconds(24 * 60 * 60)],
-            ['2023-01-02T10:00:00Z',            '2023-01-01T10:00:00Z',             Duration::ofSeconds(-24 * 60 * 60)],
+            ['2023-01-01T10:00:00Z',           '2023-01-01T10:00:00Z',           0, 0],
+            ['2023-01-01T10:00:00Z',           '2023-01-01T10:00:10Z',           10, 0],
+            ['2023-01-01T10:00:00.001Z',       '2023-01-01T10:00:10.002Z',       10, 1000000],
+            ['2023-01-01T10:00:00.001Z',       '2023-01-01T13:00:10.002+03:00',  10, 1000000],
+            ['2023-01-01T10:00:00.000000001Z', '2023-01-01T10:00:00.000000009Z', 0, 8],
+            ['2023-01-01T10:00:00Z',           '2023-01-02T10:00:00Z',           24 * 60 * 60, 0],
+            ['2023-01-02T10:00:00Z',           '2023-01-01T10:00:00Z',           -24 * 60 * 60, 0],
         ];
     }
 


### PR DESCRIPTION
Just more convenient way to get Duration between two ZonedDateTime

```php
$duration = Duration::between($first->getInstant(), $second->getInstant());
->
$duration = $first->getDurationTo($second);

```