### PR TITLE
LocalDateRange::toInterval

### DIFF
--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -245,6 +245,25 @@ final class LocalDateRange implements IteratorAggregate, Countable, JsonSerializ
     }
 
     /**
+     * Converts this LocalDateRange to Interval instance.
+     *
+     * The result is Interval from 00:00 start date and 00:00 end date + one day (because end in Interval is exclude)
+     * in the given time-zone.
+     */
+    public function toInterval(TimeZone $timeZone): Interval
+    {
+        $startZonedDateTime = $this->getStart()
+            ->atTime(LocalTime::min())
+            ->atTimeZone($timeZone);
+        $endZonedDateTime = $this->getEnd()
+            ->plusDays(1)
+            ->atTime(LocalTime::min())
+            ->atTimeZone($timeZone);
+
+        return $startZonedDateTime->getIntervalTo($endZonedDateTime);
+    }
+
+    /**
      * Converts this LocalDateRange to a native DatePeriod object.
      *
      * The result is a DatePeriod->start with time 00:00 and a DatePeriod->end

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -8,6 +8,7 @@ use Brick\DateTime\DateTimeException;
 use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalDateRange;
 use Brick\DateTime\Parser\DateTimeParseException;
+use Brick\DateTime\TimeZone;
 
 use function array_map;
 use function iterator_count;
@@ -237,6 +238,28 @@ class LocalDateRangeTest extends AbstractTestCase
             ['2010-01-01/2010-01-01', '2010-01-01T00:00:00.000000+0000', '2010-01-01T23:59:59.999999+0000'],
             ['2010-01-01/2010-01-02', '2010-01-01T00:00:00.000000+0000', '2010-01-02T23:59:59.999999+0000'],
             ['2010-01-01/2010-12-31', '2010-01-01T00:00:00.000000+0000', '2010-12-31T23:59:59.999999+0000'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerToInterval
+     */
+    public function testToInterval(string $range, string $timeZone, string $expectedInterval): void
+    {
+        $actualResult = LocalDateRange::parse($range)->toInterval(TimeZone::parse($timeZone));
+        self::assertSame($expectedInterval, (string) $actualResult);
+    }
+
+    public function providerToInterval(): array
+    {
+        return [
+            ['2010-01-01/2010-01-01', 'UTC', '2010-01-01T00:00Z/2010-01-02T00:00Z'],
+            ['2010-01-01/2020-12-31', 'UTC', '2010-01-01T00:00Z/2021-01-01T00:00Z'],
+            ['2022-03-20/2022-03-26', 'Europe/London', '2022-03-20T00:00Z/2022-03-27T00:00Z'],
+            ['2022-03-20/2022-03-27', 'Europe/London', '2022-03-20T00:00Z/2022-03-27T23:00Z'],
+            ['2022-03-20/2022-03-26', 'Europe/Berlin', '2022-03-19T23:00Z/2022-03-26T23:00Z'],
+            ['2022-03-20/2022-03-27', 'Europe/Berlin', '2022-03-19T23:00Z/2022-03-27T22:00Z'],
+            ['2022-01-01/2022-12-31', 'Europe/Berlin', '2021-12-31T23:00Z/2022-12-31T23:00Z'],
         ];
     }
 


### PR DESCRIPTION
Converting `LocalDateRange` to `Interval` is a common task in my app. Typically, I have a method to generate reports that expects a `LocalDateRange` argument. Subsequently, I need to transform it for SQL queries using the `BETWEEN` operator. It’s important to note that the timezone in my database differs from the implied timezone in `LocalDateRange`.

The new method introduced will transform any `LocalDateRange` into an `Interval` in the specified timezone.