### PR TITLE
[performance] Use static variables inside every singleton constructors.

### DIFF
--- a/src/Duration.php
+++ b/src/Duration.php
@@ -54,7 +54,14 @@ final class Duration implements JsonSerializable
      */
     public static function zero(): Duration
     {
-        return new Duration(0);
+        /** @var Duration|null $zero */
+        static $zero;
+
+        if ($zero) {
+            return $zero;
+        }
+
+        return $zero = new Duration(0);
     }
 
     /**

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -77,7 +77,14 @@ final class Instant implements JsonSerializable
 
     public static function epoch(): Instant
     {
-        return new Instant(0, 0);
+        /** @var Instant|null $epoch */
+        static $epoch;
+
+        if ($epoch) {
+            return $epoch;
+        }
+
+        return $epoch = new Instant(0, 0);
     }
 
     public static function now(?Clock $clock = null): Instant
@@ -96,7 +103,14 @@ final class Instant implements JsonSerializable
      */
     public static function min(): Instant
     {
-        return new Instant(PHP_INT_MIN, 0);
+        /** @var Instant|null $min */
+        static $min;
+
+        if ($min) {
+            return $min;
+        }
+
+        return $min = new Instant(PHP_INT_MIN, 0);
     }
 
     /**
@@ -106,7 +120,14 @@ final class Instant implements JsonSerializable
      */
     public static function max(): Instant
     {
-        return new Instant(PHP_INT_MAX, 999_999_999);
+        /** @var Instant|null $max */
+        static $max;
+
+        if ($max) {
+            return $max;
+        }
+
+        return $max = new Instant(PHP_INT_MAX, 999_999_999);
     }
 
     public function plus(Duration $duration): Instant

