### PR TITLE
Call PHPUnit methods through `self::` instead of `$this->`

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -37,8 +37,8 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function assertIs(string $className, string $expectedString, object $object): void
     {
-        $this->assertInstanceOf($className, $object);
-        $this->assertSame($expectedString, (string) $object);
+        self::assertInstanceOf($className, $object);
+        self::assertSame($expectedString, (string) $object);
     }
 
     /**
@@ -115,7 +115,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function assertLocalDateTimeEquals(LocalDateTime $expected, LocalDateTime $actual): void
     {
-        $this->assertTrue($actual->isEqualTo($expected), "$actual != $expected");
+        self::assertTrue($actual->isEqualTo($expected), "$actual != $expected");
     }
 
     protected function assertYearIs(int $yearValue, Year $year): void
@@ -225,8 +225,8 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function assertLocalDateRangeIs(int $y1, int $m1, int $d1, int $y2, int $m2, int $d2, LocalDateRange $range): void
     {
-        $this->assertLocalDateIs($y1, $m1, $d1, $range->getStart());
-        $this->assertLocalDateIs($y2, $m2, $d2, $range->getEnd());
+        self::assertLocalDateIs($y1, $m1, $d1, $range->getStart());
+        self::assertLocalDateIs($y2, $m2, $d2, $range->getEnd());
     }
 
     /**
@@ -238,8 +238,8 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function assertYearMonthRangeIs(int $y1, int $m1, int $y2, int $m2, YearMonthRange $range): void
     {
-        $this->assertYearMonthIs($y1, $m1, $range->getStart());
-        $this->assertYearMonthIs($y2, $m2, $range->getEnd());
+        self::assertYearMonthIs($y1, $m1, $range->getStart());
+        self::assertYearMonthIs($y2, $m2, $range->getEnd());
     }
 
     /**
@@ -248,7 +248,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function assertTimeZoneEquals(TimeZone $expected, TimeZone $actual): void
     {
-        $this->assertTrue($actual->isEqualTo($expected), "$actual != $expected");
+        self::assertTrue($actual->isEqualTo($expected), "$actual != $expected");
     }
 
     /**
@@ -271,7 +271,7 @@ abstract class AbstractTestCase extends TestCase
         $message = $this->export($actual) . ' !== ' . $this->export($expected);
 
         foreach ($expected as $key => $value) {
-            $this->assertSame($value, $actual[$key], $message);
+            self::assertSame($value, $actual[$key], $message);
         }
     }
 

--- a/tests/Clock/FixedClockTest.php
+++ b/tests/Clock/FixedClockTest.php
@@ -16,6 +16,6 @@ class FixedClockTest extends AbstractTestCase
     public function testFixedClock(): void
     {
         $clock = new FixedClock(Instant::of(123456789, 987654321));
-        $this->assertInstantIs(123456789, 987654321, $clock->getTime());
+        self::assertInstantIs(123456789, 987654321, $clock->getTime());
     }
 }

--- a/tests/Clock/OffsetClockTest.php
+++ b/tests/Clock/OffsetClockTest.php
@@ -29,7 +29,7 @@ class OffsetClockTest extends AbstractTestCase
         $baseClock = new FixedClock(Instant::of($second, $nano));
         $clock = new OffsetClock($baseClock, Duration::parse($duration));
 
-        $this->assertInstantIs($expectedSecond, $expectedNano, $clock->getTime());
+        self::assertInstantIs($expectedSecond, $expectedNano, $clock->getTime());
     }
 
     public function providerOffsetClock(): array

--- a/tests/Clock/ScaleClockTest.php
+++ b/tests/Clock/ScaleClockTest.php
@@ -35,8 +35,8 @@ class ScaleClockTest extends AbstractTestCase
 
         $actualTime = $scaleClock->getTime();
 
-        $this->assertInstanceOf(Instant::class, $actualTime);
-        $this->assertSame($expectedInstant, $actualTime->toDecimal());
+        self::assertInstanceOf(Instant::class, $actualTime);
+        self::assertSame($expectedInstant, $actualTime->toDecimal());
     }
 
     public function providerScaleClock(): array

--- a/tests/Clock/SystemClockTest.php
+++ b/tests/Clock/SystemClockTest.php
@@ -28,7 +28,7 @@ namespace Brick\DateTime\Tests\Clock
         {
             $clock = new SystemClock();
 
-            $this->assertInstantIs(14079491701, 555276000, $clock->getTime());
+            self::assertInstantIs(14079491701, 555276000, $clock->getTime());
         }
     }
 }

--- a/tests/DayOfWeekTest.php
+++ b/tests/DayOfWeekTest.php
@@ -27,7 +27,7 @@ class DayOfWeekTest extends AbstractTestCase
      */
     public function testConstants(int $expectedValue, int $dayOfWeekConstant): void
     {
-        $this->assertSame($expectedValue, $dayOfWeekConstant);
+        self::assertSame($expectedValue, $dayOfWeekConstant);
     }
 
     public function providerConstants(): array
@@ -45,7 +45,7 @@ class DayOfWeekTest extends AbstractTestCase
 
     public function testOf(): void
     {
-        $this->assertDayOfWeekIs(5, DayOfWeek::of(5));
+        self::assertDayOfWeekIs(5, DayOfWeek::of(5));
     }
 
     /**
@@ -76,7 +76,7 @@ class DayOfWeekTest extends AbstractTestCase
     public function testNow(int $epochSecond, string $timeZone, int $expectedDayOfWeek): void
     {
         $clock = new FixedClock(Instant::of($epochSecond));
-        $this->assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::now(TimeZone::parse($timeZone), $clock));
+        self::assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::now(TimeZone::parse($timeZone), $clock));
     }
 
     public function providerNow(): array
@@ -97,7 +97,7 @@ class DayOfWeekTest extends AbstractTestCase
             $dayOfWeek = DayOfWeek::of($day);
 
             foreach (DayOfWeek::all($dayOfWeek) as $dow) {
-                $this->assertTrue($dow->isEqualTo($dayOfWeek));
+                self::assertTrue($dow->isEqualTo($dayOfWeek));
                 $dayOfWeek = $dayOfWeek->plus(1);
             }
         }
@@ -105,44 +105,44 @@ class DayOfWeekTest extends AbstractTestCase
 
     public function testMonday(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::MONDAY, DayOfWeek::monday());
+        self::assertDayOfWeekIs(DayOfWeek::MONDAY, DayOfWeek::monday());
     }
 
     public function testTuesday(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::TUESDAY, DayOfWeek::tuesday());
+        self::assertDayOfWeekIs(DayOfWeek::TUESDAY, DayOfWeek::tuesday());
     }
 
     public function testWednesday(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::WEDNESDAY, DayOfWeek::wednesday());
+        self::assertDayOfWeekIs(DayOfWeek::WEDNESDAY, DayOfWeek::wednesday());
     }
 
     public function testThursday(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::THURSDAY, DayOfWeek::thursday());
+        self::assertDayOfWeekIs(DayOfWeek::THURSDAY, DayOfWeek::thursday());
     }
 
     public function testFriday(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::FRIDAY, DayOfWeek::friday());
+        self::assertDayOfWeekIs(DayOfWeek::FRIDAY, DayOfWeek::friday());
     }
 
     public function testSaturday(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::SATURDAY, DayOfWeek::saturday());
+        self::assertDayOfWeekIs(DayOfWeek::SATURDAY, DayOfWeek::saturday());
     }
 
     public function testSunday(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::SUNDAY, DayOfWeek::sunday());
+        self::assertDayOfWeekIs(DayOfWeek::SUNDAY, DayOfWeek::sunday());
     }
 
     public function testIs(): void
     {
         for ($i = DayOfWeek::MONDAY; $i <= DayOfWeek::SUNDAY; $i++) {
             for ($j = DayOfWeek::MONDAY; $j <= DayOfWeek::SUNDAY; $j++) {
-                $this->assertSame($i === $j, DayOfWeek::of($i)->is($j));
+                self::assertSame($i === $j, DayOfWeek::of($i)->is($j));
             }
         }
     }
@@ -151,7 +151,7 @@ class DayOfWeekTest extends AbstractTestCase
     {
         for ($i = DayOfWeek::MONDAY; $i <= DayOfWeek::SUNDAY; $i++) {
             for ($j = DayOfWeek::MONDAY; $j <= DayOfWeek::SUNDAY; $j++) {
-                $this->assertSame($i === $j, DayOfWeek::of($i)->isEqualTo(DayOfWeek::of($j)));
+                self::assertSame($i === $j, DayOfWeek::of($i)->isEqualTo(DayOfWeek::of($j)));
             }
         }
     }
@@ -161,7 +161,7 @@ class DayOfWeekTest extends AbstractTestCase
      */
     public function testIsWeekday(DayOfWeek $dayOfWeek, bool $isWeekday): void
     {
-        $this->assertSame($isWeekday, $dayOfWeek->isWeekday());
+        self::assertSame($isWeekday, $dayOfWeek->isWeekday());
     }
 
     public function providerIsWeekday(): array
@@ -182,7 +182,7 @@ class DayOfWeekTest extends AbstractTestCase
      */
     public function testIsWeekend(DayOfWeek $dayOfWeek, bool $isWeekend): void
     {
-        $this->assertSame($isWeekend, $dayOfWeek->isWeekend());
+        self::assertSame($isWeekend, $dayOfWeek->isWeekend());
     }
 
     public function providerIsWeekend(): array
@@ -207,7 +207,7 @@ class DayOfWeekTest extends AbstractTestCase
      */
     public function testPlus(int $dayOfWeek, int $plusDays, int $expectedDayOfWeek): void
     {
-        $this->assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::of($dayOfWeek)->plus($plusDays));
+        self::assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::of($dayOfWeek)->plus($plusDays));
     }
 
     /**
@@ -219,7 +219,7 @@ class DayOfWeekTest extends AbstractTestCase
      */
     public function testMinus(int $dayOfWeek, int $plusDays, int $expectedDayOfWeek): void
     {
-        $this->assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::of($dayOfWeek)->minus(-$plusDays));
+        self::assertDayOfWeekIs($expectedDayOfWeek, DayOfWeek::of($dayOfWeek)->minus(-$plusDays));
     }
 
     public function providerPlus(): Generator
@@ -253,7 +253,7 @@ class DayOfWeekTest extends AbstractTestCase
         $localDate = LocalDate::parse($localDate);
         $dayOfWeek = DayOfWeek::of($dayOfWeek);
 
-        $this->assertTrue($localDate->getDayOfWeek()->isEqualTo($dayOfWeek));
+        self::assertTrue($localDate->getDayOfWeek()->isEqualTo($dayOfWeek));
     }
 
     public function providerGetDayOfWeekFromLocalDate(): array
@@ -283,7 +283,7 @@ class DayOfWeekTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $dayOfWeek, string $expectedName): void
     {
-        $this->assertSame(json_encode($expectedName), json_encode(DayOfWeek::of($dayOfWeek)));
+        self::assertSame(json_encode($expectedName), json_encode(DayOfWeek::of($dayOfWeek)));
     }
 
     /**
@@ -294,7 +294,7 @@ class DayOfWeekTest extends AbstractTestCase
      */
     public function testToString(int $dayOfWeek, string $expectedName): void
     {
-        $this->assertSame($expectedName, (string) DayOfWeek::of($dayOfWeek));
+        self::assertSame($expectedName, (string) DayOfWeek::of($dayOfWeek));
     }
 
     public function providerToString(): array

--- a/tests/DefaultClockTest.php
+++ b/tests/DefaultClockTest.php
@@ -21,32 +21,32 @@ class DefaultClockTest extends AbstractTestCase
     public function testFreeze(): void
     {
         DefaultClock::freeze(Instant::of(123456, 5000));
-        $this->assertInstantIs(123456, 5000, Instant::now());
+        self::assertInstantIs(123456, 5000, Instant::now());
     }
 
     public function testTravel(): void
     {
         $fixedClock = new FixedClock(Instant::of(1000, 0));
         DefaultClock::set($fixedClock);
-        $this->assertInstantIs(1000, 0, Instant::now());
+        self::assertInstantIs(1000, 0, Instant::now());
 
         DefaultClock::travel(Instant::of(-1000));
-        $this->assertInstantIs(-1000, 0, Instant::now());
+        self::assertInstantIs(-1000, 0, Instant::now());
 
         $fixedClock->move(2);
-        $this->assertInstantIs(-998, 0, Instant::now());
+        self::assertInstantIs(-998, 0, Instant::now());
     }
 
     public function testScale(): void
     {
         $fixedClock = new FixedClock(Instant::of(1000, 0));
         DefaultClock::set($fixedClock);
-        $this->assertInstantIs(1000, 0, Instant::now());
+        self::assertInstantIs(1000, 0, Instant::now());
 
         DefaultClock::scale(60);
-        $this->assertInstantIs(1000, 0, Instant::now());
+        self::assertInstantIs(1000, 0, Instant::now());
 
         $fixedClock->move(2);
-        $this->assertInstantIs(1120, 0, Instant::now());
+        self::assertInstantIs(1120, 0, Instant::now());
     }
 }

--- a/tests/DurationTest.php
+++ b/tests/DurationTest.php
@@ -27,8 +27,8 @@ class DurationTest extends AbstractTestCase
     {
         $zero = Duration::zero();
 
-        $this->assertDurationIs(0, 0, $zero);
-        $this->assertSame($zero, Duration::zero());
+        self::assertDurationIs(0, 0, $zero);
+        self::assertSame($zero, Duration::zero());
     }
 
     /**
@@ -42,7 +42,7 @@ class DurationTest extends AbstractTestCase
     public function testOfSeconds(int $seconds, int $nanoAdjustment, int $expectedSeconds, int $expectedNanos): void
     {
         $duration = Duration::ofSeconds($seconds, $nanoAdjustment);
-        $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
+        self::assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
     public function providerOfSeconds(): array
@@ -65,7 +65,7 @@ class DurationTest extends AbstractTestCase
     public function testOfMillis(int $millis): void
     {
         $duration = Duration::ofMillis($millis);
-        $this->assertSame($millis, $duration->getTotalMillis());
+        self::assertSame($millis, $duration->getTotalMillis());
     }
 
     public function providerOfMillis(): array
@@ -85,7 +85,7 @@ class DurationTest extends AbstractTestCase
     public function testOfNanos(int $nanos, int $expectedSeconds, int $expectedNanos): void
     {
         $duration = Duration::ofNanos($nanos);
-        $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
+        self::assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
     public function providerOfNanos(): array
@@ -102,21 +102,21 @@ class DurationTest extends AbstractTestCase
     public function testOfMinutes(): void
     {
         for ($i = -2; $i <= 2; $i++) {
-            $this->assertSame($i * 60, Duration::ofMinutes($i)->getSeconds());
+            self::assertSame($i * 60, Duration::ofMinutes($i)->getSeconds());
         }
     }
 
     public function testOfHours(): void
     {
         for ($i = -2; $i <= 2; $i++) {
-            $this->assertSame($i * 3600, Duration::ofHours($i)->getSeconds());
+            self::assertSame($i * 3600, Duration::ofHours($i)->getSeconds());
         }
     }
 
     public function testOfDays(): void
     {
         for ($i = -2; $i <= 2; $i++) {
-            $this->assertSame($i * 86400, Duration::ofDays($i)->getSeconds());
+            self::assertSame($i * 86400, Duration::ofDays($i)->getSeconds());
         }
     }
 
@@ -128,7 +128,7 @@ class DurationTest extends AbstractTestCase
         $i1 = Instant::of($seconds1, $nanos1);
         $i2 = Instant::of($seconds2, $nanos2);
 
-        $this->assertDurationIs($seconds, $nanos, Duration::between($i1, $i2));
+        self::assertDurationIs($seconds, $nanos, Duration::between($i1, $i2));
     }
 
     public function providerBetween(): array
@@ -161,7 +161,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testParse(string $text, int $seconds, int $nanos): void
     {
-        $this->assertDurationIs($seconds, $nanos, Duration::parse($text));
+        self::assertDurationIs($seconds, $nanos, Duration::parse($text));
     }
 
     public function providerParse(): array
@@ -311,7 +311,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testIsZero(int $seconds, int $nanos, int $cmp): void
     {
-        $this->assertSame($cmp === 0, Duration::ofSeconds($seconds, $nanos)->isZero());
+        self::assertSame($cmp === 0, Duration::ofSeconds($seconds, $nanos)->isZero());
     }
 
     /**
@@ -323,7 +323,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testIsPositive(int $seconds, int $nanos, int $cmp): void
     {
-        $this->assertSame($cmp > 0, Duration::ofSeconds($seconds, $nanos)->isPositive());
+        self::assertSame($cmp > 0, Duration::ofSeconds($seconds, $nanos)->isPositive());
     }
 
     /**
@@ -335,7 +335,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testIsPositiveOrZero(int $seconds, int $nanos, int $cmp): void
     {
-        $this->assertSame($cmp >= 0, Duration::ofSeconds($seconds, $nanos)->isPositiveOrZero());
+        self::assertSame($cmp >= 0, Duration::ofSeconds($seconds, $nanos)->isPositiveOrZero());
     }
 
     /**
@@ -347,7 +347,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testIsNegative(int $seconds, int $nanos, int $cmp): void
     {
-        $this->assertSame($cmp < 0, Duration::ofSeconds($seconds, $nanos)->isNegative());
+        self::assertSame($cmp < 0, Duration::ofSeconds($seconds, $nanos)->isNegative());
     }
 
     /**
@@ -359,7 +359,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testIsNegativeOrZero(int $seconds, int $nanos, int $cmp): void
     {
-        $this->assertSame($cmp <= 0, Duration::ofSeconds($seconds, $nanos)->isNegativeOrZero());
+        self::assertSame($cmp <= 0, Duration::ofSeconds($seconds, $nanos)->isNegativeOrZero());
     }
 
     public function providerCompareToZero(): array
@@ -391,12 +391,12 @@ class DurationTest extends AbstractTestCase
         $duration1 = Duration::ofSeconds($seconds1, $nanos1);
         $duration2 = Duration::ofSeconds($seconds2, $nanos2);
 
-        $this->assertSame($cmp, $duration1->compareTo($duration2));
-        $this->assertSame($cmp === 0, $duration1->isEqualTo($duration2));
-        $this->assertSame($cmp === -1, $duration1->isLessThan($duration2));
-        $this->assertSame($cmp === 1, $duration1->isGreaterThan($duration2));
-        $this->assertSame($cmp <= 0, $duration1->isLessThanOrEqualTo($duration2));
-        $this->assertSame($cmp >= 0, $duration1->isGreaterThanOrEqualTo($duration2));
+        self::assertSame($cmp, $duration1->compareTo($duration2));
+        self::assertSame($cmp === 0, $duration1->isEqualTo($duration2));
+        self::assertSame($cmp === -1, $duration1->isLessThan($duration2));
+        self::assertSame($cmp === 1, $duration1->isGreaterThan($duration2));
+        self::assertSame($cmp <= 0, $duration1->isLessThanOrEqualTo($duration2));
+        self::assertSame($cmp >= 0, $duration1->isGreaterThanOrEqualTo($duration2));
     }
 
     public function providerCompareTo(): array
@@ -469,7 +469,7 @@ class DurationTest extends AbstractTestCase
         $duration1 = Duration::ofSeconds($s1, $n1);
         $duration2 = Duration::ofSeconds($s2, $n2);
 
-        $this->assertDurationIs($s, $n, $duration1->plus($duration2));
+        self::assertDurationIs($s, $n, $duration1->plus($duration2));
     }
 
     /**
@@ -487,7 +487,7 @@ class DurationTest extends AbstractTestCase
         $duration1 = Duration::ofSeconds($s1, $n1);
         $duration2 = Duration::ofSeconds(-$s2, -$n2);
 
-        $this->assertDurationIs($s, $n, $duration1->minus($duration2));
+        self::assertDurationIs($s, $n, $duration1->minus($duration2));
     }
 
     public function providerPlus(): array
@@ -556,7 +556,7 @@ class DurationTest extends AbstractTestCase
     public function testPlusSeconds(int $seconds, int $nanos, int $secondsToAdd, int $expectedSeconds, int $expectedNanos): void
     {
         $duration = Duration::ofSeconds($seconds, $nanos)->plusSeconds($secondsToAdd);
-        $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
+        self::assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
     public function providerPlusSeconds(): array
@@ -591,7 +591,7 @@ class DurationTest extends AbstractTestCase
     public function testPlusMinutes(int $seconds, int $minutesToAdd, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->plusMinutes($minutesToAdd);
-        $this->assertDurationIs($expectedSeconds, 0, $duration);
+        self::assertDurationIs($expectedSeconds, 0, $duration);
     }
 
     public function providerPlusMinutes(): array
@@ -619,7 +619,7 @@ class DurationTest extends AbstractTestCase
     public function testPlusHours(int $seconds, int $hoursToAdd, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->plusHours($hoursToAdd);
-        $this->assertDurationIs($expectedSeconds, 0, $duration);
+        self::assertDurationIs($expectedSeconds, 0, $duration);
     }
 
     public function providerPlusHours(): array
@@ -647,7 +647,7 @@ class DurationTest extends AbstractTestCase
     public function testPlusDays(int $seconds, int $daysToAdd, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->plusDays($daysToAdd);
-        $this->assertDurationIs($expectedSeconds, 0, $duration);
+        self::assertDurationIs($expectedSeconds, 0, $duration);
     }
 
     public function providerPlusDays(): array
@@ -675,7 +675,7 @@ class DurationTest extends AbstractTestCase
     public function testMinusSeconds(int $seconds, int $secondsToSubtract, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->minusSeconds($secondsToSubtract);
-        $this->assertDurationIs($expectedSeconds, 0, $duration);
+        self::assertDurationIs($expectedSeconds, 0, $duration);
     }
 
     public function providerMinusSeconds(): array
@@ -706,7 +706,7 @@ class DurationTest extends AbstractTestCase
     public function testMinusMinutes(int $seconds, int $minutesToSubtract, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->minusMinutes($minutesToSubtract);
-        $this->assertDurationIs($expectedSeconds, 0, $duration);
+        self::assertDurationIs($expectedSeconds, 0, $duration);
     }
 
     public function providerMinusMinutes(): array
@@ -734,7 +734,7 @@ class DurationTest extends AbstractTestCase
     public function testMinusHours(int $seconds, int $hoursToSubtract, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->minusHours($hoursToSubtract);
-        $this->assertDurationIs($expectedSeconds, 0, $duration);
+        self::assertDurationIs($expectedSeconds, 0, $duration);
     }
 
     public function providerMinusHours(): array
@@ -762,7 +762,7 @@ class DurationTest extends AbstractTestCase
     public function testMinusDays(int $seconds, int $daysToSubtract, int $expectedSeconds): void
     {
         $duration = Duration::ofSeconds($seconds)->minusDays($daysToSubtract);
-        $this->assertDurationIs($expectedSeconds, 0, $duration);
+        self::assertDurationIs($expectedSeconds, 0, $duration);
     }
 
     public function providerMinusDays(): array
@@ -792,7 +792,7 @@ class DurationTest extends AbstractTestCase
         $duration = Duration::ofSeconds($second, $nano);
         $duration = $duration->multipliedBy($multiplicand);
 
-        $this->assertDurationIs($expectedSecond, $expectedNano, $duration);
+        self::assertDurationIs($expectedSecond, $expectedNano, $duration);
     }
 
     public function providerMultipliedBy(): array
@@ -884,7 +884,7 @@ class DurationTest extends AbstractTestCase
     public function testDividedBy(int $seconds, int $nanos, int $divisor, int $expectedSeconds, int $expectedNanos): void
     {
         $duration = Duration::ofSeconds($seconds, $nanos)->dividedBy($divisor);
-        $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration);
+        self::assertDurationIs($expectedSeconds, $expectedNanos, $duration);
     }
 
     public function providerDividedBy(): array
@@ -960,7 +960,7 @@ class DurationTest extends AbstractTestCase
     public function testNegated(int $seconds, int $nanos, int $expectedSeconds, int $expectedNanos): void
     {
         $duration = Duration::ofSeconds($seconds, $nanos);
-        $this->assertDurationIs($expectedSeconds, $expectedNanos, $duration->negated());
+        self::assertDurationIs($expectedSeconds, $expectedNanos, $duration->negated());
     }
 
     public function providerNegated(): array
@@ -980,7 +980,7 @@ class DurationTest extends AbstractTestCase
     {
         for ($seconds = -3; $seconds <= 3; $seconds++) {
             $duration = Duration::ofSeconds($seconds)->abs();
-            $this->assertDurationIs(abs($seconds), 0, $duration);
+            self::assertDurationIs(abs($seconds), 0, $duration);
         }
     }
 
@@ -1012,25 +1012,25 @@ class DurationTest extends AbstractTestCase
         $test6a = Duration::ofSeconds(6);
         $test6b = Duration::ofSeconds(6);
 
-        $this->assertTrue($test5a->isEqualTo($test5a));
-        $this->assertTrue($test5a->isEqualTo($test5b));
-        $this->assertFalse($test5a->isEqualTo($test6a));
-        $this->assertFalse($test5a->isEqualTo($test6b));
+        self::assertTrue($test5a->isEqualTo($test5a));
+        self::assertTrue($test5a->isEqualTo($test5b));
+        self::assertFalse($test5a->isEqualTo($test6a));
+        self::assertFalse($test5a->isEqualTo($test6b));
 
-        $this->assertTrue($test5b->isEqualTo($test5a));
-        $this->assertTrue($test5b->isEqualTo($test5b));
-        $this->assertFalse($test5b->isEqualTo($test6a));
-        $this->assertFalse($test5b->isEqualTo($test6b));
+        self::assertTrue($test5b->isEqualTo($test5a));
+        self::assertTrue($test5b->isEqualTo($test5b));
+        self::assertFalse($test5b->isEqualTo($test6a));
+        self::assertFalse($test5b->isEqualTo($test6b));
 
-        $this->assertFalse($test6a->isEqualTo($test5a));
-        $this->assertFalse($test6a->isEqualTo($test5b));
-        $this->assertTrue($test6a->isEqualTo($test6a));
-        $this->assertTrue($test6a->isEqualTo($test6b));
+        self::assertFalse($test6a->isEqualTo($test5a));
+        self::assertFalse($test6a->isEqualTo($test5b));
+        self::assertTrue($test6a->isEqualTo($test6a));
+        self::assertTrue($test6a->isEqualTo($test6b));
 
-        $this->assertFalse($test6b->isEqualTo($test5a));
-        $this->assertFalse($test6b->isEqualTo($test5b));
-        $this->assertTrue($test6b->isEqualTo($test6a));
-        $this->assertTrue($test6b->isEqualTo($test6b));
+        self::assertFalse($test6b->isEqualTo($test5a));
+        self::assertFalse($test6b->isEqualTo($test5b));
+        self::assertTrue($test6b->isEqualTo($test6a));
+        self::assertTrue($test6b->isEqualTo($test6b));
     }
 
     /**
@@ -1043,7 +1043,7 @@ class DurationTest extends AbstractTestCase
     public function testGetTotalMillis(int $seconds, int $nanos, int $expectedMillis): void
     {
         $duration = Duration::ofSeconds($seconds, $nanos);
-        $this->assertSame($expectedMillis, $duration->getTotalMillis());
+        self::assertSame($expectedMillis, $duration->getTotalMillis());
     }
 
     public function providerGetTotalMillis(): array
@@ -1066,7 +1066,7 @@ class DurationTest extends AbstractTestCase
     public function testGetTotalMicros(int $seconds, int $nanos, int $expectedMicros): void
     {
         $duration = Duration::ofSeconds($seconds, $nanos);
-        $this->assertSame($expectedMicros, $duration->getTotalMicros());
+        self::assertSame($expectedMicros, $duration->getTotalMicros());
     }
 
     public function providerGetTotalMicros(): array
@@ -1089,7 +1089,7 @@ class DurationTest extends AbstractTestCase
     public function testGetTotalNanos(int $seconds, int $nanos, int $expectedNanos): void
     {
         $duration = Duration::ofSeconds($seconds, $nanos);
-        $this->assertSame($expectedNanos, $duration->getTotalNanos());
+        self::assertSame($expectedNanos, $duration->getTotalNanos());
     }
 
     public function providerGetTotalNanos(): array
@@ -1107,7 +1107,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToDaysPart(Duration $duration, int $days): void
     {
-        $this->assertSame($days, $duration->toDaysPart());
+        self::assertSame($days, $duration->toDaysPart());
     }
 
     public function providerToDaysPart(): array
@@ -1127,7 +1127,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToHoursPart(Duration $duration, int $hours): void
     {
-        $this->assertSame($hours, $duration->toHoursPart());
+        self::assertSame($hours, $duration->toHoursPart());
     }
 
     public function providerToHoursPart(): array
@@ -1146,7 +1146,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToMinutesPart(Duration $duration, int $minutes): void
     {
-        $this->assertSame($minutes, $duration->toMinutesPart());
+        self::assertSame($minutes, $duration->toMinutesPart());
     }
 
     public function providerToMinutesPart(): array
@@ -1165,7 +1165,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToSecondsPart(Duration $duration, int $seconds): void
     {
-        $this->assertSame($seconds, $duration->toSecondsPart());
+        self::assertSame($seconds, $duration->toSecondsPart());
     }
 
     public function providerToSecondsPart(): array
@@ -1185,7 +1185,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToMillis(Duration $duration, int $millis): void
     {
-        $this->assertSame($millis, $duration->toMillis());
+        self::assertSame($millis, $duration->toMillis());
     }
 
     public function providerToMillis(): array
@@ -1221,7 +1221,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToMillisPart(Duration $duration, int $millis): void
     {
-        $this->assertSame($millis, $duration->toMillisPart());
+        self::assertSame($millis, $duration->toMillisPart());
     }
 
     public function providerToMillisPart(): array
@@ -1241,7 +1241,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToNanos(Duration $duration, int $nanos): void
     {
-        $this->assertSame($nanos, $duration->toNanos());
+        self::assertSame($nanos, $duration->toNanos());
     }
 
     public function providerToNanos(): array
@@ -1259,7 +1259,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToNanosPart(Duration $duration, int $nanos): void
     {
-        $this->assertSame($nanos, $duration->toNanosPart());
+        self::assertSame($nanos, $duration->toNanosPart());
     }
 
     public function providerToNanosPart(): array
@@ -1279,7 +1279,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $seconds, int $nanos, string $expected): void
     {
-        $this->assertSame(json_encode($expected), json_encode(Duration::ofSeconds($seconds, $nanos)));
+        self::assertSame(json_encode($expected), json_encode(Duration::ofSeconds($seconds, $nanos)));
     }
 
     /**
@@ -1287,7 +1287,7 @@ class DurationTest extends AbstractTestCase
      */
     public function testToString(int $seconds, int $nanos, string $expected): void
     {
-        $this->assertSame($expected, (string) Duration::ofSeconds($seconds, $nanos));
+        self::assertSame($expected, (string) Duration::ofSeconds($seconds, $nanos));
     }
 
     public function providerToString(): array
