### PR TITLE
[performance] Optimize minOf/maxOf methods.

### DIFF
--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -249,10 +249,10 @@ final class LocalDate implements JsonSerializable
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
         }
 
-        $min = LocalDate::max();
+        $min = null;
 
         foreach ($dates as $date) {
-            if ($date->isBefore($min)) {
+            if ($min === null || $date->isBefore($min)) {
                 $min = $date;
             }
         }
@@ -275,10 +275,10 @@ final class LocalDate implements JsonSerializable
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
         }
 
-        $max = LocalDate::min();
+        $max = null;
 
         foreach ($dates as $date) {
-            if ($date->isAfter($max)) {
+            if ($max === null || $date->isAfter($max)) {
                 $max = $date;
             }
         }

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -134,10 +134,10 @@ final class LocalDateTime implements JsonSerializable
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
         }
 
-        $min = LocalDateTime::max();
+        $min = null;
 
         foreach ($times as $time) {
-            if ($time->isBefore($min)) {
+            if ($min === null || $time->isBefore($min)) {
                 $min = $time;
             }
         }
@@ -160,10 +160,10 @@ final class LocalDateTime implements JsonSerializable
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
         }
 
-        $max = LocalDateTime::min();
+        $max = null;
 
         foreach ($times as $time) {
-            if ($time->isAfter($max)) {
+            if ($max === null || $time->isAfter($max)) {
                 $max = $time;
             }
         }

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -214,10 +214,10 @@ final class LocalTime implements JsonSerializable
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
         }
 
-        $min = LocalTime::max();
+        $min = null;
 
         foreach ($times as $time) {
-            if ($time->isBefore($min)) {
+            if ($min === null || $time->isBefore($min)) {
                 $min = $time;
             }
         }
@@ -240,10 +240,10 @@ final class LocalTime implements JsonSerializable
             throw new DateTimeException(__METHOD__ . ' does not accept less than 1 parameter.');
         }
 
-        $max = LocalTime::min();
+        $max = null;
 
         foreach ($times as $time) {
-            if ($time->isAfter($max)) {
+            if ($max === null || $time->isAfter($max)) {
                 $max = $time;
             }
         }


### PR DESCRIPTION
Hello there,

We're using this library quite extensively in our codebase, and often happen to call methods **a lot** (like 4 million times in a request), which allows us to witness a few performance bottlenecks. So here's a very simple one we thought we could address.

Creating a new instance of LocalDate/LocalDateTime/LocalTime using the min() and max() functions is unnecessary, and we can achieve the same behavior by using array_shift (extracting the first element of the array to have a reference point for further comparisons). And we don't need to take care of the "empty array" scenario, as there's already a condition above it that throws an Exception. Finally, cherry-on-the-cake, it makes one less loop iteration.

Credit goes to [@BastienClement](https://github.com/BastienClement).