### PR TITLE
ZonedDateTime::getIntervalTo and Instant::getIntervalTo

### DIFF
--- a/src/Instant.php
+++ b/src/Instant.php
@@ -334,6 +334,15 @@ final class Instant implements JsonSerializable
     }
 
     /**
+     * Returns Interval from this Instant and the given one (exclusive).
+     * @throws DateTimeException If given Instant is before that this Instant
+     * */
+    public function getIntervalTo(Instant $that): Interval
+    {
+        return Interval::of($this, $that);
+    }
+
+    /**
      * Returns a decimal representation of the timestamp represented by this instant.
      *
      * The output does not have trailing decimal zeros.

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -334,9 +334,10 @@ final class Instant implements JsonSerializable
     }
 
     /**
-     * Returns Interval from this Instant and the given one (exclusive).
-     * @throws DateTimeException If given Instant is before that this Instant
-     * */
+     * Returns an Interval from this Instant (inclusive) to the given one (exclusive).
+     *
+     * @throws DateTimeException If the given Instant is before this Instant.
+     */
     public function getIntervalTo(Instant $that): Interval
     {
         return Interval::of($this, $that);

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -436,9 +436,10 @@ class ZonedDateTime implements JsonSerializable
     }
 
     /**
-     * Returns Interval from this ZonedDateTime and the given one (exclusive).
-     * @throws DateTimeException If given date is before this date
-     * */
+     * Returns an Interval from this ZonedDateTime (inclusive) to the given one (exclusive).
+     *
+     * @throws DateTimeException If the given ZonedDateTime is before this ZonedDateTime.
+     */
     public function getIntervalTo(ZonedDateTime $that): Interval
     {
         return $this->getInstant()->getIntervalTo($that->getInstant());

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -436,6 +436,15 @@ class ZonedDateTime implements JsonSerializable
     }
 
     /**
+     * Returns Interval from this ZonedDateTime and the given one (exclusive).
+     * @throws DateTimeException If given date is before this date
+     * */
+    public function getIntervalTo(ZonedDateTime $that): Interval
+    {
+        return $this->getInstant()->getIntervalTo($that->getInstant());
+    }
+
+    /**
      * Returns a Duration representing the time elapsed between this ZonedDateTime and the given one.
      * This method will return a negative duration if the given ZonedDateTime is before the current one.
      */

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -586,11 +586,11 @@ class InstantTest extends AbstractTestCase
     /**
      * @dataProvider providerGetIntervalTo
      */
-    public function testGetIntervalTo(int $firstSecond, int $firstNano, int $secondSecond, int $secondNano, string $expectedInterval): void
+    public function testGetIntervalTo(int $second1, int $nano1, int $second2, int $nano2, string $expectedInterval): void
     {
-        $actualResult = Instant::of($firstSecond, $firstNano)->getIntervalTo(Instant::of($secondSecond, $secondNano));
+        $actualResult = Instant::of($second1, $nano1)->getIntervalTo(Instant::of($second2, $nano2));
 
-        $this->assertSame($expectedInterval, (string)$actualResult);
+        $this->assertSame($expectedInterval, (string) $actualResult);
     }
 
     public function providerGetIntervalTo(): array

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -584,6 +584,27 @@ class InstantTest extends AbstractTestCase
     }
 
     /**
+     * @dataProvider providerGetIntervalTo
+     */
+    public function testGetIntervalTo(int $firstSecond, int $firstNano, int $secondSecond, int $secondNano, string $expectedInterval): void
+    {
+        $actualResult = Instant::of($firstSecond, $firstNano)->getIntervalTo(Instant::of($secondSecond, $secondNano));
+
+        $this->assertSame($expectedInterval, (string)$actualResult);
+    }
+
+    public function providerGetIntervalTo(): array
+    {
+        return [
+            [1672567200, 0,       1672567200, 0,       '2023-01-01T10:00Z/2023-01-01T10:00Z'],
+            [1672567200, 0,       1672567210, 0,       '2023-01-01T10:00Z/2023-01-01T10:00:10Z'],
+            [1672567200, 1000000, 1672567210, 2000000, '2023-01-01T10:00:00.001Z/2023-01-01T10:00:10.002Z'],
+            [1672567200, 1,       1672567200, 9,       '2023-01-01T10:00:00.000000001Z/2023-01-01T10:00:00.000000009Z'],
+            [1672567200, 0,       1672653600, 0,       '2023-01-01T10:00Z/2023-01-02T10:00Z'],
+        ];
+    }
+
+    /**
      * @dataProvider providerToDecimal
      *
      * @param int    $second   The epoch second.

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -857,6 +857,29 @@ class ZonedDateTimeTest extends AbstractTestCase
         ];
     }
 
+    /**
+     * @dataProvider providerGetIntervalTo
+     */
+    public function testGetIntervalTo(string $firstDate, string $secondDate, string $expectedInterval): void
+    {
+        $actualResult = ZonedDateTime::parse($firstDate)->getIntervalTo(ZonedDateTime::parse($secondDate));
+
+        $this->assertSame($expectedInterval, (string)$actualResult);
+    }
+
+    public function providerGetIntervalTo(): array
+    {
+        return [
+            ['2023-01-01T10:00:00Z',           '2023-01-01T10:00:00Z',           '2023-01-01T10:00Z/2023-01-01T10:00Z'],
+            ['2023-01-01T10:00:00Z',           '2023-01-01T10:00:10Z',           '2023-01-01T10:00Z/2023-01-01T10:00:10Z'],
+            ['2023-01-01T10:00:00.001Z',       '2023-01-01T10:00:10.002Z',       '2023-01-01T10:00:00.001Z/2023-01-01T10:00:10.002Z'],
+            ['2023-01-01T10:00:00.001Z',       '2023-01-01T13:00:10.002+03:00',  '2023-01-01T10:00:00.001Z/2023-01-01T10:00:10.002Z'],
+            ['2023-01-01T10:00:00.001+03:00',  '2023-01-01T13:00:10.002+03:00',  '2023-01-01T07:00:00.001Z/2023-01-01T10:00:10.002Z'],
+            ['2023-01-01T10:00:00.000000001Z', '2023-01-01T10:00:00.000000009Z', '2023-01-01T10:00:00.000000001Z/2023-01-01T10:00:00.000000009Z'],
+            ['2023-01-01T10:00:00Z',           '2023-01-02T10:00:00Z',           '2023-01-01T10:00Z/2023-01-02T10:00Z'],
+        ];
+    }
+
     private function getTestZonedDateTime(): ZonedDateTime
     {
         $timeZone = TimeZone::parse('America/Los_Angeles');

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -864,7 +864,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     {
         $actualResult = ZonedDateTime::parse($firstDate)->getIntervalTo(ZonedDateTime::parse($secondDate));
 
-        $this->assertSame($expectedInterval, (string)$actualResult);
+        $this->assertSame($expectedInterval, (string) $actualResult);
     }
 
     public function providerGetIntervalTo(): array


### PR DESCRIPTION
More convenient way to get Interval from two ZonedDateTime.
```php
$a->getIntervalTo($b);
// vs old version
Interval::of($a->getInstant(), $b->getInstant())
```

relates to https://github.com/brick/date-time/pull/71