@@ -1367,29 +1367,29 @@ class DurationTest extends AbstractTestCase
             for ($j = 0; $j < $count; $j++) {
                 $b = $durations[$j];
                 if ($i < $j) {
-                    $this->assertLessThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertTrue($a->isLessThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
+                    self::assertLessThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    self::assertTrue($a->isLessThan($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
                 } elseif ($i > $j) {
-                    $this->assertGreaterThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
-                    $this->assertTrue($a->isGreaterThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
+                    self::assertGreaterThan(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
+                    self::assertTrue($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isEqualTo($b), $a . ' <=> ' . $b);
                 } else {
-                    $this->assertSame(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
-                    $this->assertTrue($a->isEqualTo($b), $a . ' <=> ' . $b);
+                    self::assertSame(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                    self::assertTrue($a->isEqualTo($b), $a . ' <=> ' . $b);
                 }
 
                 if ($i <= $j) {
-                    $this->assertLessThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
+                    self::assertLessThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isGreaterThan($b), $a . ' <=> ' . $b);
                 }
                 if ($i >= $j) {
-                    $this->assertGreaterThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
-                    $this->assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
+                    self::assertGreaterThanOrEqual(0, $a->compareTo($b), $a . ' <=> ' . $b);
+                    self::assertFalse($a->isLessThan($b), $a . ' <=> ' . $b);
                 }
             }
         }

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -32,8 +32,8 @@ class InstantTest extends AbstractTestCase
     {
         $duration = Instant::of($seconds, $nanoAdjustment);
 
-        $this->assertSame($expectedSeconds, $duration->getEpochSecond());
-        $this->assertSame($expectedNanos, $duration->getNano());
+        self::assertSame($expectedSeconds, $duration->getEpochSecond());
+        self::assertSame($expectedNanos, $duration->getNano());
     }
 
     public function providerOf(): array
@@ -54,30 +54,30 @@ class InstantTest extends AbstractTestCase
     {
         $epoch = Instant::epoch();
 
-        $this->assertInstantIs(0, 0, $epoch);
-        $this->assertSame($epoch, Instant::epoch());
+        self::assertInstantIs(0, 0, $epoch);
+        self::assertSame($epoch, Instant::epoch());
     }
 
     public function testNow(): void
     {
         $clock = new FixedClock(Instant::of(123456789, 987654321));
-        $this->assertInstantIs(123456789, 987654321, Instant::now($clock));
+        self::assertInstantIs(123456789, 987654321, Instant::now($clock));
     }
 
     public function testMin(): void
     {
         $min = Instant::min();
 
-        $this->assertInstantIs(PHP_INT_MIN, 0, $min);
-        $this->assertSame($min, Instant::min());
+        self::assertInstantIs(PHP_INT_MIN, 0, $min);
+        self::assertSame($min, Instant::min());
     }
 
     public function testMax(): void
     {
         $max = Instant::max();
 
-        $this->assertInstantIs(PHP_INT_MAX, 999999999, $max);
-        $this->assertSame($max, Instant::max());
+        self::assertInstantIs(PHP_INT_MAX, 999999999, $max);
+        self::assertSame($max, Instant::max());
     }
 
     /**
@@ -93,7 +93,7 @@ class InstantTest extends AbstractTestCase
     public function testPlus(int $second, int $nano, int $plusSeconds, int $plusNanos, int $expectedSecond, int $expectedNano): void
     {
         $result = Instant::of($second, $nano)->plus(Duration::ofSeconds($plusSeconds, $plusNanos));
-        $this->assertInstantIs($expectedSecond, $expectedNano, $result);
+        self::assertInstantIs($expectedSecond, $expectedNano, $result);
     }
 
     /**
@@ -109,7 +109,7 @@ class InstantTest extends AbstractTestCase
     public function testMinus(int $second, int $nano, int $plusSeconds, int $plusNanos, int $expectedSecond, int $expectedNano): void
     {
         $result = Instant::of($second, $nano)->minus(Duration::ofSeconds(-$plusSeconds, -$plusNanos));
-        $this->assertInstantIs($expectedSecond, $expectedNano, $result);
+        self::assertInstantIs($expectedSecond, $expectedNano, $result);
     }
 
     public function providerPlus(): array
@@ -134,7 +134,7 @@ class InstantTest extends AbstractTestCase
     public function testPlusSeconds(int $second, int $nano, int $plusSeconds, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->plusSeconds($plusSeconds);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     /**
@@ -148,7 +148,7 @@ class InstantTest extends AbstractTestCase
     public function testMinusSeconds(int $second, int $nano, int $plusSeconds, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->minusSeconds(-$plusSeconds);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     public function providerPlusSeconds(): array
@@ -175,7 +175,7 @@ class InstantTest extends AbstractTestCase
     public function testPlusMinutes(int $second, int $nano, int $plusMinutes, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->plusMinutes($plusMinutes);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     /**
@@ -189,7 +189,7 @@ class InstantTest extends AbstractTestCase
     public function testMinusMinutes(int $second, int $nano, int $plusMinutes, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->minusMinutes(-$plusMinutes);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     public function providerPlusMinutes(): array
@@ -216,7 +216,7 @@ class InstantTest extends AbstractTestCase
     public function testPlusHours(int $second, int $nano, int $plusHours, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->plusHours($plusHours);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     /**
@@ -230,7 +230,7 @@ class InstantTest extends AbstractTestCase
     public function testMinusHours(int $second, int $nano, int $plusHours, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->minusHours(-$plusHours);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     public function providerPlusHours(): array
@@ -257,7 +257,7 @@ class InstantTest extends AbstractTestCase
     public function testPlusDays(int $second, int $nano, int $plusDays, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->plusDays($plusDays);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     /**
@@ -271,7 +271,7 @@ class InstantTest extends AbstractTestCase
     public function testMinusDays(int $second, int $nano, int $plusDays, int $expectedSecond): void
     {
         $result = Instant::of($second, $nano)->minusDays(-$plusDays);
-        $this->assertInstantIs($expectedSecond, $nano, $result);
+        self::assertInstantIs($expectedSecond, $nano, $result);
     }
 
     public function providerPlusDays(): array
@@ -290,13 +290,13 @@ class InstantTest extends AbstractTestCase
     public function testWithEpochSecond(): void
     {
         $instant = Instant::of(1234567890, 987654321);
-        $this->assertInstantIs(2345678901, 987654321, $instant->withEpochSecond(2345678901));
+        self::assertInstantIs(2345678901, 987654321, $instant->withEpochSecond(2345678901));
     }
 
     public function testWithNano(): void
     {
         $instant = Instant::of(1234567890, 987654321);
-        $this->assertInstantIs(1234567890, 123456789, $instant->withNano(123456789));
+        self::assertInstantIs(1234567890, 123456789, $instant->withNano(123456789));
     }
 
     /**
@@ -329,7 +329,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testCompareTo(int $s1, int $n1, int $s2, int $n2, int $cmp): void
     {
-        $this->assertSame($cmp, Instant::of($s1, $n1)->compareTo(Instant::of($s2, $n2)));
+        self::assertSame($cmp, Instant::of($s1, $n1)->compareTo(Instant::of($s2, $n2)));
     }
 
     /**
@@ -343,7 +343,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testIsEqualTo(int $s1, int $n1, int $s2, int $n2, int $cmp): void
     {
-        $this->assertSame($cmp === 0, Instant::of($s1, $n1)->isEqualTo(Instant::of($s2, $n2)));
+        self::assertSame($cmp === 0, Instant::of($s1, $n1)->isEqualTo(Instant::of($s2, $n2)));
     }
 
     /**
@@ -357,7 +357,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testIsAfter(int $s1, int $n1, int $s2, int $n2, int $cmp): void
     {
-        $this->assertSame($cmp === 1, Instant::of($s1, $n1)->isAfter(Instant::of($s2, $n2)));
+        self::assertSame($cmp === 1, Instant::of($s1, $n1)->isAfter(Instant::of($s2, $n2)));
     }
 
     /**
@@ -371,7 +371,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testIsAfterOrEqualTo(int $s1, int $n1, int $s2, int $n2, int $cmp): void
     {
-        $this->assertSame($cmp >= 0, Instant::of($s1, $n1)->isAfterOrEqualTo(Instant::of($s2, $n2)));
+        self::assertSame($cmp >= 0, Instant::of($s1, $n1)->isAfterOrEqualTo(Instant::of($s2, $n2)));
     }
 
     /**
@@ -385,7 +385,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testIsBefore(int $s1, int $n1, int $s2, int $n2, int $cmp): void
     {
-        $this->assertSame($cmp === -1, Instant::of($s1, $n1)->isBefore(Instant::of($s2, $n2)));
+        self::assertSame($cmp === -1, Instant::of($s1, $n1)->isBefore(Instant::of($s2, $n2)));
     }
 
     /**
@@ -399,7 +399,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testIsBeforeOrEqualTo(int $s1, int $n1, int $s2, int $n2, int $cmp): void
     {
-        $this->assertSame($cmp <= 0, Instant::of($s1, $n1)->isBeforeOrEqualTo(Instant::of($s2, $n2)));
+        self::assertSame($cmp <= 0, Instant::of($s1, $n1)->isBeforeOrEqualTo(Instant::of($s2, $n2)));
     }
 
     /**
@@ -414,7 +414,7 @@ class InstantTest extends AbstractTestCase
     public function testIsFuture(int $testSecond, int $testNano, int $nowSecond, int $nowNano, int $cmp): void
     {
         $clock = new FixedClock(Instant::of($nowSecond, $nowNano));
-        $this->assertSame($cmp === 1, Instant::of($testSecond, $testNano)->isFuture($clock));
+        self::assertSame($cmp === 1, Instant::of($testSecond, $testNano)->isFuture($clock));
     }
 
     /**
@@ -429,7 +429,7 @@ class InstantTest extends AbstractTestCase
     public function testIsPast(int $testSecond, int $testNano, int $nowSecond, int $nowNano, int $cmp): void
     {
         $clock = new FixedClock(Instant::of($nowSecond, $nowNano));
-        $this->assertSame($cmp === -1, Instant::of($testSecond, $testNano)->isPast($clock));
+        self::assertSame($cmp === -1, Instant::of($testSecond, $testNano)->isPast($clock));
     }
 
     public function providerCompareTo(): array
@@ -528,7 +528,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testIsBetweenInclusive(int $seconds, int $nanos, bool $isBetween): void
     {
-        $this->assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenInclusive(
+        self::assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenInclusive(
             Instant::of(-1, -1),
             Instant::of(1, 1)
         ));
@@ -543,7 +543,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testIsBetweenExclusive(int $seconds, int $nanos, bool $isBetween): void
     {
-        $this->assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenExclusive(
+        self::assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenExclusive(
             Instant::of(-1, -1),
             Instant::of(1, 1)
         ));
@@ -592,7 +592,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testToDecimal(int $second, int $nano, string $expected): void
     {
-        $this->assertSame($expected, Instant::of($second, $nano)->toDecimal());
+        self::assertSame($expected, Instant::of($second, $nano)->toDecimal());
     }
 
     public function providerToDecimal()
@@ -621,7 +621,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $epochSecond, int $nano, string $expectedString): void
     {
-        $this->assertSame(json_encode($expectedString), json_encode(Instant::of($epochSecond, $nano)));
+        self::assertSame(json_encode($expectedString), json_encode(Instant::of($epochSecond, $nano)));
     }
 
     /**
@@ -633,7 +633,7 @@ class InstantTest extends AbstractTestCase
      */
     public function testToString(int $epochSecond, int $nano, string $expectedString): void
     {
-        $this->assertSame($expectedString, (string) Instant::of($epochSecond, $nano));
+        self::assertSame($expectedString, (string) Instant::of($epochSecond, $nano));
     }
 
     public function providerToString(): array
@@ -655,7 +655,7 @@ class InstantTest extends AbstractTestCase
         $timeZone = TimeZone::utc();
         $instant = Instant::of(1000000000);
         $result = $instant->atTimeZone($timeZone);
-        $this->assertSame(1000000000, $result->getInstant()->getEpochSecond());
-        $this->assertSame('2001-09-09T01:46:40', (string) $result->getDateTime());
+        self::assertSame(1000000000, $result->getInstant()->getEpochSecond());
+        self::assertSame('2001-09-09T01:46:40', (string) $result->getDateTime());
     }
 }

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -33,8 +33,8 @@ class IntervalTest extends AbstractTestCase
 
         $interval = Interval::of($start, $end);
 
-        $this->assertInstantIs(2000000000, 987654321, $interval->getStart());
-        $this->assertInstantIs(2000000009, 123456789, $interval->getEnd());
+        self::assertInstantIs(2000000000, 987654321, $interval->getStart());
+        self::assertInstantIs(2000000009, 123456789, $interval->getEnd());
     }
 
     /**
@@ -49,15 +49,15 @@ class IntervalTest extends AbstractTestCase
 
         $newInterval = $interval->withStart(Instant::of(1999999999, 999999999));
 
-        $this->assertNotSame($newInterval, $interval);
+        self::assertNotSame($newInterval, $interval);
 
         // ensure that the original isn't changed
-        $this->assertInstantIs(2000000000, 0, $interval->getStart());
-        $this->assertInstantIs(2000000001, 0, $interval->getEnd());
+        self::assertInstantIs(2000000000, 0, $interval->getStart());
+        self::assertInstantIs(2000000001, 0, $interval->getEnd());
 
         // test the new instance
-        $this->assertInstantIs(1999999999, 999999999, $newInterval->getStart());
-        $this->assertInstantIs(2000000001, 0, $newInterval->getEnd());
+        self::assertInstantIs(1999999999, 999999999, $newInterval->getStart());
+        self::assertInstantIs(2000000001, 0, $newInterval->getEnd());
     }
 
     /**
@@ -72,15 +72,15 @@ class IntervalTest extends AbstractTestCase
 
         $newInterval = $interval->withEnd(Instant::of(2000000002, 222222222));
 
-        $this->assertNotSame($newInterval, $interval);
+        self::assertNotSame($newInterval, $interval);
 
         // ensure that the original isn't changed
-        $this->assertInstantIs(2000000000, 0, $interval->getStart());
-        $this->assertInstantIs(2000000001, 0, $interval->getEnd());
+        self::assertInstantIs(2000000000, 0, $interval->getStart());
+        self::assertInstantIs(2000000001, 0, $interval->getEnd());
 
         // test the new instance
-        $this->assertInstantIs(2000000000, 0, $newInterval->getStart());
-        $this->assertInstantIs(2000000002, 222222222, $newInterval->getEnd());
+        self::assertInstantIs(2000000000, 0, $newInterval->getStart());
+        self::assertInstantIs(2000000002, 222222222, $newInterval->getEnd());
     }
 
     public function testGetDuration(): void
@@ -92,7 +92,7 @@ class IntervalTest extends AbstractTestCase
 
         $duration = $interval->getDuration();
 
-        $this->assertDurationIs(1, 999444556, $duration);
+        self::assertDurationIs(1, 999444556, $duration);
     }
 
     /** @dataProvider providerContains */
@@ -100,7 +100,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval = Interval::of(Instant::of($start), Instant::of($end));
 
-        $this->assertSame($expected, $interval->contains(Instant::of($now)), $errorMessage);
+        self::assertSame($expected, $interval->contains(Instant::of($now)), $errorMessage);
     }
 
     public function providerContains(): array
@@ -135,7 +135,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval1 = Interval::of(Instant::of($start1), Instant::of($end1));
         $interval2 = Interval::of(Instant::of($start2), Instant::of($end2));
-        $this->assertSame($expected, $interval1->intersectsWith($interval2));
+        self::assertSame($expected, $interval1->intersectsWith($interval2));
     }
 
     public function providerIntersectsWith(): array