--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -221,7 +221,14 @@ final class LocalDate implements JsonSerializable
      */
     public static function min(): LocalDate
     {
-        return LocalDate::of(self::MIN_YEAR, 1, 1);
+        /** @var LocalDate|null $min */
+        static $min;
+
+        if ($min) {
+            return $min;
+        }
+
+        return $min = LocalDate::of(self::MIN_YEAR, 1, 1);
     }
 
     /**
@@ -231,7 +238,14 @@ final class LocalDate implements JsonSerializable
      */
     public static function max(): LocalDate
     {
-        return LocalDate::of(self::MAX_YEAR, 12, 31);
+        /** @var LocalDate|null $max */
+        static $max;
+
+        if ($max) {
+            return $max;
+        }
+
+        return $max = LocalDate::of(self::MAX_YEAR, 12, 31);
     }
 
     /**

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -108,7 +108,14 @@ final class LocalDateTime implements JsonSerializable
      */
     public static function min(): LocalDateTime
     {
-        return new LocalDateTime(LocalDate::min(), LocalTime::min());
+        /** @var LocalDateTime|null $min */
+        static $min;
+
+        if ($min) {
+            return $min;
+        }
+
+        return $min = new LocalDateTime(LocalDate::min(), LocalTime::min());
     }
 
     /**
@@ -116,7 +123,14 @@ final class LocalDateTime implements JsonSerializable
      */
     public static function max(): LocalDateTime
     {
-        return new LocalDateTime(LocalDate::max(), LocalTime::max());
+        /** @var LocalDateTime|null $max */
+        static $max;
+
+        if ($max) {
+            return $max;
+        }
+
+        return $max = new LocalDateTime(LocalDate::max(), LocalTime::max());
     }
 
     /**

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -175,12 +175,19 @@ final class LocalTime implements JsonSerializable
 
     public static function midnight(): LocalTime
     {
-        return new LocalTime(0, 0, 0, 0);
+        return self::min();
     }
 
     public static function noon(): LocalTime
     {
-        return new LocalTime(12, 0, 0, 0);
+        /** @var LocalTime|null $noon */
+        static $noon;
+
+        if ($noon) {
+            return $noon;
+        }
+
+        return $noon = new LocalTime(12, 0, 0, 0);
     }
 
     /**
@@ -188,7 +195,14 @@ final class LocalTime implements JsonSerializable
      */
     public static function min(): LocalTime
     {
-        return new LocalTime(0, 0, 0, 0);
+        /** @var LocalTime|null $min */
+        static $min;
+
+        if ($min) {
+            return $min;
+        }
+
+        return $min = new LocalTime(0, 0, 0, 0);
     }
 
     /**
@@ -196,7 +210,14 @@ final class LocalTime implements JsonSerializable
      */
     public static function max(): LocalTime
     {
-        return new LocalTime(23, 59, 59, 999_999_999);
+        /** @var LocalTime|null $max */
+        static $max;
+
+        if ($max) {
+            return $max;
+        }
+
+        return $max = new LocalTime(23, 59, 59, 999_999_999);
     }
 
     /**

--- a/src/Period.php
+++ b/src/Period.php
@@ -75,7 +75,14 @@ final class Period implements JsonSerializable
      */
     public static function zero(): Period
     {
-        return new Period(0, 0, 0);
+        /** @var Period|null $zero */
+        static $zero;
+
+        if ($zero) {
+            return $zero;
+        }
+
+        return $zero = new Period(0, 0, 0);
     }
 
     /**

--- a/src/TimeZoneOffset.php
+++ b/src/TimeZoneOffset.php
@@ -87,7 +87,14 @@ final class TimeZoneOffset extends TimeZone
 
     public static function utc(): TimeZoneOffset
     {
-        return new TimeZoneOffset(0);
+        /** @var TimeZoneOffset|null $utc */
+        static $utc;
+
+        if ($utc) {
+            return $utc;
+        }
+
+        return $utc = new TimeZoneOffset(0);
     }
 
     /**

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -25,7 +25,10 @@ class DurationTest extends AbstractTestCase
 {
     public function testZero(): void
     {
-        $this->assertDurationIs(0, 0, Duration::zero());
+        $zero = Duration::zero();
+
+        $this->assertDurationIs(0, 0, $zero);
+        $this->assertSame($zero, Duration::zero());
     }
 
     /**

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -52,7 +52,10 @@ class InstantTest extends AbstractTestCase
 
     public function testEpoch(): void
     {
-        $this->assertInstantIs(0, 0, Instant::epoch());
+        $epoch = Instant::epoch();
+
+        $this->assertInstantIs(0, 0, $epoch);
+        $this->assertSame($epoch, Instant::epoch());
     }
 
     public function testNow(): void
@@ -63,12 +66,18 @@ class InstantTest extends AbstractTestCase
 
     public function testMin(): void
     {
-        $this->assertInstantIs(PHP_INT_MIN, 0, Instant::min());
+        $min = Instant::min();
+
+        $this->assertInstantIs(PHP_INT_MIN, 0, $min);
+        $this->assertSame($min, Instant::min());
     }
 
     public function testMax(): void
     {
-        $this->assertInstantIs(PHP_INT_MAX, 999999999, Instant::max());
+        $max = Instant::max();
+
+        $this->assertInstantIs(PHP_INT_MAX, 999999999, $max);
+        $this->assertSame($max, Instant::max());
     }
 
     /**

--- a/tests/LocalDateTest.php
+++ b/tests/LocalDateTest.php
@@ -166,12 +166,18 @@ class LocalDateTest extends AbstractTestCase
 
     public function testMin(): void
     {
-        $this->assertLocalDateIs(Year::MIN_VALUE, 1, 1, LocalDate::min());
+        $min = LocalDate::min();
+
+        $this->assertLocalDateIs(Year::MIN_VALUE, 1, 1, $min);
+        $this->assertSame($min, LocalDate::min());
     }
 
     public function testMax(): void
     {
-        $this->assertLocalDateIs(Year::MAX_VALUE, 12, 31, LocalDate::max());
+        $max = LocalDate::max();
+
+        $this->assertLocalDateIs(Year::MAX_VALUE, 12, 31, $max);
+        $this->assertSame($max, LocalDate::max());
     }
 
     /**

--- a/tests/LocalDateTimeTest.php
+++ b/tests/LocalDateTimeTest.php
@@ -159,12 +159,18 @@ class LocalDateTimeTest extends AbstractTestCase
 
     public function testMin(): void
     {
-        $this->assertLocalDateTimeIs(Year::MIN_VALUE, 1, 1, 0, 0, 0, 0, LocalDateTime::min());
+        $min = LocalDateTime::min();
+
+        $this->assertLocalDateTimeIs(Year::MIN_VALUE, 1, 1, 0, 0, 0, 0, $min);
+        $this->assertSame($min, LocalDateTime::min());
     }
 
     public function testMax(): void
     {
-        $this->assertLocalDateTimeIs(Year::MAX_VALUE, 12, 31, 23, 59, 59, 999999999, LocalDateTime::max());
+        $max = LocalDateTime::max();
+
+        $this->assertLocalDateTimeIs(Year::MAX_VALUE, 12, 31, 23, 59, 59, 999999999, $max);
+        $this->assertSame($max, LocalDateTime::max());
     }
 
     public function testMinMaxOf(): void

--- a/tests/LocalTimeTest.php
+++ b/tests/LocalTimeTest.php
@@ -188,22 +188,34 @@ class LocalTimeTest extends AbstractTestCase
 
     public function testMidnight(): void
     {
-        $this->assertLocalTimeIs(0, 0, 0, 0, LocalTime::midnight());
+        $midnight = LocalTime::midnight();
+
+        $this->assertLocalTimeIs(0, 0, 0, 0, $midnight);
+        $this->assertSame($midnight, LocalTime::midnight());
     }
 
     public function testNoon(): void
     {
-        $this->assertLocalTimeIs(12, 0, 0, 0, LocalTime::noon());
+        $noon = LocalTime::noon();
+
+        $this->assertLocalTimeIs(12, 0, 0, 0, $noon);
+        $this->assertSame($noon, LocalTime::noon());
     }
 
     public function testMin(): void
     {
-        $this->assertLocalTimeIs(0, 0, 0, 0, LocalTime::min());
+        $min = LocalTime::min();
+
+        $this->assertLocalTimeIs(0, 0, 0, 0, $min);
+        $this->assertSame($min, LocalTime::min());
     }
 
     public function testMax(): void
     {
-        $this->assertLocalTimeIs(23, 59, 59, 999999999, LocalTime::max());
+        $max = LocalTime::max();
+
+        $this->assertLocalTimeIs(23, 59, 59, 999999999, $max);
+        $this->assertSame($max, LocalTime::max());
     }
 
     /**

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -46,7 +46,10 @@ class PeriodTest extends AbstractTestCase
 
     public function testZero(): void
     {
-        $this->assertPeriodIs(0, 0, 0, Period::zero());
+        $zero = Period::zero();
+
+        $this->assertPeriodIs(0, 0, 0, $zero);
+        $this->assertSame($zero, Period::zero());
     }
 
     /**

--- a/tests/TimeZoneOffsetTest.php
+++ b/tests/TimeZoneOffsetTest.php
@@ -139,7 +139,10 @@ class TimeZoneOffsetTest extends AbstractTestCase
 
     public function testUtc(): void
     {
-        $this->assertTimeZoneOffsetIs(0, TimeZoneOffset::utc());
+        $utc = TimeZoneOffset::utc();
+
+        $this->assertTimeZoneOffsetIs(0, $utc);
+        $this->assertSame($utc, TimeZoneOffset::utc());
     }
 
     /**

--- a/tests/TimeZoneTest.php
+++ b/tests/TimeZoneTest.php
@@ -68,7 +68,10 @@ class TimeZoneTest extends AbstractTestCase
 
     public function testUtc(): void
     {
-        $this->assertTimeZoneOffsetIs(0, TimeZone::utc());
+        $utc = TimeZone::utc();
+
+        $this->assertTimeZoneOffsetIs(0, $utc);
+        $this->assertSame($utc, TimeZone::utc());
     }
 
     public function testIsEqualTo(): void


### PR DESCRIPTION
Hello folks,

Here's another performance optimization when static constructors are called a lot. It was already done for some methods in the library, so I kept the same code style and applied it to all static constructors that take no arguments ("constants", in a way).

Let me know if you think some of these do not deserve it. I applied it everywhere without much thinking about it, because I don't think there's any downside of having that static variable, and I definitely know that some of these methods show up a lot in our benchmarks, like `TimeZone(Offset)::utc()` and `Duration::zero()`, `min()/max()`, etc, and then it's definitely beneficial.