### PR TITLE
Year::atMonth(): deprecate int argument, add support for Month enum.

### DIFF
--- a/src/Year.php
+++ b/src/Year.php
@@ -239,14 +239,20 @@ final class Year implements JsonSerializable, Stringable
 
     /**
      * Combines this year with a month to create a YearMonth.
-     *
-     * @param int $month The month-of-year to use, from 1 to 12.
-     *
-     * @throws DateTimeException If the month is invalid.
      */
-    public function atMonth(int $month): YearMonth
+    public function atMonth(int|Month $month): YearMonth
     {
-        return YearMonth::of($this->year, $month);
+        if (is_int($month)) {
+            // usually we don't use trigger_error() for deprecations, but we can't rely on @deprecated for a parameter type change;
+            // maybe we should revisit using trigger_error() unconditionally for deprecations in the future.
+            trigger_error('Passing an integer to Year::atMonth() is deprecated, pass a Month instance instead.', E_USER_DEPRECATED);
+
+            Field\MonthOfYear::check($month);
+
+            $month = Month::from($month);
+        }
+
+        return YearMonth::of($this->year, $month->value);
     }
 
     /**

--- a/tests/YearTest.php
+++ b/tests/YearTest.php
@@ -7,6 +7,7 @@ namespace Brick\DateTime\Tests;
 use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\DateTimeException;
 use Brick\DateTime\Instant;
+use Brick\DateTime\Month;
 use Brick\DateTime\MonthDay;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\Year;
@@ -432,6 +433,7 @@ class YearTest extends AbstractTestCase
     public function testAtMonth(): void
     {
         self::assertYearMonthIs(2014, 7, Year::of(2014)->atMonth(7));
+        self::assertYearMonthIs(2014, 7, Year::of(2014)->atMonth(Month::JULY));
     }
 
     /**


### PR DESCRIPTION
Fixes #94