@@ -182,7 +182,7 @@ class IntervalTest extends AbstractTestCase
         $interval2 = Interval::of(Instant::of($start2), Instant::of($end2));
         $expected = Interval::of(Instant::of($expectedStart), Instant::of($expectedEnd));
 
-        $this->assertTrue($expected->isEqualTo($interval1->getIntersectionWith($interval2)));
+        self::assertTrue($expected->isEqualTo($interval1->getIntersectionWith($interval2)));
     }
 
     public function providerGetIntersectionWith(): array
@@ -230,8 +230,8 @@ class IntervalTest extends AbstractTestCase
     /** @dataProvider providerIsEqualTo */
     public function testIsEqualTo(Interval $a, Interval $b, bool $expectedResult): void
     {
-        $this->assertSame($expectedResult, $a->isEqualTo($b));
-        $this->assertSame($expectedResult, $b->isEqualTo($a));
+        self::assertSame($expectedResult, $a->isEqualTo($b));
+        self::assertSame($expectedResult, $b->isEqualTo($a));
     }
 
     public function providerIsEqualTo(): array
@@ -267,7 +267,7 @@ class IntervalTest extends AbstractTestCase
             Instant::of(2000000000)
         );
 
-        $this->assertSame(json_encode('2001-09-09T01:46:40Z/2033-05-18T03:33:20Z'), json_encode($interval));
+        self::assertSame(json_encode('2001-09-09T01:46:40Z/2033-05-18T03:33:20Z'), json_encode($interval));
     }
 
     public function testToString(): void
@@ -277,6 +277,6 @@ class IntervalTest extends AbstractTestCase
             Instant::of(2000000000)
         );
 
-        $this->assertSame('2001-09-09T01:46:40Z/2033-05-18T03:33:20Z', (string) $interval);
+        self::assertSame('2001-09-09T01:46:40Z/2033-05-18T03:33:20Z', (string) $interval);
     }
 }

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -21,7 +21,7 @@ class LocalDateRangeTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertLocalDateRangeIs(2001, 2, 3, 2004, 5, 6, LocalDateRange::of(
+        self::assertLocalDateRangeIs(2001, 2, 3, 2004, 5, 6, LocalDateRange::of(
             LocalDate::of(2001, 2, 3),
             LocalDate::of(2004, 5, 6)
         ));
@@ -50,7 +50,7 @@ class LocalDateRangeTest extends AbstractTestCase
      */
     public function testParse(string $text, int $y1, int $m1, int $d1, int $y2, int $m2, int $d2): void
     {
-        $this->assertLocalDateRangeIs($y1, $m1, $d1, $y2, $m2, $d2, LocalDateRange::parse($text));
+        self::assertLocalDateRangeIs($y1, $m1, $d1, $y2, $m2, $d2, LocalDateRange::parse($text));
     }
 
     public function providerParse(): array
@@ -97,7 +97,7 @@ class LocalDateRangeTest extends AbstractTestCase
      */
     public function testIsEqualTo(string $testRange, bool $isEqual): void
     {
-        $this->assertSame($isEqual, LocalDateRange::of(
+        self::assertSame($isEqual, LocalDateRange::of(
             LocalDate::of(2001, 2, 3),
             LocalDate::of(2004, 5, 6)
         )->isEqualTo(LocalDateRange::parse($testRange)));
@@ -121,7 +121,7 @@ class LocalDateRangeTest extends AbstractTestCase
      */
     public function testContains(string $range, string $date, bool $contains): void
     {
-        $this->assertSame($contains, LocalDateRange::parse($range)->contains(LocalDate::parse($date)));
+        self::assertSame($contains, LocalDateRange::parse($range)->contains(LocalDate::parse($date)));
     }
 
     public function providerContains(): array
@@ -162,7 +162,7 @@ class LocalDateRangeTest extends AbstractTestCase
                 $actual[] = (string) $date;
             }
 
-            $this->assertSame($expected, $actual);
+            self::assertSame($expected, $actual);
         }
     }
 
@@ -174,7 +174,7 @@ class LocalDateRangeTest extends AbstractTestCase
      */
     public function testCount(string $range, int $count): void
     {
-        $this->assertCount($count, LocalDateRange::parse($range));
+        self::assertCount($count, LocalDateRange::parse($range));
     }
 
     public function providerCount(): array
@@ -191,7 +191,7 @@ class LocalDateRangeTest extends AbstractTestCase
 
     public function testJsonSerialize(): void
     {
-        $this->assertSame(json_encode('2008-12-31/2011-01-01'), json_encode(LocalDateRange::of(
+        self::assertSame(json_encode('2008-12-31/2011-01-01'), json_encode(LocalDateRange::of(
             LocalDate::of(2008, 12, 31),
             LocalDate::of(2011, 1, 1)
         )));
@@ -199,7 +199,7 @@ class LocalDateRangeTest extends AbstractTestCase
 
     public function testToString(): void
     {
-        $this->assertSame('2008-12-31/2011-01-01', (string) LocalDateRange::of(
+        self::assertSame('2008-12-31/2011-01-01', (string) LocalDateRange::of(
             LocalDate::of(2008, 12, 31),
             LocalDate::of(2011, 1, 1)
         ));
@@ -223,12 +223,12 @@ class LocalDateRangeTest extends AbstractTestCase
         $zip = array_map(null, $rangeArray, $periodArray);
 
         foreach ($zip as [$date, $dateTime]) {
-            $this->assertTrue($date->isEqualTo(LocalDate::fromNativeDateTime($dateTime)));
+            self::assertTrue($date->isEqualTo(LocalDate::fromNativeDateTime($dateTime)));
         }
 
-        $this->assertSame(iterator_count($period), $range->count());
-        $this->assertSame($expectedStart, $period->start->format('Y-m-d\TH:i:s.uO'));
-        $this->assertSame($expectedEnd, $period->end->format('Y-m-d\TH:i:s.uO'));
+        self::assertSame(iterator_count($period), $range->count());
+        self::assertSame($expectedStart, $period->start->format('Y-m-d\TH:i:s.uO'));
+        self::assertSame($expectedEnd, $period->end->format('Y-m-d\TH:i:s.uO'));
     }
 
     public function providerToNativeDatePeriod(): array
@@ -248,8 +248,8 @@ class LocalDateRangeTest extends AbstractTestCase
         $aRange = LocalDateRange::parse($a);
         $bRange = LocalDateRange::parse($b);
 
-        $this->assertSame($expectedResult, $aRange->intersectsWith($bRange));
-        $this->assertSame($expectedResult, $bRange->intersectsWith($aRange));
+        self::assertSame($expectedResult, $aRange->intersectsWith($bRange));
+        self::assertSame($expectedResult, $bRange->intersectsWith($aRange));
     }
 
     public function providerIntersectsWith(): array
@@ -275,8 +275,8 @@ class LocalDateRangeTest extends AbstractTestCase
         $aRange = LocalDateRange::parse($a);
         $bRange = LocalDateRange::parse($b);
 
-        $this->assertSame($expectedIntersection, (string) $aRange->getIntersectionWith($bRange));
-        $this->assertSame($expectedIntersection, (string) $bRange->getIntersectionWith($aRange));
+        self::assertSame($expectedIntersection, (string) $aRange->getIntersectionWith($bRange));
+        self::assertSame($expectedIntersection, (string) $bRange->getIntersectionWith($aRange));
     }
 
     public function providerGetIntersectionWith(): array
@@ -315,7 +315,7 @@ class LocalDateRangeTest extends AbstractTestCase
         $actualRange = $originalRange->withStart(LocalDate::parse($start));
 
         if ($expectedRange !== null) {
-            $this->assertSame($expectedRange, (string) $actualRange);
+            self::assertSame($expectedRange, (string) $actualRange);
         }
     }
 
@@ -346,7 +346,7 @@ class LocalDateRangeTest extends AbstractTestCase
         $actualRange = $originalRange->withEnd(LocalDate::parse($end));
 
         if ($expectedRange !== null) {
-            $this->assertSame($expectedRange, (string) $actualRange);
+            self::assertSame($expectedRange, (string) $actualRange);
         }
     }
 
@@ -369,7 +369,7 @@ class LocalDateRangeTest extends AbstractTestCase
     {
         $dateRange = LocalDateRange::parse($dateRange);
 
-        $this->assertSame($expectedPeriod, (string) $dateRange->toPeriod());
+        self::assertSame($expectedPeriod, (string) $dateRange->toPeriod());
     }
 
     public function providerToPeriod(): array

--- a/tests/LocalDateTest.php
+++ b/tests/LocalDateTest.php
@@ -27,7 +27,7 @@ class LocalDateTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertLocalDateIs(2007, 7, 15, LocalDate::of(2007, 7, 15));
+        self::assertLocalDateIs(2007, 7, 15, LocalDate::of(2007, 7, 15));
     }
 
     /**
@@ -90,7 +90,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testOfEpochDay(int $epochDay, int $year, int $month, int $day): void
     {
-        $this->assertLocalDateIs($year, $month, $day, LocalDate::ofEpochDay($epochDay));
+        self::assertLocalDateIs($year, $month, $day, LocalDate::ofEpochDay($epochDay));
     }
 
     public function testOfEpochDayOutOfRangeThrowsException(): void
@@ -109,7 +109,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testToEpochDay(int $epochDay, int $year, int $month, int $day): void
     {
-        $this->assertSame($epochDay, LocalDate::of($year, $month, $day)->toEpochDay());
+        self::assertSame($epochDay, LocalDate::of($year, $month, $day)->toEpochDay());
     }
 
     public function providerEpochDay(): array
@@ -136,7 +136,7 @@ class LocalDateTest extends AbstractTestCase
     public function testFromNativeDateTime(): void
     {
         $dateTime = new DateTime('2018-07-21');
-        $this->assertLocalDateIs(2018, 7, 21, LocalDate::fromNativeDateTime($dateTime));
+        self::assertLocalDateIs(2018, 7, 21, LocalDate::fromNativeDateTime($dateTime));
     }
 
     /**
@@ -151,7 +151,7 @@ class LocalDateTest extends AbstractTestCase
     public function testNow(int $epochSecond, string $timeZone, int $year, int $month, int $day): void
     {
         $clock = new FixedClock(Instant::of($epochSecond));
-        $this->assertLocalDateIs($year, $month, $day, LocalDate::now(TimeZone::parse($timeZone), $clock));
+        self::assertLocalDateIs($year, $month, $day, LocalDate::now(TimeZone::parse($timeZone), $clock));
     }
 
     public function providerNow(): array
@@ -168,16 +168,16 @@ class LocalDateTest extends AbstractTestCase
     {
         $min = LocalDate::min();
 
-        $this->assertLocalDateIs(Year::MIN_VALUE, 1, 1, $min);
-        $this->assertSame($min, LocalDate::min());
+        self::assertLocalDateIs(Year::MIN_VALUE, 1, 1, $min);
+        self::assertSame($min, LocalDate::min());
     }
 
     public function testMax(): void
     {
         $max = LocalDate::max();
 
-        $this->assertLocalDateIs(Year::MAX_VALUE, 12, 31, $max);
-        $this->assertSame($max, LocalDate::max());
+        self::assertLocalDateIs(Year::MAX_VALUE, 12, 31, $max);
+        self::assertSame($max, LocalDate::max());
     }
 
     /**
@@ -185,7 +185,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testGetYearMonth(int $year, int $month, int $day): void
     {
-        $this->assertYearMonthIs($year, $month, LocalDate::of($year, $month, $day)->getYearMonth());
+        self::assertYearMonthIs($year, $month, LocalDate::of($year, $month, $day)->getYearMonth());
     }
 
     public function providerGetYearMonth(): array
@@ -207,7 +207,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testGetDayOfWeek(int $year, int $month, int $day, int $dayOfWeek): void
     {
-        $this->assertDayOfWeekIs($dayOfWeek, LocalDate::of($year, $month, $day)->getDayOfWeek());
+        self::assertDayOfWeekIs($dayOfWeek, LocalDate::of($year, $month, $day)->getDayOfWeek());
     }
 
     public function providerDayOfWeek(): array
@@ -250,7 +250,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testOfYearDay(int $year, int $month, int $day, int $dayOfYear): void
     {
-        $this->assertLocalDateIs($year, $month, $day, LocalDate::ofYearDay($year, $dayOfYear));
+        self::assertLocalDateIs($year, $month, $day, LocalDate::ofYearDay($year, $dayOfYear));
     }
 
     /**
@@ -263,7 +263,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testGetDayOfYear(int $year, int $month, int $day, int $dayOfYear): void
     {
-        $this->assertSame($dayOfYear, LocalDate::of($year, $month, $day)->getDayOfYear());
+        self::assertSame($dayOfYear, LocalDate::of($year, $month, $day)->getDayOfYear());
     }
 
     public function providerDayOfYear(): array
@@ -468,7 +468,7 @@ class LocalDateTest extends AbstractTestCase
     public function testGetYearWeek(int $year, int $month, int $day, int $expectedYear, int $expectedWeek): void
     {
         $yearWeek = LocalDate::of($year, $month, $day)->getYearWeek();
-        $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
+        self::assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
     /**
@@ -483,7 +483,7 @@ class LocalDateTest extends AbstractTestCase
     public function testWithYear(int $year, int $month, int $day, int $newYear, int $expectedDay): void
     {
         $localDate = LocalDate::of($year, $month, $day)->withYear($newYear);
-        $this->assertLocalDateIs($newYear, $month, $expectedDay, $localDate);
+        self::assertLocalDateIs($newYear, $month, $expectedDay, $localDate);
     }
 
     public function providerWithYear(): array
@@ -529,7 +529,7 @@ class LocalDateTest extends AbstractTestCase
     public function testWithMonth(int $year, int $month, int $day, int $newMonth, int $expectedDay): void
     {
         $localDate = LocalDate::of($year, $month, $day)->withMonth($newMonth);
-        $this->assertLocalDateIs($year, $newMonth, $expectedDay, $localDate);
+        self::assertLocalDateIs($year, $newMonth, $expectedDay, $localDate);
     }
 
     public function providerWithMonth(): array
@@ -582,7 +582,7 @@ class LocalDateTest extends AbstractTestCase
     public function testWithDay(int $year, int $month, int $day, int $newDay): void
     {
         $localDate = LocalDate::of($year, $month, $day)->withDay($newDay);
-        $this->assertLocalDateIs($year, $month, $newDay, $localDate);
+        self::assertLocalDateIs($year, $month, $newDay, $localDate);
     }
 
     public function providerWithDay(): array
@@ -638,7 +638,7 @@ class LocalDateTest extends AbstractTestCase
         $date = LocalDate::of($y, $m, $d);
         $period = Period::of($py, $pm, $pd);
 
-        $this->assertLocalDateIs($ey, $em, $ed, $date->plusPeriod($period));
+        self::assertLocalDateIs($ey, $em, $ed, $date->plusPeriod($period));
     }
 
     /**
@@ -659,7 +659,7 @@ class LocalDateTest extends AbstractTestCase
         $date = LocalDate::of($y, $m, $d);
         $period = Period::of(-$py, -$pm, -$pd);
 
-        $this->assertLocalDateIs($ey, $em, $ed, $date->minusPeriod($period));
+        self::assertLocalDateIs($ey, $em, $ed, $date->minusPeriod($period));
     }
 
     public function providerPeriod(): array
@@ -692,7 +692,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testPlusYears(int $y, int $m, int $d, int $ay, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusYears($ay));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusYears($ay));
     }
 
     public function providerPlusYears(): array
@@ -719,7 +719,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testPlusMonths(int $y, int $m, int $d, int $am, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusMonths($am));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusMonths($am));
     }
 
     public function providerPlusMonths(): array
@@ -755,7 +755,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testPlusWeeks(int $y, int $m, int $d, int $aw, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusWeeks($aw));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusWeeks($aw));
     }
 
     public function providerPlusWeeks(): array
@@ -784,7 +784,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testPlusDays(int $y, int $m, int $d, int $ad, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusDays($ad));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->plusDays($ad));
     }
 
     public function providerPlusDays(): array
@@ -812,7 +812,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testPlusWeekdays(string $date, int $days, string $expectedDate): void
     {
-        $this->assertSame($expectedDate, (string) LocalDate::parse($date)->plusWeekdays($days));
+        self::assertSame($expectedDate, (string) LocalDate::parse($date)->plusWeekdays($days));
     }
 
     /**
@@ -820,7 +820,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testMinusWeekdays(string $date, int $days, string $expectedDate): void
     {
-        $this->assertSame($expectedDate, (string) LocalDate::parse($date)->minusWeekdays(-$days));
+        self::assertSame($expectedDate, (string) LocalDate::parse($date)->minusWeekdays(-$days));
     }
 
     public function providerPlusWeekdays(): array
@@ -998,7 +998,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function tesMinusYears(int $y, int $m, int $d, int $sy, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusYears($sy));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusYears($sy));
     }
 
     public function providerMinusYears(): array
@@ -1025,7 +1025,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testMinusMonths(int $y, int $m, int $d, int $sm, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusMonths($sm));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusMonths($sm));
     }
 
     public function providerMinusMonths(): array
@@ -1061,7 +1061,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testMinusWeeks(int $y, int $m, int $d, int $sw, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusWeeks($sw));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusWeeks($sw));
     }
 
     public function providerMinusWeeks(): array
@@ -1090,7 +1090,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testMinusDays(int $y, int $m, int $d, int $sd, int $ey, int $em, int $ed): void
     {
-        $this->assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusDays($sd));
+        self::assertLocalDateIs($ey, $em, $ed, LocalDate::of($y, $m, $d)->minusDays($sd));
     }
 
     public function providerMinusDays(): array
@@ -1125,7 +1125,7 @@ class LocalDateTest extends AbstractTestCase
         $date1 = LocalDate::of($y1, $m1, $d1);
         $date2 = LocalDate::of($y2, $m2, $d2);
 
-        $this->assertPeriodIs($y, $m, $d, $date1->until($date2));
+        self::assertPeriodIs($y, $m, $d, $date1->until($date2));
     }
 
     public function providerUntil(): array
@@ -1232,7 +1232,7 @@ class LocalDateTest extends AbstractTestCase
         $date1 = LocalDate::parse($date1);
         $date2 = LocalDate::parse($date2);
 
-        $this->assertSame($expectedDays, $date1->daysUntil($date2));
+        self::assertSame($expectedDays, $date1->daysUntil($date2));
     }
 
     public function providerDaysUntil(): array
@@ -1249,7 +1249,7 @@ class LocalDateTest extends AbstractTestCase
     public function testAtTime(): void
     {
         $localDateTime = LocalDate::of(1, 2, 3)->atTime(LocalTime::of(4, 5, 6, 7));
-        $this->assertLocalDateTimeIs(1, 2, 3, 4, 5, 6, 7, $localDateTime);
+        self::assertLocalDateTimeIs(1, 2, 3, 4, 5, 6, 7, $localDateTime);
     }
 
     /**
@@ -1262,7 +1262,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testIsLeapYear(int $y, int $m, int $d, bool $isLeap): void
     {
-        $this->assertSame($isLeap, LocalDate::of($y, $m, $d)->isLeapYear());
+        self::assertSame($isLeap, LocalDate::of($y, $m, $d)->isLeapYear());
     }
 
     /**
@@ -1275,7 +1275,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testGetLengthOfYear(int $y, int $m, int $d, bool $isLeap): void
     {
-        $this->assertSame($isLeap ? 366 : 365, LocalDate::of($y, $m, $d)->getLengthOfYear());
+        self::assertSame($isLeap ? 366 : 365, LocalDate::of($y, $m, $d)->getLengthOfYear());
     }
 
     public function providerIsLeapYear(): array
@@ -1303,7 +1303,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testGetLengthOfMonth(int $y, int $m, int $d, int $length): void
     {
-        $this->assertSame($length, LocalDate::of($y, $m, $d)->getLengthOfMonth());
+        self::assertSame($length, LocalDate::of($y, $m, $d)->getLengthOfMonth());
     }
 
     public function providerGetLengthOfMonth(): array
@@ -1337,12 +1337,12 @@ class LocalDateTest extends AbstractTestCase
         $date1 = LocalDate::parse($date1);
         $date2 = LocalDate::parse($date2);
 
-        $this->assertSame($cmp, $date1->compareTo($date2));
-        $this->assertSame($cmp === 0, $date1->isEqualTo($date2));
-        $this->assertSame($cmp === -1, $date1->isBefore($date2));
-        $this->assertSame($cmp === 1, $date1->isAfter($date2));
-        $this->assertSame($cmp <= 0, $date1->isBeforeOrEqualTo($date2));
-        $this->assertSame($cmp >= 0, $date1->isAfterOrEqualTo($date2));
+        self::assertSame($cmp, $date1->compareTo($date2));
+        self::assertSame($cmp === 0, $date1->isEqualTo($date2));
+        self::assertSame($cmp === -1, $date1->isBefore($date2));
+        self::assertSame($cmp === 1, $date1->isAfter($date2));
+        self::assertSame($cmp <= 0, $date1->isBeforeOrEqualTo($date2));
+        self::assertSame($cmp >= 0, $date1->isAfterOrEqualTo($date2));
     }
 
     public function providerCompareTo(): array
@@ -1370,7 +1370,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $year, int $month, int $day, string $expected): void
     {
-        $this->assertSame(json_encode($expected), json_encode(LocalDate::of($year, $month, $day)));
+        self::assertSame(json_encode($expected), json_encode(LocalDate::of($year, $month, $day)));
     }
 
     /**
@@ -1383,7 +1383,7 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testToString(int $year, int $month, int $day, string $expected): void
     {
-        $this->assertSame($expected, (string) LocalDate::of($year, $month, $day));
+        self::assertSame($expected, (string) LocalDate::of($year, $month, $day));
     }
 
     public function providerToString(): array
@@ -1400,8 +1400,8 @@ class LocalDateTest extends AbstractTestCase
         $b = LocalDate::of(2016, 7, 31);
         $c = LocalDate::of(2017, 2, 1);
 
-        $this->assertSame($a, LocalDate::minOf($a, $b, $c));
-        $this->assertSame($c, LocalDate::maxOf($a, $b, $c));
+        self::assertSame($a, LocalDate::minOf($a, $b, $c));
+        self::assertSame($c, LocalDate::maxOf($a, $b, $c));
     }
 
     public function testMinOfZeroElementsThrowsException(): void
@@ -1427,8 +1427,8 @@ class LocalDateTest extends AbstractTestCase
         $localDate = LocalDate::parse($dateTime);
         $dateTime = $localDate->toNativeDateTime();
 
-        $this->assertInstanceOf(DateTime::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTime::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     /**
@@ -1442,8 +1442,8 @@ class LocalDateTest extends AbstractTestCase
         $localDate = LocalDate::parse($dateTime);
         $dateTime = $localDate->toNativeDateTimeImmutable();
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTimeImmutable::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     public function providerToNativeDateTime(): array

--- a/tests/LocalDateTimeTest.php
+++ b/tests/LocalDateTimeTest.php
@@ -31,13 +31,13 @@ class LocalDateTimeTest extends AbstractTestCase
         $date = LocalDate::of(2001, 12, 23);
         $time = LocalTime::of(12, 34, 56, 987654321);
 
-        $this->assertLocalDateTimeIs(2001, 12, 23, 12, 34, 56, 987654321, new LocalDateTime($date, $time));
+        self::assertLocalDateTimeIs(2001, 12, 23, 12, 34, 56, 987654321, new LocalDateTime($date, $time));
     }
 
     public function testFromNativeDateTime(): void
     {
         $dateTime = new DateTime('2018-07-21 14:09:10.23456');
-        $this->assertLocalDateTimeIs(2018, 7, 21, 14, 9, 10, 234560000, LocalDateTime::fromNativeDateTime($dateTime));
+        self::assertLocalDateTimeIs(2018, 7, 21, 14, 9, 10, 234560000, LocalDateTime::fromNativeDateTime($dateTime));
     }
 
     /**
@@ -58,7 +58,7 @@ class LocalDateTimeTest extends AbstractTestCase
     {
         $clock = new FixedClock(Instant::of($second, $nano));
         $timeZone = TimeZoneOffset::ofTotalSeconds($offset);
-        $this->assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, LocalDateTime::now($timeZone, $clock));
+        self::assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, LocalDateTime::now($timeZone, $clock));
     }
 
     public function providerNow(): array
@@ -85,7 +85,7 @@ class LocalDateTimeTest extends AbstractTestCase
      */
     public function testParse(string $t, int $y, int $m, int $d, int $h, int $i, int $s, int $n): void
     {
-        $this->assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, LocalDateTime::parse($t));
+        self::assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, LocalDateTime::parse($t));
     }
 
     public function providerParse(): array
@@ -161,16 +161,16 @@ class LocalDateTimeTest extends AbstractTestCase
     {
         $min = LocalDateTime::min();
 
-        $this->assertLocalDateTimeIs(Year::MIN_VALUE, 1, 1, 0, 0, 0, 0, $min);
-        $this->assertSame($min, LocalDateTime::min());
+        self::assertLocalDateTimeIs(Year::MIN_VALUE, 1, 1, 0, 0, 0, 0, $min);
+        self::assertSame($min, LocalDateTime::min());
     }
 
     public function testMax(): void
     {
         $max = LocalDateTime::max();
 
-        $this->assertLocalDateTimeIs(Year::MAX_VALUE, 12, 31, 23, 59, 59, 999999999, $max);
-        $this->assertSame($max, LocalDateTime::max());
+        self::assertLocalDateTimeIs(Year::MAX_VALUE, 12, 31, 23, 59, 59, 999999999, $max);
+        self::assertSame($max, LocalDateTime::max());
     }
 
     public function testMinMaxOf(): void
@@ -179,8 +179,8 @@ class LocalDateTimeTest extends AbstractTestCase
         $b = LocalDateTime::parse('2005-12-31T23:59:59.999999999');
         $c = LocalDateTime::parse('2006-07-12T05:22:11');
 
-        $this->assertSame($a, LocalDateTime::minOf($a, $b, $c));
-        $this->assertSame($c, LocalDateTime::maxOf($a, $b, $c));
+        self::assertSame($a, LocalDateTime::minOf($a, $b, $c));
+        self::assertSame($c, LocalDateTime::maxOf($a, $b, $c));
     }
 
     public function testMinOfZeroElementsThrowsException(): void
@@ -206,7 +206,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testGetDayOfWeek(int $year, int $month, int $day, int $dayOfWeek): void
     {
         $dateTime = LocalDateTime::of($year, $month, $day, 15, 30, 45);
-        $this->assertDayOfWeekIs($dayOfWeek, $dateTime->getDayOfWeek());
+        self::assertDayOfWeekIs($dayOfWeek, $dateTime->getDayOfWeek());
     }
 
     public function providerGetDayOfWeek(): array
@@ -240,7 +240,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testGetDayOfYear(int $year, int $month, int $day, int $dayOfYear): void
     {
         $dateTime = LocalDate::of($year, $month, $day)->atTime(LocalTime::midnight());
-        $this->assertSame($dayOfYear, $dateTime->getDayOfYear());
+        self::assertSame($dayOfYear, $dateTime->getDayOfYear());
     }
 
     public function providerGetDayOfYear(): array
@@ -265,7 +265,7 @@ class LocalDateTimeTest extends AbstractTestCase
     {
         $dateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6, 789));
         $newDate = LocalDate::of($y, $m, $d);
-        $this->assertLocalDateTimeIs($y, $m, $d, 4, 5, 6, 789, $dateTime->withDate($newDate));
+        self::assertLocalDateTimeIs($y, $m, $d, 4, 5, 6, 789, $dateTime->withDate($newDate));
     }
 
     public function providerWithDate(): array
@@ -288,7 +288,7 @@ class LocalDateTimeTest extends AbstractTestCase
     {
         $dateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6, 789));
         $newTime = LocalTime::of($h, $m, $s, $n);
-        $this->assertLocalDateTimeIs(2001, 2, 3, $h, $m, $s, $n, $dateTime->withTime($newTime));
+        self::assertLocalDateTimeIs(2001, 2, 3, $h, $m, $s, $n, $dateTime->withTime($newTime));
     }
 
     public function providerWithTime(): array
@@ -313,7 +313,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $date = LocalDate::of($year, $month, $day);
         $time = LocalTime::of(1, 2, 3, 123456789);
         $localDateTime = $date->atTime($time)->withYear($newYear);
-        $this->assertLocalDateTimeIs($newYear, $month, $expectedDay, 1, 2, 3, 123456789, $localDateTime);
+        self::assertLocalDateTimeIs($newYear, $month, $expectedDay, 1, 2, 3, 123456789, $localDateTime);
     }
 
     public function providerWithYear(): array
@@ -361,7 +361,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $date = LocalDate::of($year, $month, $day);
         $time = LocalTime::of(1, 2, 3, 123456789);
         $localDateTime = $date->atTime($time)->withMonth($newMonth);
-        $this->assertLocalDateTimeIs($year, $newMonth, $expectedDay, 1, 2, 3, 123456789, $localDateTime);
+        self::assertLocalDateTimeIs($year, $newMonth, $expectedDay, 1, 2, 3, 123456789, $localDateTime);
     }
 
     public function providerWithMonth(): array
@@ -416,7 +416,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $date = LocalDate::of($year, $month, $day);
         $time = LocalTime::of(1, 2, 3, 123456789);
         $localDateTime = $date->atTime($time)->withDay($newDay);
-        $this->assertLocalDateTimeIs($year, $month, $newDay, 1, 2, 3, 123456789, $localDateTime);
+        self::assertLocalDateTimeIs($year, $month, $newDay, 1, 2, 3, 123456789, $localDateTime);
     }
 
     public function providerWithDay(): array
@@ -462,7 +462,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testWithHour(int $hour): void
     {
         $localDateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(12, 34, 56, 123456789));
-        $this->assertLocalDateTimeIs(2001, 2, 3, $hour, 34, 56, 123456789, $localDateTime->withHour($hour));
+        self::assertLocalDateTimeIs(2001, 2, 3, $hour, 34, 56, 123456789, $localDateTime->withHour($hour));
     }
 
     public function providerWithHour(): array
@@ -498,7 +498,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testWithMinute(int $minute): void
     {
         $localDateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(12, 34, 56, 123456789));
-        $this->assertLocalDateTimeIs(2001, 2, 3, 12, $minute, 56, 123456789, $localDateTime->withMinute($minute));
+        self::assertLocalDateTimeIs(2001, 2, 3, 12, $minute, 56, 123456789, $localDateTime->withMinute($minute));
     }
 
     public function providerWithMinute(): array
@@ -534,7 +534,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testWithSecond(int $second): void
     {
         $localDateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(12, 34, 56, 123456789));
-        $this->assertLocalDateTimeIs(2001, 2, 3, 12, 34, $second, 123456789, $localDateTime->withSecond($second));
+        self::assertLocalDateTimeIs(2001, 2, 3, 12, 34, $second, 123456789, $localDateTime->withSecond($second));
     }
 
     public function providerWithSecond(): array
@@ -570,7 +570,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testWithNano(int $nano): void
     {
         $localDateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(12, 34, 56, 123456789));
-        $this->assertLocalDateTimeIs(2001, 2, 3, 12, 34, 56, $nano, $localDateTime->withNano($nano));
+        self::assertLocalDateTimeIs(2001, 2, 3, 12, 34, 56, $nano, $localDateTime->withNano($nano));
     }
 
     public function providerWithNano(): array
@@ -616,7 +616,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $dateTime = LocalDate::of($y, $m, $d)->atTime(LocalTime::of(12, 34, 56, 123456789));
         $period = Period::of($py, $pm, $pd);
 
-        $this->assertLocalDateTimeIs($ey, $em, $ed, 12, 34, 56, 123456789, $dateTime->plusPeriod($period));
+        self::assertLocalDateTimeIs($ey, $em, $ed, 12, 34, 56, 123456789, $dateTime->plusPeriod($period));
     }
 
     /**
@@ -637,7 +637,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $dateTime = LocalDate::of($y, $m, $d)->atTime(LocalTime::of(12, 34, 56, 123456789));
         $period = Period::of($py, $pm, $pd);
 
-        $this->assertLocalDateTimeIs($ey, $em, $ed, 12, 34, 56, 123456789, $dateTime->minusPeriod($period->negated()));
+        self::assertLocalDateTimeIs($ey, $em, $ed, 12, 34, 56, 123456789, $dateTime->minusPeriod($period->negated()));
     }
 
     public function providerPeriod(): array
@@ -674,7 +674,7 @@ class LocalDateTimeTest extends AbstractTestCase
     {
         $localDateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6, 123456789));
         $duration = Duration::ofSeconds($ds, $dn);
-        $this->assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, $localDateTime->plusDuration($duration));
+        self::assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, $localDateTime->plusDuration($duration));
     }
 
     /**
@@ -694,7 +694,7 @@ class LocalDateTimeTest extends AbstractTestCase
     {
         $localDateTime = LocalDate::of(2001, 2, 3)->atTime(LocalTime::of(4, 5, 6, 123456789));
         $duration = Duration::ofSeconds(-$ds, -$dn);
-        $this->assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, $localDateTime->minusDuration($duration));
+        self::assertLocalDateTimeIs($y, $m, $d, $h, $i, $s, $n, $localDateTime->minusDuration($duration));
     }
 
     public function providerDuration(): array
@@ -718,7 +718,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusYears(string $dateTime, int $years, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusYears($years);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusYears(): array
@@ -740,7 +740,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusMonths(string $dateTime, int $months, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusMonths($months);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusMonths(): array
@@ -762,7 +762,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusWeeks(string $dateTime, int $weeks, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusWeeks($weeks);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusWeeks(): array
@@ -784,7 +784,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusDays(string $dateTime, int $days, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusDays($days);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusDays(): array
@@ -806,7 +806,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusHours(string $dateTime, int $hours, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusHours($hours);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusHours(): array
@@ -828,7 +828,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusMinutes(string $dateTime, int $minutes, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusMinutes($minutes);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusMinutes(): array
@@ -850,7 +850,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusSeconds(string $dateTime, int $seconds, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusSeconds($seconds);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusSeconds(): array
@@ -872,7 +872,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testPlusNanos(string $dateTime, int $nanosToAdd, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->plusNanos($nanosToAdd);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerPlusNanos(): array
@@ -895,7 +895,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusYears(string $dateTime, int $years, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusYears($years);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusYears(): array
@@ -917,7 +917,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusMonths(string $dateTime, int $months, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusMonths($months);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusMonths(): array
@@ -939,7 +939,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusWeeks(string $dateTime, int $weeks, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusWeeks($weeks);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusWeeks(): array
@@ -961,7 +961,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusDays(string $dateTime, int $days, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusDays($days);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusDays(): array
@@ -983,7 +983,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusHours(string $dateTime, int $hours, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusHours($hours);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusHours(): array
@@ -1005,7 +1005,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusMinutes(string $dateTime, int $minutes, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusMinutes($minutes);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusMinutes(): array
@@ -1027,7 +1027,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusSeconds(string $dateTime, int $seconds, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusSeconds($seconds);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusSeconds(): array
@@ -1049,7 +1049,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testMinusNanos(string $dateTime, int $nanosToSubtract, string $expectedDateTime): void
     {
         $actualDateTime = LocalDateTime::parse($dateTime)->minusNanos($nanosToSubtract);
-        $this->assertSame($expectedDateTime, (string) $actualDateTime);
+        self::assertSame($expectedDateTime, (string) $actualDateTime);
     }
 
     public function providerMinusNanos(): array
@@ -1073,7 +1073,7 @@ class LocalDateTimeTest extends AbstractTestCase
     public function testAtTimeZone(string $dateTime, string $timeZone, int $epochSeconds, int $nanos): void
     {
         $localDateTime = LocalDateTime::parse($dateTime)->atTimeZone(TimeZone::parse($timeZone));
-        $this->assertInstantIs($epochSeconds, $nanos, $localDateTime->getInstant());
+        self::assertInstantIs($epochSeconds, $nanos, $localDateTime->getInstant());
     }
 
     public function providerAtTimeZone(): array
@@ -1098,13 +1098,13 @@ class LocalDateTimeTest extends AbstractTestCase
         $dateTime1 = LocalDateTime::parse($dateTime1);
         $dateTime2 = LocalDateTime::parse($dateTime2);
 
-        $this->assertSame($result, $dateTime1->compareTo($dateTime2));
+        self::assertSame($result, $dateTime1->compareTo($dateTime2));
 
-        $this->assertSame($result === 0, $dateTime1->isEqualTo($dateTime2));
-        $this->assertSame($result === 1, $dateTime1->isAfter($dateTime2));
-        $this->assertSame($result === -1, $dateTime1->isBefore($dateTime2));
-        $this->assertSame($result >= 0, $dateTime1->isAfterOrEqualTo($dateTime2));
-        $this->assertSame($result <= 0, $dateTime1->isBeforeOrEqualTo($dateTime2));
+        self::assertSame($result === 0, $dateTime1->isEqualTo($dateTime2));
+        self::assertSame($result === 1, $dateTime1->isAfter($dateTime2));
+        self::assertSame($result === -1, $dateTime1->isBefore($dateTime2));
+        self::assertSame($result >= 0, $dateTime1->isAfterOrEqualTo($dateTime2));
+        self::assertSame($result <= 0, $dateTime1->isBeforeOrEqualTo($dateTime2));
     }
 
     public function providerCompareTo(): array
@@ -1136,7 +1136,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $clock = new FixedClock(Instant::of($clockTimestamp));
         $localDateTime = LocalDateTime::parse($localDateTime);
         $timeZone = TimeZoneOffset::parse($offset);
-        $this->assertSame($isFuture, $localDateTime->isFuture($timeZone, $clock));
+        self::assertSame($isFuture, $localDateTime->isFuture($timeZone, $clock));
     }
 
     /**
@@ -1147,7 +1147,7 @@ class LocalDateTimeTest extends AbstractTestCase
         $clock = new FixedClock(Instant::of($clockTimestamp));
         $localDateTime = LocalDateTime::parse($localDateTime);
         $timeZone = TimeZoneOffset::parse($offset);
-        $this->assertSame(! $isFuture, $localDateTime->isPast($timeZone, $clock));
+        self::assertSame(! $isFuture, $localDateTime->isPast($timeZone, $clock));
     }
 
     public function providerForPastFuture(): array
@@ -1171,8 +1171,8 @@ class LocalDateTimeTest extends AbstractTestCase
         $localDateTime = LocalDateTime::parse($dateTime);
         $dateTime = $localDateTime->toNativeDateTime();
 
-        $this->assertInstanceOf(DateTime::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTime::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     /**
@@ -1186,8 +1186,8 @@ class LocalDateTimeTest extends AbstractTestCase
         $localDateTime = LocalDateTime::parse($dateTime);
         $dateTime = $localDateTime->toNativeDateTimeImmutable();
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTimeImmutable::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     public function providerToNativeDateTime(): array
@@ -1217,7 +1217,7 @@ class LocalDateTimeTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $year, int $month, int $day, int $hour, int $minute, int $second, int $nano, string $expected): void
     {
-        $this->assertSame(json_encode($expected), json_encode(LocalDateTime::of($year, $month, $day, $hour, $minute, $second, $nano)));
+        self::assertSame(json_encode($expected), json_encode(LocalDateTime::of($year, $month, $day, $hour, $minute, $second, $nano)));
     }
 
     /**
@@ -1234,7 +1234,7 @@ class LocalDateTimeTest extends AbstractTestCase
      */
     public function testToString(int $year, int $month, int $day, int $hour, int $minute, int $second, int $nano, string $expected): void
     {
-        $this->assertSame($expected, (string) LocalDateTime::of($year, $month, $day, $hour, $minute, $second, $nano));
+        self::assertSame($expected, (string) LocalDateTime::of($year, $month, $day, $hour, $minute, $second, $nano));
     }
 
     public function providerToString(): array

--- a/tests/LocalTimeTest.php
+++ b/tests/LocalTimeTest.php
@@ -24,7 +24,7 @@ class LocalTimeTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertLocalTimeIs(12, 34, 56, 123456789, LocalTime::of(12, 34, 56, 123456789));
+        self::assertLocalTimeIs(12, 34, 56, 123456789, LocalTime::of(12, 34, 56, 123456789));
     }
 
     /**
@@ -59,7 +59,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testOfSecondOfDay(int $secondOfDay, int $hour, int $minute, int $second): void
     {
         $localTime = LocalTime::ofSecondOfDay($secondOfDay, 123);
-        $this->assertLocalTimeIs($hour, $minute, $second, 123, $localTime);
+        self::assertLocalTimeIs($hour, $minute, $second, 123, $localTime);
     }
 
     public function providerOfSecondOfDay(): array
@@ -109,10 +109,10 @@ class LocalTimeTest extends AbstractTestCase
     {
         $time = LocalTime::parse($text);
 
-        $this->assertSame($hour, $time->getHour());
-        $this->assertSame($minute, $time->getMinute());
-        $this->assertSame($second, $time->getSecond());
-        $this->assertSame($nano, $time->getNano());
+        self::assertSame($hour, $time->getHour());
+        self::assertSame($minute, $time->getMinute());
+        self::assertSame($second, $time->getSecond());
+        self::assertSame($nano, $time->getNano());
     }
 
     public function providerParse(): array
@@ -155,7 +155,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testFromNativeDateTime(): void
     {
         $dateTime = new DateTime('2018-07-21 14:09:10.23456');
-        $this->assertLocalTimeIs(14, 9, 10, 234560000, LocalTime::fromNativeDateTime($dateTime));
+        self::assertLocalTimeIs(14, 9, 10, 234560000, LocalTime::fromNativeDateTime($dateTime));
     }
 
     /**
@@ -173,7 +173,7 @@ class LocalTimeTest extends AbstractTestCase
     {
         $clock = new FixedClock(Instant::of($second, $nano));
         $timeZone = TimeZoneOffset::ofTotalSeconds($offset);
-        $this->assertLocalTimeIs($h, $m, $s, $n, LocalTime::now($timeZone, $clock));
+        self::assertLocalTimeIs($h, $m, $s, $n, LocalTime::now($timeZone, $clock));
     }
 
     public function providerNow(): array
@@ -190,32 +190,32 @@ class LocalTimeTest extends AbstractTestCase
     {
         $midnight = LocalTime::midnight();
 
-        $this->assertLocalTimeIs(0, 0, 0, 0, $midnight);
-        $this->assertSame($midnight, LocalTime::midnight());
+        self::assertLocalTimeIs(0, 0, 0, 0, $midnight);
+        self::assertSame($midnight, LocalTime::midnight());
     }
 
     public function testNoon(): void
     {
         $noon = LocalTime::noon();
 
-        $this->assertLocalTimeIs(12, 0, 0, 0, $noon);
-        $this->assertSame($noon, LocalTime::noon());
+        self::assertLocalTimeIs(12, 0, 0, 0, $noon);
+        self::assertSame($noon, LocalTime::noon());
     }
 
     public function testMin(): void
     {
         $min = LocalTime::min();
 
-        $this->assertLocalTimeIs(0, 0, 0, 0, $min);
-        $this->assertSame($min, LocalTime::min());
+        self::assertLocalTimeIs(0, 0, 0, 0, $min);
+        self::assertSame($min, LocalTime::min());
     }
 
     public function testMax(): void
     {
         $max = LocalTime::max();
 
-        $this->assertLocalTimeIs(23, 59, 59, 999999999, $max);
-        $this->assertSame($max, LocalTime::max());
+        self::assertLocalTimeIs(23, 59, 59, 999999999, $max);
+        self::assertSame($max, LocalTime::max());
     }
 
     /**
@@ -225,7 +225,7 @@ class LocalTimeTest extends AbstractTestCase
      */
     public function testWithHour(int $hour): void
     {
-        $this->assertLocalTimeIs($hour, 34, 56, 789, LocalTime::of(12, 34, 56, 789)->withHour($hour));
+        self::assertLocalTimeIs($hour, 34, 56, 789, LocalTime::of(12, 34, 56, 789)->withHour($hour));
     }
 
     public function providerWithHour(): array
@@ -260,7 +260,7 @@ class LocalTimeTest extends AbstractTestCase
      */
     public function testWithMinute(int $minute): void
     {
-        $this->assertLocalTimeIs(12, $minute, 56, 789, LocalTime::of(12, 34, 56, 789)->withMinute($minute));
+        self::assertLocalTimeIs(12, $minute, 56, 789, LocalTime::of(12, 34, 56, 789)->withMinute($minute));
     }
 
     public function providerWithMinute(): array
@@ -295,7 +295,7 @@ class LocalTimeTest extends AbstractTestCase
      */
     public function testWithSecond(int $second): void
     {
-        $this->assertLocalTimeIs(12, 34, $second, 789, LocalTime::of(12, 34, 56, 789)->withSecond($second));
+        self::assertLocalTimeIs(12, 34, $second, 789, LocalTime::of(12, 34, 56, 789)->withSecond($second));
     }
 
     public function providerWithSecond(): array
@@ -330,7 +330,7 @@ class LocalTimeTest extends AbstractTestCase
      */
     public function testWithNano(int $nano): void
     {
-        $this->assertLocalTimeIs(12, 34, 56, $nano, LocalTime::of(12, 34, 56, 789)->withNano($nano));
+        self::assertLocalTimeIs(12, 34, 56, $nano, LocalTime::of(12, 34, 56, 789)->withNano($nano));
     }
 
     public function providerWithNano(): array
@@ -376,7 +376,7 @@ class LocalTimeTest extends AbstractTestCase
     {
         $localTime = LocalTime::of($h, $m, $s, $n);
         $duration = Duration::ofSeconds($ds, $dn);
-        $this->assertLocalTimeIs($eh, $em, $es, $en, $localTime->plusDuration($duration));
+        self::assertLocalTimeIs($eh, $em, $es, $en, $localTime->plusDuration($duration));
     }
 
     /**
@@ -397,7 +397,7 @@ class LocalTimeTest extends AbstractTestCase
     {
         $localTime = LocalTime::of($h, $m, $s, $n);
         $duration = Duration::ofSeconds(-$ds, -$dn);
-        $this->assertLocalTimeIs($eh, $em, $es, $en, $localTime->minusDuration($duration));
+        self::assertLocalTimeIs($eh, $em, $es, $en, $localTime->minusDuration($duration));
     }
 
     public function providerDuration(): array
@@ -420,7 +420,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testPlusHours(int $h, int $d, int $eh): void
     {
         $result = LocalTime::of($h, 34, 56, 789)->plusHours($d);
-        $this->assertLocalTimeIs($eh, 34, 56, 789, $result);
+        self::assertLocalTimeIs($eh, 34, 56, 789, $result);
     }
 
     /**
@@ -433,7 +433,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testMinusHours(int $h, int $d, int $eh): void
     {
         $result = LocalTime::of($h, 34, 56, 789)->minusHours(-$d);
-        $this->assertLocalTimeIs($eh, 34, 56, 789, $result);
+        self::assertLocalTimeIs($eh, 34, 56, 789, $result);
     }
 
     public function providerPlusHours(): array
@@ -481,7 +481,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testPlusMinutes(int $h, int $m, int $d, int $eh, int $em): void
     {
         $result = LocalTime::of($h, $m, 56, 789)->plusMinutes($d);
-        $this->assertLocalTimeIs($eh, $em, 56, 789, $result);
+        self::assertLocalTimeIs($eh, $em, 56, 789, $result);
     }
 
     /**
@@ -496,7 +496,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testMinusMinutes(int $h, int $m, int $d, int $eh, int $em): void
     {
         $result = LocalTime::of($h, $m, 56, 789)->minusMinutes(-$d);
-        $this->assertLocalTimeIs($eh, $em, 56, 789, $result);
+        self::assertLocalTimeIs($eh, $em, 56, 789, $result);
     }
 
     public function providerPlusMinutes(): array
@@ -564,7 +564,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testPlusSeconds(int $h, int $m, int $s, int $d, int $eh, int $em, int $es): void
     {
         $result = LocalTime::of($h, $m, $s, 123456789)->plusSeconds($d);
-        $this->assertLocalTimeIs($eh, $em, $es, 123456789, $result);
+        self::assertLocalTimeIs($eh, $em, $es, 123456789, $result);
     }
 
     /**
@@ -581,7 +581,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testMinusSeconds(int $h, int $m, int $s, int $d, int $eh, int $em, int $es): void
     {
         $result = LocalTime::of($h, $m, $s, 123456789)->minusSeconds(-$d);
-        $this->assertLocalTimeIs($eh, $em, $es, 123456789, $result);
+        self::assertLocalTimeIs($eh, $em, $es, 123456789, $result);
     }
 
     public function providerPlusSeconds(): array
@@ -663,7 +663,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testPlusNanos(int $h, int $m, int $s, int $n, int $d, int $eh, int $em, int $es, int $en): void
     {
         $result = LocalTime::of($h, $m, $s, $n)->plusNanos($d);
-        $this->assertLocalTimeIs($eh, $em, $es, $en, $result);
+        self::assertLocalTimeIs($eh, $em, $es, $en, $result);
     }
 
     /**
@@ -682,7 +682,7 @@ class LocalTimeTest extends AbstractTestCase
     public function testMinusNanos(int $h, int $m, int $s, int $n, int $d, int $eh, int $em, int $es, int $en): void
     {
         $result = LocalTime::of($h, $m, $s, $n)->minusNanos(-$d);
-        $this->assertLocalTimeIs($eh, $em, $es, $en, $result);
+        self::assertLocalTimeIs($eh, $em, $es, $en, $result);
     }
 
     public function providerPlusNanos(): array
@@ -730,12 +730,12 @@ class LocalTimeTest extends AbstractTestCase
         $t1 = LocalTime::of($h1, $m1, $s1, $n1);
         $t2 = LocalTime::of($h2, $m2, $s2, $n2);
 
-        $this->assertSame($cmp, $t1->compareTo($t2));
-        $this->assertSame($cmp === 0, $t1->isEqualTo($t2));
-        $this->assertSame($cmp === -1, $t1->isBefore($t2));
-        $this->assertSame($cmp === 1, $t1->isAfter($t2));
-        $this->assertSame($cmp <= 0, $t1->isBeforeOrEqualTo($t2));
-        $this->assertSame($cmp >= 0, $t1->isAfterOrEqualTo($t2));
+        self::assertSame($cmp, $t1->compareTo($t2));
+        self::assertSame($cmp === 0, $t1->isEqualTo($t2));
+        self::assertSame($cmp === -1, $t1->isBefore($t2));
+        self::assertSame($cmp === 1, $t1->isAfter($t2));
+        self::assertSame($cmp <= 0, $t1->isBeforeOrEqualTo($t2));
+        self::assertSame($cmp >= 0, $t1->isAfterOrEqualTo($t2));
     }
 
     public function providerCompareTo(): array
@@ -1005,7 +1005,7 @@ class LocalTimeTest extends AbstractTestCase
         $time = LocalTime::of(12, 34, 56, 789);
         $date = LocalDate::of(2014, 11, 30);
 
-        $this->assertLocalDateTimeIs(2014, 11, 30, 12, 34, 56, 789, $time->atDate($date));
+        self::assertLocalDateTimeIs(2014, 11, 30, 12, 34, 56, 789, $time->atDate($date));
     }
 
     /**
@@ -1015,8 +1015,8 @@ class LocalTimeTest extends AbstractTestCase
     {
         $time = LocalTime::of($hour, $minute, $second);
 
-        $this->assertSame($result, $time->toSecondOfDay());
-        $this->assertSame($result, $time->withNano(123)->toSecondOfDay());
+        self::assertSame($result, $time->toSecondOfDay());
+        self::assertSame($result, $time->withNano(123)->toSecondOfDay());
     }
 
     public function providerToSecondOfDay(): array
@@ -1042,7 +1042,7 @@ class LocalTimeTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $h, int $m, int $s, int $n, string $r): void
     {
-        $this->assertSame(json_encode($r), json_encode(LocalTime::of($h, $m, $s, $n)));
+        self::assertSame(json_encode($r), json_encode(LocalTime::of($h, $m, $s, $n)));
     }
 
     /**
@@ -1056,7 +1056,7 @@ class LocalTimeTest extends AbstractTestCase
      */
     public function testToString(int $h, int $m, int $s, int $n, string $r): void
     {
-        $this->assertSame($r, (string) LocalTime::of($h, $m, $s, $n));
+        self::assertSame($r, (string) LocalTime::of($h, $m, $s, $n));
     }
 
     public function providerToString(): array
@@ -1077,8 +1077,8 @@ class LocalTimeTest extends AbstractTestCase
         $b = LocalTime::of(14, 30);
         $c = LocalTime::of(17, 15);
 
-        $this->assertSame($a, LocalTime::minOf($a, $b, $c));
-        $this->assertSame($c, LocalTime::maxOf($a, $b, $c));
+        self::assertSame($a, LocalTime::minOf($a, $b, $c));
+        self::assertSame($c, LocalTime::maxOf($a, $b, $c));
     }
 
     public function testMinOfZeroElementsThrowsException(): void
@@ -1104,8 +1104,8 @@ class LocalTimeTest extends AbstractTestCase
         $localTime = LocalTime::parse($dateTime);
         $dateTime = $localTime->toNativeDateTime();
 
-        $this->assertInstanceOf(DateTime::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTime::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     /**
@@ -1119,8 +1119,8 @@ class LocalTimeTest extends AbstractTestCase
         $localTime = LocalTime::parse($dateTime);
         $dateTime = $localTime->toNativeDateTimeImmutable();
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTimeImmutable::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     public function providerToNativeDateTime()

--- a/tests/MonthDayTest.php
+++ b/tests/MonthDayTest.php
@@ -23,7 +23,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testOf(int $month, int $day): void
     {
-        $this->assertMonthDayIs($month, $day, MonthDay::of($month, $day));
+        self::assertMonthDayIs($month, $day, MonthDay::of($month, $day));
     }
 
     public function providerOf(): array
@@ -84,7 +84,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testParse(string $text, int $month, int $day): void
     {
-        $this->assertMonthDayIs($month, $day, MonthDay::parse($text));
+        self::assertMonthDayIs($month, $day, MonthDay::parse($text));
     }
 
     public function providerParse(): array
@@ -153,7 +153,7 @@ class MonthDayTest extends AbstractTestCase
     public function testNow(int $epochSecond, string $timeZone, int $month, int $day): void
     {
         $clock = new FixedClock(Instant::of($epochSecond));
-        $this->assertMonthDayIs($month, $day, MonthDay::now(TimeZone::parse($timeZone), $clock));
+        self::assertMonthDayIs($month, $day, MonthDay::now(TimeZone::parse($timeZone), $clock));
     }
 
     public function providerNow(): array
@@ -177,7 +177,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testCompareTo(int $m1, int $d1, int $m2, int $d2, int $result): void
     {
-        $this->assertSame($result, MonthDay::of($m1, $d1)->compareTo(MonthDay::of($m2, $d2)));
+        self::assertSame($result, MonthDay::of($m1, $d1)->compareTo(MonthDay::of($m2, $d2)));
     }
 
     /**
@@ -191,7 +191,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testIsEqualTo(int $m1, int $d1, int $m2, int $d2, int $result): void
     {
-        $this->assertSame($result === 0, MonthDay::of($m1, $d1)->isEqualTo(MonthDay::of($m2, $d2)));
+        self::assertSame($result === 0, MonthDay::of($m1, $d1)->isEqualTo(MonthDay::of($m2, $d2)));
     }
 
     /**
@@ -205,7 +205,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testIsBefore(int $m1, int $d1, int $m2, int $d2, int $result): void
     {
-        $this->assertSame($result === -1, MonthDay::of($m1, $d1)->isBefore(MonthDay::of($m2, $d2)));
+        self::assertSame($result === -1, MonthDay::of($m1, $d1)->isBefore(MonthDay::of($m2, $d2)));
     }
 
     /**
@@ -219,7 +219,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testIsAfter(int $m1, int $d1, int $m2, int $d2, int $result): void
     {
-        $this->assertSame($result === 1, MonthDay::of($m1, $d1)->isAfter(MonthDay::of($m2, $d2)));
+        self::assertSame($result === 1, MonthDay::of($m1, $d1)->isAfter(MonthDay::of($m2, $d2)));
     }
 
     public function providerCompareTo(): array
@@ -254,7 +254,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testIsValidYear(int $month, int $day, int $year, bool $isValid): void
     {
-        $this->assertSame($isValid, MonthDay::of($month, $day)->isValidYear($year));
+        self::assertSame($isValid, MonthDay::of($month, $day)->isValidYear($year));
     }
 
     public function providerIsValidYear(): array
@@ -293,8 +293,8 @@ class MonthDayTest extends AbstractTestCase
         $monthDay = MonthDay::of($month, $day);
         $newMonthDay = $monthDay->withMonth($newMonth);
 
-        $this->assertMonthDayIs($month, $day, $monthDay);
-        $this->assertMonthDayIs($newMonth, $expectedDay, $newMonthDay);
+        self::assertMonthDayIs($month, $day, $monthDay);
+        self::assertMonthDayIs($newMonth, $expectedDay, $newMonthDay);
     }
 
     public function providerWithMonth(): array
@@ -347,8 +347,8 @@ class MonthDayTest extends AbstractTestCase
         $monthDay = MonthDay::of($month, $day);
         $newMonthDay = $monthDay->withDay($day);
 
-        $this->assertMonthDayIs($month, $day, $monthDay);
-        $this->assertMonthDayIs($month, $day, $newMonthDay);
+        self::assertMonthDayIs($month, $day, $monthDay);
+        self::assertMonthDayIs($month, $day, $newMonthDay);
     }
 
     /**
@@ -363,8 +363,8 @@ class MonthDayTest extends AbstractTestCase
         $monthDay = MonthDay::of($month, $day);
         $newMonthDay = $monthDay->withDay($newDay);
 
-        $this->assertMonthDayIs($month, $day, $monthDay);
-        $this->assertMonthDayIs($month, $newDay, $newMonthDay);
+        self::assertMonthDayIs($month, $day, $monthDay);
+        self::assertMonthDayIs($month, $newDay, $newMonthDay);
     }
 
     public function providerWithDay(): array
@@ -432,7 +432,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testAtYear(int $month, int $day, int $year, int $expectedDay): void
     {
-        $this->assertLocalDateIs($year, $month, $expectedDay, MonthDay::of($month, $day)->atYear($year));
+        self::assertLocalDateIs($year, $month, $expectedDay, MonthDay::of($month, $day)->atYear($year));
     }
 
     public function providerAtYear(): array
@@ -473,7 +473,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $month, int $day, string $string): void
     {
-        $this->assertSame(json_encode($string), json_encode(MonthDay::of($month, $day)));
+        self::assertSame(json_encode($string), json_encode(MonthDay::of($month, $day)));
     }
 
     /**
@@ -485,7 +485,7 @@ class MonthDayTest extends AbstractTestCase
      */
     public function testToString(int $month, int $day, string $string): void
     {
-        $this->assertSame($string, (string) MonthDay::of($month, $day));
+        self::assertSame($string, (string) MonthDay::of($month, $day));
     }
 
     public function providerToString(): array

--- a/tests/MonthTest.php
+++ b/tests/MonthTest.php
@@ -23,7 +23,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testConstants(int $expectedValue, int $monthConstant): void
     {
-        $this->assertSame($expectedValue, $monthConstant);
+        self::assertSame($expectedValue, $monthConstant);
     }
 
     public function providerConstants(): array
@@ -46,7 +46,7 @@ class MonthTest extends AbstractTestCase
 
     public function testOf(): void
     {
-        $this->assertMonthIs(8, Month::of(8));
+        self::assertMonthIs(8, Month::of(8));
     }
 
     /**
@@ -72,7 +72,7 @@ class MonthTest extends AbstractTestCase
         $currentMonth = Month::JANUARY;
 
         foreach (Month::getAll() as $month) {
-            $this->assertMonthIs($currentMonth, $month);
+            self::assertMonthIs($currentMonth, $month);
             $currentMonth++;
         }
     }
@@ -81,7 +81,7 @@ class MonthTest extends AbstractTestCase
     {
         for ($i = Month::JANUARY; $i <= Month::DECEMBER; $i++) {
             for ($j = Month::JANUARY; $j <= Month::DECEMBER; $j++) {
-                $this->assertSame($i === $j, Month::of($i)->is($j));
+                self::assertSame($i === $j, Month::of($i)->is($j));
             }
         }
     }
@@ -90,7 +90,7 @@ class MonthTest extends AbstractTestCase
     {
         for ($i = Month::JANUARY; $i <= Month::DECEMBER; $i++) {
             for ($j = Month::JANUARY; $j <= Month::DECEMBER; $j++) {
-                $this->assertSame($i === $j, Month::of($i)->isEqualTo(Month::of($j)));
+                self::assertSame($i === $j, Month::of($i)->isEqualTo(Month::of($j)));
             }
         }
     }
@@ -103,7 +103,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testGetMinLength(int $month, int $minLength): void
     {
-        $this->assertSame($minLength, Month::of($month)->getMinLength());
+        self::assertSame($minLength, Month::of($month)->getMinLength());
     }
 
     public function minLengthProvider(): array
@@ -132,7 +132,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testGetMaxLength(int $month, int $minLength): void
     {
-        $this->assertSame($minLength, Month::of($month)->getMaxLength());
+        self::assertSame($minLength, Month::of($month)->getMaxLength());
     }
 
     public function maxLengthProvider(): array
@@ -162,7 +162,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testFirstDayOfYear(int $month, bool $leapYear, int $firstDayOfYear): void
     {
-        $this->assertSame($firstDayOfYear, Month::of($month)->getFirstDayOfYear($leapYear));
+        self::assertSame($firstDayOfYear, Month::of($month)->getFirstDayOfYear($leapYear));
     }
 
     public function providerFirstDayOfYear(): array
@@ -205,7 +205,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testGetLength(int $month, bool $leapYear, int $expectedLength): void
     {
-        $this->assertSame($expectedLength, Month::of($month)->getLength($leapYear));
+        self::assertSame($expectedLength, Month::of($month)->getLength($leapYear));
     }
 
     public function providerGetLength()
@@ -243,8 +243,8 @@ class MonthTest extends AbstractTestCase
     {
         foreach (Month::getAll() as $month) {
             foreach ([-24, -12, 0, 12, 24] as $monthsToAdd) {
-                $this->assertTrue($month->plus($monthsToAdd)->isEqualTo($month));
-                $this->assertTrue($month->minus($monthsToAdd)->isEqualTo($month));
+                self::assertTrue($month->plus($monthsToAdd)->isEqualTo($month));
+                self::assertTrue($month->minus($monthsToAdd)->isEqualTo($month));
             }
         }
     }
@@ -258,7 +258,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testPlus(int $month, int $plusMonths, int $expectedMonth): void
     {
-        $this->assertMonthIs($expectedMonth, Month::of($month)->plus($plusMonths));
+        self::assertMonthIs($expectedMonth, Month::of($month)->plus($plusMonths));
     }
 
     /**
@@ -270,7 +270,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testMinus(int $month, int $plusMonths, int $expectedMonth): void
     {
-        $this->assertMonthIs($expectedMonth, Month::of($month)->minus(-$plusMonths));
+        self::assertMonthIs($expectedMonth, Month::of($month)->minus(-$plusMonths));
     }
 
     public function providerPlus(): Generator
@@ -299,7 +299,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $month, string $expectedName): void
     {
-        $this->assertSame(json_encode($expectedName), json_encode(Month::of($month)));
+        self::assertSame(json_encode($expectedName), json_encode(Month::of($month)));
     }
 
     /**
@@ -310,7 +310,7 @@ class MonthTest extends AbstractTestCase
      */
     public function testToString(int $month, string $expectedName): void
     {
-        $this->assertSame($expectedName, (string) Month::of($month));
+        self::assertSame($expectedName, (string) Month::of($month));
     }
 
     public function providerToString(): array

--- a/tests/PeriodTest.php
+++ b/tests/PeriodTest.php
@@ -21,35 +21,35 @@ class PeriodTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertPeriodIs(1, 2, 3, Period::of(1, 2, 3));
+        self::assertPeriodIs(1, 2, 3, Period::of(1, 2, 3));
     }
 
     public function testOfYears(): void
     {
-        $this->assertPeriodIs(11, 0, 0, Period::ofYears(11));
+        self::assertPeriodIs(11, 0, 0, Period::ofYears(11));
     }
 
     public function testOfMonths(): void
     {
-        $this->assertPeriodIs(0, 11, 0, Period::ofMonths(11));
+        self::assertPeriodIs(0, 11, 0, Period::ofMonths(11));
     }
 
     public function testOfWeeks(): void
     {
-        $this->assertPeriodIs(0, 0, 77, Period::ofWeeks(11));
+        self::assertPeriodIs(0, 0, 77, Period::ofWeeks(11));
     }
 
     public function testOfDays(): void
     {
-        $this->assertPeriodIs(0, 0, 11, Period::ofDays(11));
+        self::assertPeriodIs(0, 0, 11, Period::ofDays(11));
     }
 
     public function testZero(): void
     {
         $zero = Period::zero();
 
-        $this->assertPeriodIs(0, 0, 0, $zero);
-        $this->assertSame($zero, Period::zero());
+        self::assertPeriodIs(0, 0, 0, $zero);
+        self::assertSame($zero, Period::zero());
     }
 
     /**
@@ -62,7 +62,7 @@ class PeriodTest extends AbstractTestCase
      */
     public function testParse(string $text, int $years, int $months, int $days): void
     {
-        $this->assertPeriodIs($years, $months, $days, Period::parse($text));
+        self::assertPeriodIs($years, $months, $days, Period::parse($text));
     }
 
     public function providerParse(): array
@@ -190,101 +190,101 @@ class PeriodTest extends AbstractTestCase
     public function testBetween(): void
     {
         $period = Period::between(LocalDate::of(2010, 1, 15), LocalDate::of(2011, 3, 18));
-        $this->assertPeriodIs(1, 2, 3, $period);
+        self::assertPeriodIs(1, 2, 3, $period);
     }
 
     public function testWithYears(): void
     {
-        $this->assertPeriodIs(9, 2, 3, Period::of(1, 2, 3)->withYears(9));
+        self::assertPeriodIs(9, 2, 3, Period::of(1, 2, 3)->withYears(9));
     }
 
     public function testWithMonths(): void
     {
-        $this->assertPeriodIs(1, 9, 3, Period::of(1, 2, 3)->withMonths(9));
+        self::assertPeriodIs(1, 9, 3, Period::of(1, 2, 3)->withMonths(9));
     }
 
     public function testWithDays(): void
     {
-        $this->assertPeriodIs(1, 2, 9, Period::of(1, 2, 3)->withDays(9));
+        self::assertPeriodIs(1, 2, 9, Period::of(1, 2, 3)->withDays(9));
     }
 
     public function testWithSameValuesReturnsThis(): void
     {
         $period = Period::of(1, 2, 3);
 
-        $this->assertSame($period, $period->withYears(1));
-        $this->assertSame($period, $period->withMonths(2));
-        $this->assertSame($period, $period->withDays(3));
+        self::assertSame($period, $period->withYears(1));
+        self::assertSame($period, $period->withMonths(2));
+        self::assertSame($period, $period->withDays(3));
     }
 
     public function testPlusYears(): void
     {
-        $this->assertPeriodIs(11, 2, 3, Period::of(1, 2, 3)->plusYears(10));
+        self::assertPeriodIs(11, 2, 3, Period::of(1, 2, 3)->plusYears(10));
     }
 
     public function testPlusMonths(): void
     {
-        $this->assertPeriodIs(1, 12, 3, Period::of(1, 2, 3)->plusMonths(10));
+        self::assertPeriodIs(1, 12, 3, Period::of(1, 2, 3)->plusMonths(10));
     }
 
     public function testPlusDays(): void
     {
-        $this->assertPeriodIs(1, 2, 13, Period::of(1, 2, 3)->plusDays(10));
+        self::assertPeriodIs(1, 2, 13, Period::of(1, 2, 3)->plusDays(10));
     }
 
     public function testPlusZeroReturnsThis(): void
     {
         $period = Period::of(1, 2, 3);
 
-        $this->assertSame($period, $period->plusYears(0));
-        $this->assertSame($period, $period->plusMonths(0));
-        $this->assertSame($period, $period->plusDays(0));
+        self::assertSame($period, $period->plusYears(0));
+        self::assertSame($period, $period->plusMonths(0));
+        self::assertSame($period, $period->plusDays(0));
     }
 
     public function testMinusYears(): void
     {
-        $this->assertPeriodIs(-1, 2, 3, Period::of(1, 2, 3)->minusYears(2));
+        self::assertPeriodIs(-1, 2, 3, Period::of(1, 2, 3)->minusYears(2));
     }
 
     public function testMinusMonths(): void
     {
-        $this->assertPeriodIs(1, -2, 3, Period::of(1, 2, 3)->minusMonths(4));
+        self::assertPeriodIs(1, -2, 3, Period::of(1, 2, 3)->minusMonths(4));
     }
 
     public function testMinusDays(): void
     {
-        $this->assertPeriodIs(1, 2, -3, Period::of(1, 2, 3)->minusDays(6));
+        self::assertPeriodIs(1, 2, -3, Period::of(1, 2, 3)->minusDays(6));
     }
 
     public function testMinusZeroReturnsThis(): void
     {
         $period = Period::of(1, 2, 3);
 
-        $this->assertSame($period, $period->minusYears(0));
-        $this->assertSame($period, $period->minusMonths(0));
-        $this->assertSame($period, $period->minusDays(0));
+        self::assertSame($period, $period->minusYears(0));
+        self::assertSame($period, $period->minusMonths(0));
+        self::assertSame($period, $period->minusDays(0));
     }
 
     public function testMultipliedBy(): void
     {
-        $this->assertPeriodIs(-2, -4, -6, Period::of(1, 2, 3)->multipliedBy(-2));
+        self::assertPeriodIs(-2, -4, -6, Period::of(1, 2, 3)->multipliedBy(-2));
     }
 
     public function testMultipliedByOneReturnsThis(): void
     {
         $period = Period::of(1, 2, 3);
-        $this->assertSame($period, $period->multipliedBy(1));
+        self::assertSame($period, $period->multipliedBy(1));
     }
 
     public function testNegated(): void
     {
-        $this->assertPeriodIs(-7, -8, -9, Period::of(7, 8, 9)->negated());
+        self::assertPeriodIs(-7, -8, -9, Period::of(7, 8, 9)->negated());
     }
 
     public function testZeroNegatedReturnsThis(): void
     {
         $period = Period::zero();
-        $this->assertSame($period, $period->negated());
+        self::assertSame($period, $period->negated());
     }
 
     /**
@@ -298,7 +298,7 @@ class PeriodTest extends AbstractTestCase
      */
     public function testNormalized(int $y, int $m, int $d, int $ny, int $nm): void
     {
-        $this->assertPeriodIs($ny, $nm, $d, Period::of($y, $m, $d)->normalized());
+        self::assertPeriodIs($ny, $nm, $d, Period::of($y, $m, $d)->normalized());
     }
 
     public function providerNormalized(): array
@@ -325,7 +325,7 @@ class PeriodTest extends AbstractTestCase
      */
     public function testIsZero(int $years, int $months, int $days, bool $isZero): void
     {
-        $this->assertSame($isZero, Period::of($years, $months, $days)->isZero());
+        self::assertSame($isZero, Period::of($years, $months, $days)->isZero());
     }
 
     public function providerIsZero(): array
@@ -354,8 +354,8 @@ class PeriodTest extends AbstractTestCase
         $p1 = Period::of($y1, $m1, $d1);
         $p2 = Period::of($y2, $m2, $d2);
 
-        $this->assertSame($isEqual, $p1->isEqualTo($p2));
-        $this->assertSame($isEqual, $p2->isEqualTo($p1));
+        self::assertSame($isEqual, $p1->isEqualTo($p2));
+        self::assertSame($isEqual, $p2->isEqualTo($p1));
     }
 
     public function providerIsEqualTo(): array
@@ -383,9 +383,9 @@ class PeriodTest extends AbstractTestCase
         $period = Period::of($years, $months, $days);
         $dateInterval = $period->toNativeDateInterval();
 
-        $this->assertSame($years, $dateInterval->y);
-        $this->assertSame($months, $dateInterval->m);
-        $this->assertSame($days, $dateInterval->d);
+        self::assertSame($years, $dateInterval->y);
+        self::assertSame($months, $dateInterval->m);
+        self::assertSame($days, $dateInterval->d);
     }
 
     public function providerToNativeDateInterval(): array
@@ -406,7 +406,7 @@ class PeriodTest extends AbstractTestCase
      */
     public function testJsonSerialize(int $years, int $months, int $days, string $expected): void
     {
-        $this->assertSame(json_encode($expected), json_encode(Period::of($years, $months, $days)));
+        self::assertSame(json_encode($expected), json_encode(Period::of($years, $months, $days)));
     }
 
     /**
@@ -419,7 +419,7 @@ class PeriodTest extends AbstractTestCase
      */
     public function testToString(int $years, int $months, int $days, string $expected): void
     {
-        $this->assertSame($expected, (string) Period::of($years, $months, $days));
+        self::assertSame($expected, (string) Period::of($years, $months, $days));
     }
 
     public function providerToString(): array

--- a/tests/StopwatchTest.php
+++ b/tests/StopwatchTest.php
@@ -24,18 +24,18 @@ class StopwatchTest extends AbstractTestCase
     {
         $stopwatch = new Stopwatch();
 
-        $this->assertNull($stopwatch->getStartTime());
-        $this->assertFalse($stopwatch->isRunning());
-        $this->assertDurationIs(0, 0, $stopwatch->getElapsedTime());
+        self::assertNull($stopwatch->getStartTime());
+        self::assertFalse($stopwatch->isRunning());
+        self::assertDurationIs(0, 0, $stopwatch->getElapsedTime());
     }
 
     public function testNew(): Stopwatch
     {
         $stopwatch = new Stopwatch(self::$clock);
 
-        $this->assertNull($stopwatch->getStartTime());
-        $this->assertFalse($stopwatch->isRunning());
-        $this->assertDurationIs(0, 0, $stopwatch->getElapsedTime());
+        self::assertNull($stopwatch->getStartTime());
+        self::assertFalse($stopwatch->isRunning());
+        self::assertDurationIs(0, 0, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -49,9 +49,9 @@ class StopwatchTest extends AbstractTestCase
 
         $stopwatch->start();
 
-        $this->assertInstantIs(1000, 1, $stopwatch->getStartTime());
-        $this->assertTrue($stopwatch->isRunning());
-        $this->assertDurationIs(0, 0, $stopwatch->getElapsedTime());
+        self::assertInstantIs(1000, 1, $stopwatch->getStartTime());
+        self::assertTrue($stopwatch->isRunning());
+        self::assertDurationIs(0, 0, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -63,9 +63,9 @@ class StopwatchTest extends AbstractTestCase
     {
         self::setClockTime(2000, 0);
 
-        $this->assertInstantIs(1000, 1, $stopwatch->getStartTime());
-        $this->assertTrue($stopwatch->isRunning());
-        $this->assertDurationIs(999, 999999999, $stopwatch->getElapsedTime());
+        self::assertInstantIs(1000, 1, $stopwatch->getStartTime());
+        self::assertTrue($stopwatch->isRunning());
+        self::assertDurationIs(999, 999999999, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -75,9 +75,9 @@ class StopwatchTest extends AbstractTestCase
         $stopwatch = new Stopwatch();
         $stopwatch->stop();
 
-        $this->assertNull($stopwatch->getStartTime());
-        $this->assertFalse($stopwatch->isRunning());
-        $this->assertDurationIs(0, 0, $stopwatch->getElapsedTime());
+        self::assertNull($stopwatch->getStartTime());
+        self::assertFalse($stopwatch->isRunning());
+        self::assertDurationIs(0, 0, $stopwatch->getElapsedTime());
     }
 
     /**
@@ -89,9 +89,9 @@ class StopwatchTest extends AbstractTestCase
 
         $stopwatch->stop();
 
-        $this->assertNull($stopwatch->getStartTime());
-        $this->assertFalse($stopwatch->isRunning());
-        $this->assertDurationIs(2000, 1, $stopwatch->getElapsedTime());
+        self::assertNull($stopwatch->getStartTime());
+        self::assertFalse($stopwatch->isRunning());
+        self::assertDurationIs(2000, 1, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -103,9 +103,9 @@ class StopwatchTest extends AbstractTestCase
     {
         self::setClockTime(4000, 9);
 
-        $this->assertNull($stopwatch->getStartTime());
-        $this->assertFalse($stopwatch->isRunning());
-        $this->assertDurationIs(2000, 1, $stopwatch->getElapsedTime());
+        self::assertNull($stopwatch->getStartTime());
+        self::assertFalse($stopwatch->isRunning());
+        self::assertDurationIs(2000, 1, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -119,9 +119,9 @@ class StopwatchTest extends AbstractTestCase
 
         $stopwatch->start();
 
-        $this->assertInstantIs(5000, 9, $stopwatch->getStartTime());
-        $this->assertTrue($stopwatch->isRunning());
-        $this->assertDurationIs(2000, 1, $stopwatch->getElapsedTime());
+        self::assertInstantIs(5000, 9, $stopwatch->getStartTime());
+        self::assertTrue($stopwatch->isRunning());
+        self::assertDurationIs(2000, 1, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -133,9 +133,9 @@ class StopwatchTest extends AbstractTestCase
     {
         self::setClockTime(5001, 10);
 
-        $this->assertInstantIs(5000, 9, $stopwatch->getStartTime());
-        $this->assertTrue($stopwatch->isRunning());
-        $this->assertDurationIs(2001, 2, $stopwatch->getElapsedTime());
+        self::assertInstantIs(5000, 9, $stopwatch->getStartTime());
+        self::assertTrue($stopwatch->isRunning());
+        self::assertDurationIs(2001, 2, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -149,9 +149,9 @@ class StopwatchTest extends AbstractTestCase
 
         $stopwatch->stop();
 
-        $this->assertNull($stopwatch->getStartTime());
-        $this->assertFalse($stopwatch->isRunning());
-        $this->assertDurationIs(2002, 12, $stopwatch->getElapsedTime());
+        self::assertNull($stopwatch->getStartTime());
+        self::assertFalse($stopwatch->isRunning());
+        self::assertDurationIs(2002, 12, $stopwatch->getElapsedTime());
 
         return $stopwatch;
     }
@@ -163,9 +163,9 @@ class StopwatchTest extends AbstractTestCase
     {
         self::setClockTime(6000, 999);
 
-        $this->assertNull($stopwatch->getStartTime());
-        $this->assertFalse($stopwatch->isRunning());
-        $this->assertDurationIs(2002, 12, $stopwatch->getElapsedTime());
+        self::assertNull($stopwatch->getStartTime());
+        self::assertFalse($stopwatch->isRunning());
+        self::assertDurationIs(2002, 12, $stopwatch->getElapsedTime());
     }
 
     private static function setClockTime(int $second, int $nano): void

--- a/tests/TimeZoneOffsetTest.php
+++ b/tests/TimeZoneOffsetTest.php
@@ -26,7 +26,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
      */
     public function testOf(int $hours, int $minutes, int $seconds, int $totalSeconds): void
     {
-        $this->assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::of($hours, $minutes, $seconds));
+        self::assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::of($hours, $minutes, $seconds));
     }
 
     public function providerOf(): iterable
@@ -86,7 +86,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
      */
     public function testOfTotalSeconds(int $totalSeconds): void
     {
-        $this->assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::ofTotalSeconds($totalSeconds));
+        self::assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::ofTotalSeconds($totalSeconds));
     }
 
     public function providerTotalSeconds(): iterable
@@ -141,8 +141,8 @@ class TimeZoneOffsetTest extends AbstractTestCase
     {
         $utc = TimeZoneOffset::utc();
 
-        $this->assertTimeZoneOffsetIs(0, $utc);
-        $this->assertSame($utc, TimeZoneOffset::utc());
+        self::assertTimeZoneOffsetIs(0, $utc);
+        self::assertSame($utc, TimeZoneOffset::utc());
     }
 
     /**
@@ -153,7 +153,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
      */
     public function testParse(string $text, int $totalSeconds): void
     {
-        $this->assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::parse($text));
+        self::assertTimeZoneOffsetIs($totalSeconds, TimeZoneOffset::parse($text));
     }
 
     public function providerParse(): iterable
@@ -236,7 +236,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
      */
     public function testGetId(int $totalSeconds, string $expectedId): void
     {
-        $this->assertSame($expectedId, TimeZoneOffset::ofTotalSeconds($totalSeconds)->getId());
+        self::assertSame($expectedId, TimeZoneOffset::ofTotalSeconds($totalSeconds)->getId());
     }
 
     /**
@@ -247,7 +247,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
      */
     public function testToString(int $totalSeconds, string $string): void
     {
-        $this->assertSame($string, (string) TimeZoneOffset::ofTotalSeconds($totalSeconds));
+        self::assertSame($string, (string) TimeZoneOffset::ofTotalSeconds($totalSeconds));
     }
 
     public function providerGetId(): iterable
@@ -285,7 +285,7 @@ class TimeZoneOffsetTest extends AbstractTestCase
         $whateverInstant = Instant::of(123456789, 987654321);
         $timeZoneOffset = TimeZoneOffset::ofTotalSeconds(-18000);
 
-        $this->assertSame(-18000, $timeZoneOffset->getOffset($whateverInstant));
+        self::assertSame(-18000, $timeZoneOffset->getOffset($whateverInstant));
     }
 
     /**
@@ -298,8 +298,8 @@ class TimeZoneOffsetTest extends AbstractTestCase
     {
         $dateTimeZone = TimeZoneOffset::ofTotalSeconds($totalSeconds)->toNativeDateTimeZone();
 
-        $this->assertSame($string, $dateTimeZone->getName());
-        $this->assertSame($totalSeconds, $dateTimeZone->getOffset(new DateTimeImmutable()));
+        self::assertSame($string, $dateTimeZone->getName());
+        self::assertSame($totalSeconds, $dateTimeZone->getOffset(new DateTimeImmutable()));
     }
 
     public function providerToNativeDateTimeZone(): iterable

--- a/tests/TimeZoneRegionTest.php
+++ b/tests/TimeZoneRegionTest.php
@@ -19,7 +19,7 @@ class TimeZoneRegionTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertSame('Europe/London', TimeZoneRegion::of('Europe/London')->getId());
+        self::assertSame('Europe/London', TimeZoneRegion::of('Europe/London')->getId());
     }
 
     /**
@@ -45,7 +45,7 @@ class TimeZoneRegionTest extends AbstractTestCase
 
     public function testParse(): void
     {
-        $this->assertSame('Europe/London', TimeZoneRegion::parse('Europe/London')->getId());
+        self::assertSame('Europe/London', TimeZoneRegion::parse('Europe/London')->getId());
     }
 
     /**
@@ -71,7 +71,7 @@ class TimeZoneRegionTest extends AbstractTestCase
     public function testGetAllTimeZones(bool $includeObsolete): void
     {
         $identifiers = TimeZoneRegion::getAllIdentifiers($includeObsolete);
-        $this->assertGreaterThan(1, count($identifiers));
+        self::assertGreaterThan(1, count($identifiers));
 
         $expectedIdentifiers = [
             'UTC',
@@ -86,14 +86,14 @@ class TimeZoneRegionTest extends AbstractTestCase
         ];
 
         foreach ($expectedIdentifiers as $identifier) {
-            $this->assertContains($identifier, $identifiers);
+            self::assertContains($identifier, $identifiers);
         }
 
         foreach ($expectedObsoleteIdentifiers as $identifier) {
             if ($includeObsolete) {
-                $this->assertContains($identifier, $identifiers);
+                self::assertContains($identifier, $identifiers);
             } else {
-                $this->assertNotContains($identifier, $identifiers);
+                self::assertNotContains($identifier, $identifiers);
             }
         }
     }
@@ -113,7 +113,7 @@ class TimeZoneRegionTest extends AbstractTestCase
     {
         $identifiers = TimeZoneRegion::getIdentifiersForCountry($countryCode);
 
-        $this->assertSame($expectedIdentifiers, $identifiers);
+        self::assertSame($expectedIdentifiers, $identifiers);
     }
 
     public function providerGetTimeZonesForCountry(): array
@@ -141,7 +141,7 @@ class TimeZoneRegionTest extends AbstractTestCase
     public function testGetOffset(string $region, int $epochSecond, int $expectedOffset): void
     {
         $actualOffset = TimeZoneRegion::of($region)->getOffset(Instant::of($epochSecond));
-        $this->assertSame($expectedOffset, $actualOffset);
+        self::assertSame($expectedOffset, $actualOffset);
     }
 
     public function providerGetOffset(): array
@@ -158,17 +158,17 @@ class TimeZoneRegionTest extends AbstractTestCase
     {
         $dateTimeZone = TimeZoneRegion::of('Europe/London')->toNativeDateTimeZone();
 
-        $this->assertInstanceOf(DateTimeZone::class, $dateTimeZone);
-        $this->assertSame('Europe/London', $dateTimeZone->getName());
+        self::assertInstanceOf(DateTimeZone::class, $dateTimeZone);
+        self::assertSame('Europe/London', $dateTimeZone->getName());
     }
 
     public function testGetId(): void
     {
-        $this->assertSame('Europe/Paris', TimeZoneRegion::of('Europe/Paris')->getId());
+        self::assertSame('Europe/Paris', TimeZoneRegion::of('Europe/Paris')->getId());
     }
 
     public function testToString(): void
     {
-        $this->assertSame('America/Los_Angeles', (string) TimeZoneRegion::of('America/Los_Angeles'));
+        self::assertSame('America/Los_Angeles', (string) TimeZoneRegion::of('America/Los_Angeles'));
     }
 }

--- a/tests/TimeZoneTest.php
+++ b/tests/TimeZoneTest.php
@@ -28,8 +28,8 @@ class TimeZoneTest extends AbstractTestCase
     {
         $timeZone = TimeZone::parse($text);
 
-        $this->assertInstanceOf($class, $timeZone);
-        $this->assertSame($id, $timeZone->getId());
+        self::assertInstanceOf($class, $timeZone);
+        self::assertSame($id, $timeZone->getId());
     }
 
     public function providerParse(): iterable
@@ -70,14 +70,14 @@ class TimeZoneTest extends AbstractTestCase
     {
         $utc = TimeZone::utc();
 
-        $this->assertTimeZoneOffsetIs(0, $utc);
-        $this->assertSame($utc, TimeZone::utc());
+        self::assertTimeZoneOffsetIs(0, $utc);
+        self::assertSame($utc, TimeZone::utc());
     }
 
     public function testIsEqualTo(): void
     {
-        $this->assertTrue(TimeZone::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(0)));
-        $this->assertFalse(TimeZone::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(3600)));
+        self::assertTrue(TimeZone::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(0)));
+        self::assertFalse(TimeZone::utc()->isEqualTo(TimeZoneOffset::ofTotalSeconds(3600)));
     }
 
     /**
@@ -88,7 +88,7 @@ class TimeZoneTest extends AbstractTestCase
     public function testFromNativeDateTimeZone(string $tz): void
     {
         $dateTimeZone = new DateTimeZone($tz);
-        $this->assertSame($tz, TimeZone::fromNativeDateTimeZone($dateTimeZone)->getId());
+        self::assertSame($tz, TimeZone::fromNativeDateTimeZone($dateTimeZone)->getId());
     }
 
     public function providerFromNativeDateTimeZone(): iterable

--- a/tests/Utility/MathTest.php
+++ b/tests/Utility/MathTest.php
@@ -21,7 +21,7 @@ class MathTest extends TestCase
      */
     public function testFloorDiv(int $a, int $b, int $expected): void
     {
-        $this->assertSame($expected, Math::floorDiv($a, $b));
+        self::assertSame($expected, Math::floorDiv($a, $b));
     }
 
     public function providerFloorDiv(): array
@@ -43,7 +43,7 @@ class MathTest extends TestCase
      */
     public function testFloorMod(int $a, int $b, int $expected): void
     {
-        $this->assertSame($expected, Math::floorMod($a, $b));
+        self::assertSame($expected, Math::floorMod($a, $b));
     }
 
     public function providerFloorMod(): array

--- a/tests/YearMonthRangeTest.php
+++ b/tests/YearMonthRangeTest.php
@@ -18,7 +18,7 @@ class YearMonthRangeTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertYearMonthRangeIs(2001, 2, 2004, 5, YearMonthRange::of(
+        self::assertYearMonthRangeIs(2001, 2, 2004, 5, YearMonthRange::of(
             YearMonth::of(2001, 2),
             YearMonth::of(2004, 5)
         ));
@@ -45,7 +45,7 @@ class YearMonthRangeTest extends AbstractTestCase
      */
     public function testParse(string $text, int $y1, int $m1, int $y2, int $m2): void
     {
-        $this->assertYearMonthRangeIs($y1, $m1, $y2, $m2, YearMonthRange::parse($text));
+        self::assertYearMonthRangeIs($y1, $m1, $y2, $m2, YearMonthRange::parse($text));
     }
 
     public function providerParse(): array
@@ -88,7 +88,7 @@ class YearMonthRangeTest extends AbstractTestCase
      */
     public function testIsEqualTo(string $testRange, bool $isEqual): void
     {
-        $this->assertSame($isEqual, YearMonthRange::of(
+        self::assertSame($isEqual, YearMonthRange::of(
             YearMonth::of(2001, 2),
             YearMonth::of(2004, 5)
         )->isEqualTo(YearMonthRange::parse($testRange)));
@@ -110,7 +110,7 @@ class YearMonthRangeTest extends AbstractTestCase
      */
     public function testContains(string $range, string $yearMonth, bool $contains): void
     {
-        $this->assertSame($contains, YearMonthRange::parse($range)->contains(YearMonth::parse($yearMonth)));
+        self::assertSame($contains, YearMonthRange::parse($range)->contains(YearMonth::parse($yearMonth)));
     }
 
     public function providerContains(): array
@@ -152,7 +152,7 @@ class YearMonthRangeTest extends AbstractTestCase
                 $actual[] = (string) $yearMonth;
             }
 
-            $this->assertSame($expected, $actual);
+            self::assertSame($expected, $actual);
         }
     }
 
@@ -164,7 +164,7 @@ class YearMonthRangeTest extends AbstractTestCase
      */
     public function testCount(string $range, int $count): void
     {
-        $this->assertCount($count, YearMonthRange::parse($range));
+        self::assertCount($count, YearMonthRange::parse($range));
     }
 
     public function providerCount(): array
@@ -183,7 +183,7 @@ class YearMonthRangeTest extends AbstractTestCase
      */
     public function testToLocalDateRange(string $yearMonthRange, string $expectedRange): void
     {
-        $this->assertSame($expectedRange, (string) YearMonthRange::parse($yearMonthRange)->toLocalDateRange());
+        self::assertSame($expectedRange, (string) YearMonthRange::parse($yearMonthRange)->toLocalDateRange());
     }
 
     public function providerToLocalDateRange(): array
@@ -199,7 +199,7 @@ class YearMonthRangeTest extends AbstractTestCase
 
     public function testJsonSerialize(): void
     {
-        $this->assertSame(json_encode('2008-12/2011-01'), json_encode(YearMonthRange::of(
+        self::assertSame(json_encode('2008-12/2011-01'), json_encode(YearMonthRange::of(
             YearMonth::of(2008, 12),
             YearMonth::of(2011, 1)
         )));
@@ -207,7 +207,7 @@ class YearMonthRangeTest extends AbstractTestCase
 
     public function testToString(): void
     {
-        $this->assertSame('2008-12/2011-01', (string) YearMonthRange::of(
+        self::assertSame('2008-12/2011-01', (string) YearMonthRange::of(
             YearMonth::of(2008, 12),
             YearMonth::of(2011, 1)
         ));

--- a/tests/YearMonthTest.php
+++ b/tests/YearMonthTest.php
@@ -19,7 +19,7 @@ class YearMonthTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertYearMonthIs(2007, 7, YearMonth::of(2007, 7));
+        self::assertYearMonthIs(2007, 7, YearMonth::of(2007, 7));
     }
 
     /**
@@ -31,7 +31,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testParse(string $text, int $year, int $month): void
     {
-        $this->assertYearMonthIs($year, $month, YearMonth::parse($text));
+        self::assertYearMonthIs($year, $month, YearMonth::parse($text));
     }
 
     public function providerParse(): array
@@ -98,7 +98,7 @@ class YearMonthTest extends AbstractTestCase
     public function testNow(int $epochSecond, string $timeZone, int $year, int $month): void
     {
         $clock = new FixedClock(Instant::of($epochSecond));
-        $this->assertYearMonthIs($year, $month, YearMonth::now(TimeZone::parse($timeZone), $clock));
+        self::assertYearMonthIs($year, $month, YearMonth::now(TimeZone::parse($timeZone), $clock));
     }
 
     public function providerNow(): array
@@ -120,7 +120,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsLeapYear(int $year, int $month, bool $isLeap): void
     {
-        $this->assertSame($isLeap, YearMonth::of($year, $month)->isLeapYear());
+        self::assertSame($isLeap, YearMonth::of($year, $month)->isLeapYear());
     }
 
     public function providerIsLeapYear(): array
@@ -144,7 +144,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testGetLengthOfMonth(int $year, int $month, int $length): void
     {
-        $this->assertSame($length, YearMonth::of($year, $month)->getLengthOfMonth());
+        self::assertSame($length, YearMonth::of($year, $month)->getLengthOfMonth());
     }
 
     public function providerGetLengthOfMonth(): array
@@ -186,7 +186,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testGetLengthOfYear(int $year, int $month, int $length): void
     {
-        $this->assertSame($length, YearMonth::of($year, $month)->getLengthOfYear());
+        self::assertSame($length, YearMonth::of($year, $month)->getLengthOfYear());
     }
 
     public function providerGetLengthOfYear(): array
@@ -209,7 +209,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testCompareTo(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result, YearMonth::of($y1, $m1)->compareTo(YearMonth::of($y2, $m2)));
+        self::assertSame($result, YearMonth::of($y1, $m1)->compareTo(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -223,7 +223,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsEqualTo(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result === 0, YearMonth::of($y1, $m1)->isEqualTo(YearMonth::of($y2, $m2)));
+        self::assertSame($result === 0, YearMonth::of($y1, $m1)->isEqualTo(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -237,7 +237,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsBefore(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result === -1, YearMonth::of($y1, $m1)->isBefore(YearMonth::of($y2, $m2)));
+        self::assertSame($result === -1, YearMonth::of($y1, $m1)->isBefore(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -251,7 +251,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsBeforeOrEqualTo(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result <= 0, YearMonth::of($y1, $m1)->isBeforeOrEqualTo(YearMonth::of($y2, $m2)));
+        self::assertSame($result <= 0, YearMonth::of($y1, $m1)->isBeforeOrEqualTo(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -265,7 +265,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsAfter(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result === 1, YearMonth::of($y1, $m1)->isAfter(YearMonth::of($y2, $m2)));
+        self::assertSame($result === 1, YearMonth::of($y1, $m1)->isAfter(YearMonth::of($y2, $m2)));
     }
 
     /**
@@ -279,7 +279,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testIsAfterOrEqualTo(int $y1, int $m1, int $y2, int $m2, int $result): void
     {
-        $this->assertSame($result >= 0, YearMonth::of($y1, $m1)->isAfterOrEqualTo(YearMonth::of($y2, $m2)));
+        self::assertSame($result >= 0, YearMonth::of($y1, $m1)->isAfterOrEqualTo(YearMonth::of($y2, $m2)));
     }
 
     public function providerCompareTo(): array
@@ -306,27 +306,27 @@ class YearMonthTest extends AbstractTestCase
 
     public function testWithYear(): void
     {
-        $this->assertYearMonthIs(2001, 5, YearMonth::of(2000, 5)->withYear(2001));
+        self::assertYearMonthIs(2001, 5, YearMonth::of(2000, 5)->withYear(2001));
     }
 
     public function testWithYearWithSameYear(): void
     {
-        $this->assertYearMonthIs(2018, 2, YearMonth::of(2018, 2)->withYear(2018));
+        self::assertYearMonthIs(2018, 2, YearMonth::of(2018, 2)->withYear(2018));
     }
 
     public function testWithMonth(): void
     {
-        $this->assertYearMonthIs(2000, 12, YearMonth::of(2000, 1)->withMonth(12));
+        self::assertYearMonthIs(2000, 12, YearMonth::of(2000, 1)->withMonth(12));
     }
 
     public function testWithMonthWithSameMonth(): void
     {
-        $this->assertYearMonthIs(2000, 2, YearMonth::of(2000, 2)->withMonth(2));
+        self::assertYearMonthIs(2000, 2, YearMonth::of(2000, 2)->withMonth(2));
     }
 
     public function testGetFirstDay(): void
     {
-        $this->assertLocalDateIs(2023, 10, 1, YearMonth::of(2023, 10)->getFirstDay());
+        self::assertLocalDateIs(2023, 10, 1, YearMonth::of(2023, 10)->getFirstDay());
     }
 
     /**
@@ -334,7 +334,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testGetLastDay(int $year, int $month, int $day): void
     {
-        $this->assertLocalDateIs($year, $month, $day, YearMonth::of($year, $month)->getLastDay());
+        self::assertLocalDateIs($year, $month, $day, YearMonth::of($year, $month)->getLastDay());
     }
 
     public function providerGetLastDay(): array
@@ -350,7 +350,7 @@ class YearMonthTest extends AbstractTestCase
 
     public function testAtDay(): void
     {
-        $this->assertLocalDateIs(2001, 2, 3, YearMonth::of(2001, 02)->atDay(3));
+        self::assertLocalDateIs(2001, 2, 3, YearMonth::of(2001, 02)->atDay(3));
     }
 
     /**
@@ -359,13 +359,13 @@ class YearMonthTest extends AbstractTestCase
     public function testPlusYears(int $year, int $month, int $plusYears, int $expectedYear, int $expectedMonth): void
     {
         $yearMonth = YearMonth::of($year, $month);
-        $this->assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->plusYears($plusYears));
+        self::assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->plusYears($plusYears));
     }
 
     public function testPlusZeroYears(): void
     {
         $yearMonth = YearMonth::of(2005, 1);
-        $this->assertYearMonthIs(2005, 1, $yearMonth->plusYears(0));
+        self::assertYearMonthIs(2005, 1, $yearMonth->plusYears(0));
     }
 
     public function providerPlusYears(): array
@@ -382,7 +382,7 @@ class YearMonthTest extends AbstractTestCase
     public function testMinusYears(int $year, int $month, int $plusYears, int $expectedYear, int $expectedMonth): void
     {
         $yearMonth = YearMonth::of($year, $month);
-        $this->assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->minusYears($plusYears));
+        self::assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->minusYears($plusYears));
     }
 
     public function providerMinusYears(): array
@@ -399,7 +399,7 @@ class YearMonthTest extends AbstractTestCase
     public function testPlusMonths(int $year, int $month, int $plusMonths, int $expectedYear, int $expectedMonth): void
     {
         $yearMonth = YearMonth::of($year, $month);
-        $this->assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->plusMonths($plusMonths));
+        self::assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->plusMonths($plusMonths));
     }
 
     public function providerPlusMonths(): array
@@ -423,7 +423,7 @@ class YearMonthTest extends AbstractTestCase
     public function testMinusMonths(int $year, int $month, int $plusMonths, int $expectedYear, int $expectedMonth): void
     {
         $yearMonth = YearMonth::of($year, $month);
-        $this->assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->minusMonths($plusMonths));
+        self::assertYearMonthIs($expectedYear, $expectedMonth, $yearMonth->minusMonths($plusMonths));
     }
 
     public function providerMinusMonths(): array
@@ -446,7 +446,7 @@ class YearMonthTest extends AbstractTestCase
      */
     public function testToLocalDateRange(int $year, int $month, string $expectedRange): void
     {
-        $this->assertSame($expectedRange, (string) YearMonth::of($year, $month)->toLocalDateRange());
+        self::assertSame($expectedRange, (string) YearMonth::of($year, $month)->toLocalDateRange());
     }
 
     public function providerToLocalDateRange(): array
@@ -461,11 +461,11 @@ class YearMonthTest extends AbstractTestCase
 
     public function testJsonSerialize(): void
     {
-        $this->assertSame(json_encode('2013-09'), json_encode(YearMonth::of(2013, 9)));
+        self::assertSame(json_encode('2013-09'), json_encode(YearMonth::of(2013, 9)));
     }
 
     public function testToString(): void
     {
-        $this->assertSame('2013-09', (string) YearMonth::of(2013, 9));
+        self::assertSame('2013-09', (string) YearMonth::of(2013, 9));
     }
 }

--- a/tests/YearTest.php
+++ b/tests/YearTest.php
@@ -23,7 +23,7 @@ class YearTest extends AbstractTestCase
 {
     public function testOf(): void
     {
-        $this->assertYearIs(1987, Year::of(1987));
+        self::assertYearIs(1987, Year::of(1987));
     }
 
     /**
@@ -55,7 +55,7 @@ class YearTest extends AbstractTestCase
     public function testNow(int $epochSecond, string $timeZone, int $expectedYear): void
     {
         $clock = new FixedClock(Instant::of($epochSecond));
-        $this->assertYearIs($expectedYear, Year::now(TimeZone::parse($timeZone), $clock));
+        self::assertYearIs($expectedYear, Year::now(TimeZone::parse($timeZone), $clock));
     }
 
     public function providerNow(): array
@@ -78,7 +78,7 @@ class YearTest extends AbstractTestCase
      */
     public function testIsLeap(int $year, bool $isLeap): void
     {
-        $this->assertSame($isLeap, Year::of($year)->isLeap());
+        self::assertSame($isLeap, Year::of($year)->isLeap());
     }
 
     public function providerIsLeap(): array
@@ -152,7 +152,7 @@ class YearTest extends AbstractTestCase
      */
     public function testIsValidMonthDay(int $year, int $month, int $day, bool $isValid): void
     {
-        $this->assertSame($isValid, Year::of($year)->isValidMonthDay(MonthDay::of($month, $day)));
+        self::assertSame($isValid, Year::of($year)->isValidMonthDay(MonthDay::of($month, $day)));
     }
 
     public function providerIsValidMonthDay(): array
@@ -178,7 +178,7 @@ class YearTest extends AbstractTestCase
      */
     public function testGetLength(int $year, int $length): void
     {
-        $this->assertSame($length, Year::of($year)->getLength());
+        self::assertSame($length, Year::of($year)->getLength());
     }
 
     public function providerGetLength(): array
@@ -247,7 +247,7 @@ class YearTest extends AbstractTestCase
      */
     public function testPlus(int $year, int $plusYears, int $expectedYear): void
     {
-        $this->assertYearIs($expectedYear, Year::of($year)->plus($plusYears));
+        self::assertYearIs($expectedYear, Year::of($year)->plus($plusYears));
     }
 
     public function providerPlus(): array
@@ -264,7 +264,7 @@ class YearTest extends AbstractTestCase
      */
     public function testMinus(int $year, int $minusYears, int $expectedYear): void
     {
-        $this->assertYearIs($expectedYear, Year::of($year)->minus($minusYears));
+        self::assertYearIs($expectedYear, Year::of($year)->minus($minusYears));
     }
 
     public function providerMinus(): array
@@ -285,7 +285,7 @@ class YearTest extends AbstractTestCase
      */
     public function testCompareTo(int $year1, int $year2, int $cmp): void
     {
-        $this->assertSame($cmp, Year::of($year1)->compareTo(Year::of($year2)));
+        self::assertSame($cmp, Year::of($year1)->compareTo(Year::of($year2)));
     }
 
     /**
@@ -297,7 +297,7 @@ class YearTest extends AbstractTestCase
      */
     public function testIsEqualTo(int $year1, int $year2, int $cmp): void
     {
-        $this->assertSame($cmp === 0, Year::of($year1)->isEqualTo(Year::of($year2)));
+        self::assertSame($cmp === 0, Year::of($year1)->isEqualTo(Year::of($year2)));
     }
 
     /**
@@ -309,7 +309,7 @@ class YearTest extends AbstractTestCase
      */
     public function testIsAfter(int $year1, int $year2, int $cmp): void
     {
-        $this->assertSame($cmp === 1, Year::of($year1)->isAfter(Year::of($year2)));
+        self::assertSame($cmp === 1, Year::of($year1)->isAfter(Year::of($year2)));
     }
 
     /**
@@ -321,7 +321,7 @@ class YearTest extends AbstractTestCase
      */
     public function testIsBefore(int $year1, int $year2, int $cmp): void
     {
-        $this->assertSame($cmp === -1, Year::of($year1)->isBefore(Year::of($year2)));
+        self::assertSame($cmp === -1, Year::of($year1)->isBefore(Year::of($year2)));
     }
 
     public function providerCompareTo(): array
@@ -365,7 +365,7 @@ class YearTest extends AbstractTestCase
      */
     public function testAtDay(int $year, int $dayOfYear, int $month, int $day): void
     {
-        $this->assertLocalDateIs($year, $month, $day, Year::of($year)->atDay($dayOfYear));
+        self::assertLocalDateIs($year, $month, $day, Year::of($year)->atDay($dayOfYear));
     }
 
     public function providerAtDay(): array
@@ -390,7 +390,7 @@ class YearTest extends AbstractTestCase
 
     public function testAtMonth(): void
     {
-        $this->assertYearMonthIs(2014, 7, Year::of(2014)->atMonth(7));
+        self::assertYearMonthIs(2014, 7, Year::of(2014)->atMonth(7));
     }
 
     /**
@@ -422,7 +422,7 @@ class YearTest extends AbstractTestCase
     public function testAtMonthDay(int $year, int $month, int $day, int $expectedDay): void
     {
         $monthDay = MonthDay::of($month, $day);
-        $this->assertLocalDateIs($year, $month, $expectedDay, Year::of($year)->atMonthDay($monthDay));
+        self::assertLocalDateIs($year, $month, $expectedDay, Year::of($year)->atMonthDay($monthDay));
     }
 
     public function providerAtMonthDay(): array
@@ -443,7 +443,7 @@ class YearTest extends AbstractTestCase
      */
     public function testToLocalDateRange(int $year, string $expectedRange): void
     {
-        $this->assertSame($expectedRange, (string) Year::of($year)->toLocalDateRange());
+        self::assertSame($expectedRange, (string) Year::of($year)->toLocalDateRange());
     }
 
     public function providerToLocalDateRange(): array
@@ -457,11 +457,11 @@ class YearTest extends AbstractTestCase
 
     public function testJsonSerialize(): void
     {
-        $this->assertSame(json_encode('1987'), json_encode(Year::of(1987)));
+        self::assertSame(json_encode('1987'), json_encode(Year::of(1987)));
     }
 
     public function testToString(): void
     {
-        $this->assertSame('1987', (string) Year::of(1987));
+        self::assertSame('1987', (string) Year::of(1987));
     }
 }

--- a/tests/YearWeekTest.php
+++ b/tests/YearWeekTest.php
@@ -103,7 +103,7 @@ class YearWeekTest extends AbstractTestCase
     public function testIs53WeekYear(int $year): void
     {
         $yearWeek = YearWeek::of($year, 1);
-        $this->assertTrue($yearWeek->is53WeekYear());
+        self::assertTrue($yearWeek->is53WeekYear());
     }
 
     /**
@@ -114,7 +114,7 @@ class YearWeekTest extends AbstractTestCase
         $yearWeek = YearWeek::of($weekBasedYear, $weekOfWeekBasedYear);
         $actual = $yearWeek->atDay($dayOfWeek);
 
-        $this->assertLocalDateIs($year, $month, $dayOfMonth, $actual);
+        self::assertLocalDateIs($year, $month, $dayOfMonth, $actual);
     }
 
     public function providerAtDay(): array
@@ -172,20 +172,20 @@ class YearWeekTest extends AbstractTestCase
                         $b = YearWeek::of($year2, $week2);
 
                         if ($year1 < $year2) {
-                            $this->assertCompareTo(-1, $a, $b);
-                            $this->assertCompareTo(1, $b, $a);
+                            self::assertCompareTo(-1, $a, $b);
+                            self::assertCompareTo(1, $b, $a);
                         } elseif ($year1 > $year2) {
-                            $this->assertCompareTo(1, $a, $b);
-                            $this->assertCompareTo(-1, $b, $a);
+                            self::assertCompareTo(1, $a, $b);
+                            self::assertCompareTo(-1, $b, $a);
                         } elseif ($week1 < $week2) {
-                            $this->assertCompareTo(-1, $a, $b);
-                            $this->assertCompareTo(1, $b, $a);
+                            self::assertCompareTo(-1, $a, $b);
+                            self::assertCompareTo(1, $b, $a);
                         } elseif ($week1 > $week2) {
-                            $this->assertCompareTo(1, $a, $b);
-                            $this->assertCompareTo(-1, $b, $a);
+                            self::assertCompareTo(1, $a, $b);
+                            self::assertCompareTo(-1, $b, $a);
                         } else {
-                            $this->assertCompareTo(0, $a, $b);
-                            $this->assertCompareTo(0, $b, $a);
+                            self::assertCompareTo(0, $a, $b);
+                            self::assertCompareTo(0, $b, $a);
                         }
                     }
                 }
@@ -209,7 +209,7 @@ class YearWeekTest extends AbstractTestCase
     public function testWithYear(int $year, int $week, int $withYear, int $expectedYear, int $expectedWeek): void
     {
         $yearWeek = YearWeek::of($year, $week)->withYear($withYear);
-        $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
+        self::assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
     public function providerWithWeek(): array
@@ -227,7 +227,7 @@ class YearWeekTest extends AbstractTestCase
     public function testWithWeek(int $year, int $week, int $withWeek, int $expectedYear, int $expectedWeek): void
     {
         $yearWeek = YearWeek::of($year, $week)->withWeek($withWeek);
-        $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
+        self::assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
     public function providerPlusYears(): array
@@ -252,7 +252,7 @@ class YearWeekTest extends AbstractTestCase
     public function testPlusYears(int $year, int $week, int $delta, int $expectedYear, int $expectedWeek): void
     {
         $yearWeek = YearWeek::of($year, $week)->plusYears($delta);
-        $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
+        self::assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
     /**
@@ -261,7 +261,7 @@ class YearWeekTest extends AbstractTestCase
     public function testMinusYears(int $year, int $week, int $delta, int $expectedYear, int $expectedWeek): void
     {
         $yearWeek = YearWeek::of($year, $week)->minusYears(-$delta);
-        $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
+        self::assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
     public function providerPlusWeeks(): array
@@ -289,7 +289,7 @@ class YearWeekTest extends AbstractTestCase
     public function testPlusWeeks(int $year, int $week, int $delta, int $expectedYear, int $expectedWeek): void
     {
         $yearWeek = YearWeek::of($year, $week)->plusWeeks($delta);
-        $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
+        self::assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
     /**
@@ -298,7 +298,7 @@ class YearWeekTest extends AbstractTestCase
     public function testMinusWeeks(int $year, int $week, int $delta, int $expectedYear, int $expectedWeek): void
     {
         $yearWeek = YearWeek::of($year, $week)->minusWeeks(-$delta);
-        $this->assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
+        self::assertYearWeekIs($expectedYear, $expectedWeek, $yearWeek);
     }
 
     public function providerToString(): array
@@ -324,7 +324,7 @@ class YearWeekTest extends AbstractTestCase
     public function testJsonSerialize(int $year, int $week, string $expected): void
     {
         $yearWeek = YearWeek::of($year, $week);
-        $this->assertSame(json_encode($expected), json_encode($yearWeek));
+        self::assertSame(json_encode($expected), json_encode($yearWeek));
     }
 
     /**
@@ -333,7 +333,7 @@ class YearWeekTest extends AbstractTestCase
     public function testToString(int $year, int $week, string $expected): void
     {
         $yearWeek = YearWeek::of($year, $week);
-        $this->assertSame($expected, (string) $yearWeek);
+        self::assertSame($expected, (string) $yearWeek);
     }
 
     public function testNow(): void
@@ -342,7 +342,7 @@ class YearWeekTest extends AbstractTestCase
         $timeZone = TimeZone::parse('Asia/Taipei');
         $yearWeek = YearWeek::now($timeZone, $now);
 
-        $this->assertYearWeekIs(2033, 20, $yearWeek);
+        self::assertYearWeekIs(2033, 20, $yearWeek);
     }
 
     /**
@@ -357,7 +357,7 @@ class YearWeekTest extends AbstractTestCase
     {
         $yearWeek = YearWeek::of($year, $week);
 
-        $this->assertIs(LocalDate::class, $firstDay, $yearWeek->getFirstDay());
+        self::assertIs(LocalDate::class, $firstDay, $yearWeek->getFirstDay());
         $this->assertIs(LocalDate::class, $lastDay, $yearWeek->getLastDay());
     }
 
@@ -369,7 +369,7 @@ class YearWeekTest extends AbstractTestCase
         $yearWeek = YearWeek::of($year, $week);
         $expectedDateRange = (string) LocalDateRange::parse($firstDay . '/' . $lastDay);
 
-        $this->assertSame($expectedDateRange, (string) $yearWeek->toLocalDateRange());
+        self::assertSame($expectedDateRange, (string) $yearWeek->toLocalDateRange());
     }
 
     public function providerGetFirstLastDay(): array
@@ -464,11 +464,11 @@ class YearWeekTest extends AbstractTestCase
 
     private function assertCompareTo(int $expected, YearWeek $a, YearWeek $b): void
     {
-        $this->assertSame($expected, $a->compareTo($b));
-        $this->assertSame($expected === -1 || $expected === 0, $a->isBeforeOrEqualTo($b));
-        $this->assertSame($expected === -1, $a->isBefore($b));
-        $this->assertSame($expected === 0, $a->isEqualTo($b));
-        $this->assertSame($expected === 1, $a->isAfter($b));
-        $this->assertSame($expected === 1 || $expected === 0, $a->isAfterOrEqualTo($b));
+        self::assertSame($expected, $a->compareTo($b));
+        self::assertSame($expected === -1 || $expected === 0, $a->isBeforeOrEqualTo($b));
+        self::assertSame($expected === -1, $a->isBefore($b));
+        self::assertSame($expected === 0, $a->isEqualTo($b));
+        self::assertSame($expected === 1, $a->isAfter($b));
+        self::assertSame($expected === 1 || $expected === 0, $a->isAfterOrEqualTo($b));
     }
 }

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -50,14 +50,14 @@ class ZonedDateTimeTest extends AbstractTestCase
 
         $zonedDateTime = ZonedDateTime::of($localDateTime, $timeZone);
 
-        $this->assertInstanceOf(ZonedDateTime::class, $zonedDateTime);
+        self::assertInstanceOf(ZonedDateTime::class, $zonedDateTime);
 
-        $this->assertLocalDateTimeEquals($expectedDateTime, $zonedDateTime->getDateTime());
-        $this->assertTimeZoneEquals($timeZone, $zonedDateTime->getTimeZone());
-        $this->assertTimeZoneEquals($offset, $zonedDateTime->getTimeZoneOffset());
+        self::assertLocalDateTimeEquals($expectedDateTime, $zonedDateTime->getDateTime());
+        self::assertTimeZoneEquals($timeZone, $zonedDateTime->getTimeZone());
+        self::assertTimeZoneEquals($offset, $zonedDateTime->getTimeZoneOffset());
 
-        $this->assertSame($epochSecond, $zonedDateTime->getEpochSecond());
-        $this->assertSame($nanoOfSecond, $zonedDateTime->getNano());
+        self::assertSame($epochSecond, $zonedDateTime->getEpochSecond());
+        self::assertSame($nanoOfSecond, $zonedDateTime->getNano());
     }
 
     public function providerOf(): array
@@ -335,8 +335,8 @@ class ZonedDateTimeTest extends AbstractTestCase
         $instant = Instant::of(1000000000);
         $zonedDateTime = ZonedDateTime::ofInstant($instant, TimeZone::parse($timeZone));
 
-        $this->assertSame(1000000000, $zonedDateTime->getInstant()->getEpochSecond());
-        $this->assertSame($formattedDatetime, (string) $zonedDateTime->getDateTime());
+        self::assertSame(1000000000, $zonedDateTime->getInstant()->getEpochSecond());
+        self::assertSame($formattedDatetime, (string) $zonedDateTime->getDateTime());
     }
 
     public function providerOfInstant(): array
@@ -360,10 +360,10 @@ class ZonedDateTimeTest extends AbstractTestCase
     {
         $zonedDateTime = ZonedDateTime::parse($text);
 
-        $this->assertSame($date, (string) $zonedDateTime->getDate());
-        $this->assertSame($time, (string) $zonedDateTime->getTime());
-        $this->assertSame($offset, (string) $zonedDateTime->getTimeZoneOffset());
-        $this->assertSame($zone, (string) $zonedDateTime->getTimeZone());
+        self::assertSame($date, (string) $zonedDateTime->getDate());
+        self::assertSame($time, (string) $zonedDateTime->getTime());
+        self::assertSame($offset, (string) $zonedDateTime->getTimeZoneOffset());
+        self::assertSame($zone, (string) $zonedDateTime->getTimeZone());
     }
 
     public function providerParse(): iterable
@@ -445,7 +445,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     public function testFromNativeDateTime(string $dateTimeString, string $timeZone, string $expected): void
     {
         $dateTime = new DateTime($dateTimeString, new DateTimeZone($timeZone));
-        $this->assertIs(ZonedDateTime::class, $expected, ZonedDateTime::fromNativeDateTime($dateTime));
+        self::assertIs(ZonedDateTime::class, $expected, ZonedDateTime::fromNativeDateTime($dateTime));
     }
 
     public function providerFromNativeDateTime(): array
@@ -465,15 +465,15 @@ class ZonedDateTimeTest extends AbstractTestCase
         $datetime1 = ZonedDateTime::ofInstant(Instant::of(1000000000), $timezone1);
         $datetime2 = $datetime1->withTimeZoneSameInstant($timezone2);
 
-        $this->assertSame($timezone1, $datetime1->getTimeZone());
-        $this->assertSame($timezone2, $datetime2->getTimeZone());
-        $this->assertSame('2001-09-08T18:46:40', (string) $datetime2->getDateTime());
+        self::assertSame($timezone1, $datetime1->getTimeZone());
+        self::assertSame($timezone2, $datetime2->getTimeZone());
+        self::assertSame('2001-09-08T18:46:40', (string) $datetime2->getDateTime());
 
         $datetime2 = $datetime1->withTimeZoneSameLocal($timezone2);
 
-        $this->assertSame($timezone1, $datetime1->getTimeZone());
-        $this->assertSame($timezone2, $datetime2->getTimeZone());
-        $this->assertSame('2001-09-09T01:46:40', (string) $datetime2->getDateTime());
+        self::assertSame($timezone1, $datetime1->getTimeZone());
+        self::assertSame($timezone2, $datetime2->getTimeZone());
+        self::assertSame('2001-09-09T01:46:40', (string) $datetime2->getDateTime());
     }
 
     /**
@@ -488,19 +488,19 @@ class ZonedDateTimeTest extends AbstractTestCase
         $z1 = ZonedDateTime::parse($z1);
         $z2 = ZonedDateTime::parse($z2);
 
-        $this->assertSame($cmp, $z1->compareTo($z2));
-        $this->assertSame($cmp === 0, $z1->isEqualTo($z2));
-        $this->assertSame($cmp === -1, $z1->isBefore($z2));
-        $this->assertSame($cmp === 1, $z1->isAfter($z2));
-        $this->assertSame($cmp <= 0, $z1->isBeforeOrEqualTo($z2));
-        $this->assertSame($cmp >= 0, $z1->isAfterOrEqualTo($z2));
+        self::assertSame($cmp, $z1->compareTo($z2));
+        self::assertSame($cmp === 0, $z1->isEqualTo($z2));
+        self::assertSame($cmp === -1, $z1->isBefore($z2));
+        self::assertSame($cmp === 1, $z1->isAfter($z2));
+        self::assertSame($cmp <= 0, $z1->isBeforeOrEqualTo($z2));
+        self::assertSame($cmp >= 0, $z1->isAfterOrEqualTo($z2));
 
-        $this->assertSame(-$cmp, $z2->compareTo($z1));
-        $this->assertSame($cmp === 0, $z2->isEqualTo($z1));
-        $this->assertSame($cmp === 1, $z2->isBefore($z1));
-        $this->assertSame($cmp === -1, $z2->isAfter($z1));
-        $this->assertSame($cmp >= 0, $z2->isBeforeOrEqualTo($z1));
-        $this->assertSame($cmp <= 0, $z2->isAfterOrEqualTo($z1));
+        self::assertSame(-$cmp, $z2->compareTo($z1));
+        self::assertSame($cmp === 0, $z2->isEqualTo($z1));
+        self::assertSame($cmp === 1, $z2->isBefore($z1));
+        self::assertSame($cmp === -1, $z2->isAfter($z1));
+        self::assertSame($cmp >= 0, $z2->isBeforeOrEqualTo($z1));
+        self::assertSame($cmp <= 0, $z2->isAfterOrEqualTo($z1));
     }
 
     public function providerCompareTo(): array
@@ -520,186 +520,186 @@ class ZonedDateTimeTest extends AbstractTestCase
 
     public function testGetYear(): void
     {
-        $this->assertSame(2000, $this->getTestZonedDateTime()->getYear());
+        self::assertSame(2000, $this->getTestZonedDateTime()->getYear());
     }
 
     public function testGetMonth(): void
     {
-        $this->assertSame(1, $this->getTestZonedDateTime()->getMonth());
+        self::assertSame(1, $this->getTestZonedDateTime()->getMonth());
     }
 
     public function testGetDay(): void
     {
-        $this->assertSame(20, $this->getTestZonedDateTime()->getDay());
+        self::assertSame(20, $this->getTestZonedDateTime()->getDay());
     }
 
     public function testGetDayOfWeek(): void
     {
-        $this->assertDayOfWeekIs(DayOfWeek::THURSDAY, $this->getTestZonedDateTime()->getDayOfWeek());
+        self::assertDayOfWeekIs(DayOfWeek::THURSDAY, $this->getTestZonedDateTime()->getDayOfWeek());
     }
 
     public function testGetDayOfYear(): void
     {
-        $this->assertSame(20, $this->getTestZonedDateTime()->getDayOfYear());
+        self::assertSame(20, $this->getTestZonedDateTime()->getDayOfYear());
     }
 
     public function testGetHour(): void
     {
-        $this->assertSame(12, $this->getTestZonedDateTime()->getHour());
+        self::assertSame(12, $this->getTestZonedDateTime()->getHour());
     }
 
     public function testGetMinute(): void
     {
-        $this->assertSame(34, $this->getTestZonedDateTime()->getMinute());
+        self::assertSame(34, $this->getTestZonedDateTime()->getMinute());
     }
 
     public function testGetSecond(): void
     {
-        $this->assertSame(56, $this->getTestZonedDateTime()->getSecond());
+        self::assertSame(56, $this->getTestZonedDateTime()->getSecond());
     }
 
     public function testWithDate(): void
     {
         $newDate = LocalDate::of(2000, 1, 22);
 
-        $this->assertIs(ZonedDateTime::class, '2000-01-22T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withDate($newDate));
+        self::assertIs(ZonedDateTime::class, '2000-01-22T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withDate($newDate));
     }
 
     public function testWithTime(): void
     {
         $time = LocalTime::of(1, 2, 3, 987654321);
 
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T01:02:03.987654321-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withTime($time));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T01:02:03.987654321-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withTime($time));
     }
 
     public function testWithYear(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2020-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withYear(2020));
+        self::assertIs(ZonedDateTime::class, '2020-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withYear(2020));
     }
 
     public function testWithMonth(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-07-20T12:34:56.123456789-07:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withMonth(7));
+        self::assertIs(ZonedDateTime::class, '2000-07-20T12:34:56.123456789-07:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withMonth(7));
     }
 
     public function testWithDay(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-31T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withDay(31));
+        self::assertIs(ZonedDateTime::class, '2000-01-31T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withDay(31));
     }
 
     public function testWithHour(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T23:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withHour(23));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T23:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withHour(23));
     }
 
     public function testWithMinute(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:00:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withMinute(0));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:00:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withMinute(0));
     }
 
     public function testWithSecond(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:34:06.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withSecond(6));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:34:06.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withSecond(6));
     }
 
     public function testWithNano(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:34:56.000000123-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withNano(123));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:34:56.000000123-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withNano(123));
     }
 
     public function testWithFixedOffsetTimeZone(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:34:56.123456789-08:00', $this->getTestZonedDateTime()->withFixedOffsetTimeZone());
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:34:56.123456789-08:00', $this->getTestZonedDateTime()->withFixedOffsetTimeZone());
     }
 
     public function testPlusPeriod(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-04-06T12:34:56.123456789-07:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusPeriod(Period::ofWeeks(11)));
+        self::assertIs(ZonedDateTime::class, '2000-04-06T12:34:56.123456789-07:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusPeriod(Period::ofWeeks(11)));
     }
 
     public function testPlusDuration(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:35:01.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusDuration(Duration::ofSeconds(5)));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:35:01.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusDuration(Duration::ofSeconds(5)));
     }
 
     public function testPlusYears(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2002-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusYears(2));
+        self::assertIs(ZonedDateTime::class, '2002-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusYears(2));
     }
 
     public function testPlusMonths(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-03-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusMonths(2));
+        self::assertIs(ZonedDateTime::class, '2000-03-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusMonths(2));
     }
 
     public function testPlusWeeks(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-02-03T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusWeeks(2));
+        self::assertIs(ZonedDateTime::class, '2000-02-03T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusWeeks(2));
     }
 
     public function testPlusDays(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-22T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusDays(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-22T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusDays(2));
     }
 
     public function testPlusHours(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T14:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusHours(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T14:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusHours(2));
     }
 
     public function testPlusMinutes(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:36:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusMinutes(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:36:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusMinutes(2));
     }
 
     public function testPlusSeconds(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:34:58.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusSeconds(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:34:58.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->plusSeconds(2));
     }
 
     public function testMinusPeriod(): void
     {
-        $this->assertIs(ZonedDateTime::class, '1999-11-04T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusPeriod(Period::ofWeeks(11)));
+        self::assertIs(ZonedDateTime::class, '1999-11-04T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusPeriod(Period::ofWeeks(11)));
     }
 
     public function testMinusDuration(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:34:51.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusDuration(Duration::ofSeconds(5)));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:34:51.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusDuration(Duration::ofSeconds(5)));
     }
 
     public function testMinusYears(): void
     {
-        $this->assertIs(ZonedDateTime::class, '1999-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusYears(1));
+        self::assertIs(ZonedDateTime::class, '1999-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusYears(1));
     }
 
     public function testMinusMonths(): void
     {
-        $this->assertIs(ZonedDateTime::class, '1999-12-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusMonths(1));
+        self::assertIs(ZonedDateTime::class, '1999-12-20T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusMonths(1));
     }
 
     public function testMinusWeeks(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-06T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusWeeks(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-06T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusWeeks(2));
     }
 
     public function testMinusDays(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-18T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusDays(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-18T12:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusDays(2));
     }
 
     public function testMinusHours(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T10:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusHours(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T10:34:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusHours(2));
     }
 
     public function testMinusMinutes(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:32:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusMinutes(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:32:56.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusMinutes(2));
     }
 
     public function testMinusSeconds(): void
     {
-        $this->assertIs(ZonedDateTime::class, '2000-01-20T12:34:54.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusSeconds(2));
+        self::assertIs(ZonedDateTime::class, '2000-01-20T12:34:54.123456789-08:00[America/Los_Angeles]', $this->getTestZonedDateTime()->minusSeconds(2));
     }
 
     public function testIsBetweenInclusive(): void
@@ -717,8 +717,8 @@ class ZonedDateTimeTest extends AbstractTestCase
         $localDateTime = LocalDateTime::parse($localDateTime);
         $notIncluZonedDateTime = ZonedDateTime::of($localDateTime, $timeZone);
 
-        $this->assertTrue($fromZonedDateTime->isBetweenInclusive($fromZonedDateTime, $toZonedDateTime));
-        $this->assertFalse($fromZonedDateTime->isBetweenInclusive($toZonedDateTime, $notIncluZonedDateTime));
+        self::assertTrue($fromZonedDateTime->isBetweenInclusive($fromZonedDateTime, $toZonedDateTime));
+        self::assertFalse($fromZonedDateTime->isBetweenInclusive($toZonedDateTime, $notIncluZonedDateTime));
     }
 
     public function testIsBetweenExclusive(): void
@@ -736,8 +736,8 @@ class ZonedDateTimeTest extends AbstractTestCase
         $localDateTime = LocalDateTime::parse($localDateTime);
         $incluZonedDateTime = ZonedDateTime::of($localDateTime, $timeZone);
 
-        $this->assertTrue($incluZonedDateTime->isBetweenExclusive($fromZonedDateTime, $toZonedDateTime));
-        $this->assertFalse($fromZonedDateTime->isBetweenExclusive($fromZonedDateTime, $toZonedDateTime));
+        self::assertTrue($incluZonedDateTime->isBetweenExclusive($fromZonedDateTime, $toZonedDateTime));
+        self::assertFalse($fromZonedDateTime->isBetweenExclusive($fromZonedDateTime, $toZonedDateTime));
     }
 
     /**
@@ -747,7 +747,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     {
         $clock = new FixedClock(Instant::of($clockTimestamp));
         $zonedDateTime = ZonedDateTime::parse($zonedDateTime);
-        $this->assertSame($isFuture, $zonedDateTime->isFuture($clock));
+        self::assertSame($isFuture, $zonedDateTime->isFuture($clock));
     }
 
     /**
@@ -757,7 +757,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     {
         $clock = new FixedClock(Instant::of($clockTimestamp));
         $zonedDateTime = ZonedDateTime::parse($zonedDateTime);
-        $this->assertSame(! $isFuture, $zonedDateTime->isPast($clock));
+        self::assertSame(! $isFuture, $zonedDateTime->isPast($clock));
     }
 
     public function providerForPastFuture(): array
@@ -781,8 +781,8 @@ class ZonedDateTimeTest extends AbstractTestCase
         $zonedDateTime = ZonedDateTime::parse($dateTime);
         $dateTime = $zonedDateTime->toNativeDateTime();
 
-        $this->assertInstanceOf(DateTime::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTime::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     /**
@@ -796,8 +796,8 @@ class ZonedDateTimeTest extends AbstractTestCase
         $zonedDateTime = ZonedDateTime::parse($dateTime);
         $dateTime = $zonedDateTime->toNativeDateTimeImmutable();
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $dateTime);
-        $this->assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
+        self::assertInstanceOf(DateTimeImmutable::class, $dateTime);
+        self::assertSame($expected, $dateTime->format('Y-m-d\TH:i:s.uO'));
     }
 
     public function providerToNativeDateTime(): array
@@ -821,7 +821,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $localDateTime = LocalDateTime::parse($localDateTime);
         $zonedDateTime = ZonedDateTime::of($localDateTime, $timeZone);
 
-        $this->assertSame(json_encode('2000-01-20T12:34:56.123456789-08:00[America/Los_Angeles]'), json_encode($zonedDateTime));
+        self::assertSame(json_encode('2000-01-20T12:34:56.123456789-08:00[America/Los_Angeles]'), json_encode($zonedDateTime));
     }
 
     public function testToString(): void
@@ -831,7 +831,7 @@ class ZonedDateTimeTest extends AbstractTestCase
         $localDateTime = LocalDateTime::parse($localDateTime);
         $zonedDateTime = ZonedDateTime::of($localDateTime, $timeZone);
 
-        $this->assertSame('2000-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', (string) $zonedDateTime);
+        self::assertSame('2000-01-20T12:34:56.123456789-08:00[America/Los_Angeles]', (string) $zonedDateTime);
     }
 
     /**
@@ -841,7 +841,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     {
         $actualResult = ZonedDateTime::parse($firstDate)->getDurationTo(ZonedDateTime::parse($secondDate));
 
-        $this->assertDurationIs($expectedSeconds, $expectedNanos, $actualResult);
+        self::assertDurationIs($expectedSeconds, $expectedNanos, $actualResult);
     }
 
     public function providerGetDurationTo(): array

--- a/tools/ecs/ecs.php
+++ b/tools/ecs/ecs.php
@@ -200,7 +200,7 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, ['on_multiline' => 'ensure_fully_multiline']);
     $ecsConfig->ruleWithConfiguration(OrderedClassElementsFixer::class, ['order' => ['use_trait', 'case', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'phpunit', 'method_public', 'magic', 'method_protected', 'method_private', 'destruct']]);
     $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, ['syntax' => 'short']);
-    $ecsConfig->ruleWithConfiguration(PhpUnitTestCaseStaticMethodCallsFixer::class, ['call_type' => 'this']);
+    $ecsConfig->ruleWithConfiguration(PhpUnitTestCaseStaticMethodCallsFixer::class, ['call_type' => 'self']);
     $ecsConfig->ruleWithConfiguration(PhpdocTypesOrderFixer::class, ['null_adjustment' => 'always_last']);
     $ecsConfig->ruleWithConfiguration(NoSuperfluousPhpdocTagsFixer::class, ['allow_mixed' => true]);
     $ecsConfig->ruleWithConfiguration(ClassAttributesSeparationFixer::class, ['elements' => ['method' => 'one', 'property' => 'one']]);


### PR DESCRIPTION
This is for preference.

Related to https://github.com/brick/date-time/pull/77#issuecomment-1721904161

Note that custom `assertX` functions are not supported by the fixer, it only take into account PHPUnit ones.

I had to manually replace them to maintain consistency.
 
