### PR TITLE
Add @psalm-* annotations for better static analysis (compatible with PHPStan too)

### DIFF
--- a/src/DayOfWeek.php
+++ b/src/DayOfWeek.php
@@ -226,6 +226,8 @@ enum DayOfWeek: int implements JsonSerializable
 
     /**
      * Serializes as a string using {@see DayOfWeek::toString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -234,6 +236,8 @@ enum DayOfWeek: int implements JsonSerializable
 
     /**
      * Returns the capitalized English name of this day-of-week.
+     *
+     * @psalm-return non-empty-string
      */
     public function toString(): string
     {

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -466,6 +466,8 @@ final class Duration implements JsonSerializable, Stringable
      * @param Duration $that The other duration to compare to.
      *
      * @return int [-1,0,1] If this duration is less than, equal to, or greater than the given duration.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(Duration $that): int
     {

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -756,6 +756,8 @@ final class Duration implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see Duration::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -772,6 +774,8 @@ final class Duration implements JsonSerializable, Stringable
      * The hours, minutes and seconds will all have the same sign.
      *
      * Note that multiples of 24 hours are not output as days to avoid confusion with Period.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -817,6 +821,8 @@ final class Duration implements JsonSerializable, Stringable
 
     /**
      * {@see Duration::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -238,6 +238,8 @@ final class Instant implements JsonSerializable, Stringable
      * Compares this instant with another.
      *
      * @return int [-1,0,1] If this instant is before, on, or after the given instant.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(Instant $that): int
     {

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -368,6 +368,8 @@ final class Instant implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see Instant::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -376,6 +378,8 @@ final class Instant implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this instant.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -384,6 +388,8 @@ final class Instant implements JsonSerializable, Stringable
 
     /**
      * {@see Instant::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -140,6 +140,8 @@ final class Interval implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see Interval::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -148,6 +150,8 @@ final class Interval implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this interval.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -156,6 +160,8 @@ final class Interval implements JsonSerializable, Stringable
 
     /**
      * {@see Interval::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -771,6 +771,8 @@ final class LocalDate implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see LocalDate::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -779,6 +781,8 @@ final class LocalDate implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this date.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -799,6 +803,8 @@ final class LocalDate implements JsonSerializable, Stringable
 
     /**
      * {@see LocalDate::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -591,6 +591,8 @@ final class LocalDate implements JsonSerializable, Stringable
      * Returns -1 if this date is before the given date, 1 if after, 0 if the dates are equal.
      *
      * @return int [-1,0,1] If this date is before, on, or after the given date.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(LocalDate $that): int
     {

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -239,6 +239,8 @@ final class LocalDateRange implements IteratorAggregate, Countable, JsonSerializ
 
     /**
      * Serializes as a string using {@see LocalDateRange::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -262,6 +264,8 @@ final class LocalDateRange implements IteratorAggregate, Countable, JsonSerializ
 
     /**
      * Returns the ISO 8601 representation of this date range.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -270,6 +274,8 @@ final class LocalDateRange implements IteratorAggregate, Countable, JsonSerializ
 
     /**
      * {@see LocalDateRange::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -738,6 +738,8 @@ final class LocalDateTime implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see LocalDateTime::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -746,6 +748,8 @@ final class LocalDateTime implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this date time.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -754,6 +758,8 @@ final class LocalDateTime implements JsonSerializable, Stringable
 
     /**
      * {@see LocalDateTime::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -659,6 +659,8 @@ final class LocalDateTime implements JsonSerializable, Stringable
      * @param LocalDateTime $that The date-time to compare to.
      *
      * @return int [-1,0,1] If this date-time is before, on, or after the given date-time.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(LocalDateTime $that): int
     {

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -643,6 +643,8 @@ final class LocalTime implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see LocalTime::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -661,6 +663,8 @@ final class LocalTime implements JsonSerializable, Stringable
      * The format used will be the shortest that outputs the full value of
      * the time where the omitted parts are implied to be zero.
      * The nanoseconds value, if present, can be 0 to 9 digits.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -674,6 +678,8 @@ final class LocalTime implements JsonSerializable, Stringable
 
     /**
      * {@see LocalTime::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -527,6 +527,8 @@ final class LocalTime implements JsonSerializable, Stringable
      * @param LocalTime $that The time to compare to.
      *
      * @return int [-1,0,1] If this time is before, on, or after the given time.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(LocalTime $that): int
     {

--- a/src/Month.php
+++ b/src/Month.php
@@ -201,6 +201,8 @@ enum Month : int implements JsonSerializable
 
     /**
      * Serializes as a string using {@see Month::toString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -209,6 +211,8 @@ enum Month : int implements JsonSerializable
 
     /**
      * Returns the capitalized English name of this Month.
+     *
+     * @psalm-return non-empty-string
      */
     public function toString(): string
     {

--- a/src/MonthDay.php
+++ b/src/MonthDay.php
@@ -133,6 +133,8 @@ final class MonthDay implements JsonSerializable, Stringable
      * Returns -1 if this date is before the given date, 1 if after, 0 if the dates are equal.
      *
      * @return int [-1,0,1] If this date is before, on, or after the given date.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(MonthDay $that): int
     {

--- a/src/MonthDay.php
+++ b/src/MonthDay.php
@@ -243,6 +243,8 @@ final class MonthDay implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see MonthDay::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -251,6 +253,8 @@ final class MonthDay implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this month-day.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -263,6 +267,8 @@ final class MonthDay implements JsonSerializable, Stringable
 
     /**
      * {@see MonthDay::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/Period.php
+++ b/src/Period.php
@@ -379,6 +379,8 @@ final class Period implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see Period::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -387,6 +389,8 @@ final class Period implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this period.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -411,6 +415,8 @@ final class Period implements JsonSerializable, Stringable
 
     /**
      * {@see Period::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/TimeZone.php
+++ b/src/TimeZone.php
@@ -93,6 +93,9 @@ abstract class TimeZone implements Stringable
      */
     abstract public function toNativeDateTimeZone(): DateTimeZone;
 
+    /**
+     * @psalm-return non-empty-string
+     */
     public function __toString(): string
     {
         return $this->getId();

--- a/src/Year.php
+++ b/src/Year.php
@@ -284,6 +284,8 @@ final class Year implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see Year::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -292,6 +294,8 @@ final class Year implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this year.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -307,6 +311,8 @@ final class Year implements JsonSerializable, Stringable
 
     /**
      * {@see Year::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/Year.php
+++ b/src/Year.php
@@ -178,6 +178,8 @@ final class Year implements JsonSerializable, Stringable
      * @param Year $that The year to compare to.
      *
      * @return int [-1, 0, 1] If this year is before, equal to, or after the given year.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(Year $that): int
     {

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -304,6 +304,8 @@ final class YearMonth implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see YearMonth::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -312,6 +314,8 @@ final class YearMonth implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this year-month.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -330,6 +334,8 @@ final class YearMonth implements JsonSerializable, Stringable
 
     /**
      * {@see YearMonth::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -147,6 +147,8 @@ final class YearMonth implements JsonSerializable, Stringable
 
     /**
      * @return int [-1,0,1] If this year-month is before, on, or after the given year-month.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(YearMonth $that): int
     {

--- a/src/YearMonthRange.php
+++ b/src/YearMonthRange.php
@@ -182,6 +182,8 @@ class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable, 
 
     /**
      * Serializes as a string using {@see YearMonthRange::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -193,6 +195,8 @@ class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable, 
      *
      * ISO 8601 does not seem to provide a standard notation for year-month ranges, but we're using the same format as
      * date ranges.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -201,6 +205,8 @@ class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable, 
 
     /**
      * {@see YearMonthRange::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -106,6 +106,8 @@ final class YearWeek implements JsonSerializable, Stringable
 
     /**
      * @return int [-1,0,1] If this year-week is before, on, or after the given year-week.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(YearWeek $that): int
     {

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -311,6 +311,8 @@ final class YearWeek implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see YearWeek::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -319,6 +321,8 @@ final class YearWeek implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this year-week.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -337,6 +341,8 @@ final class YearWeek implements JsonSerializable, Stringable
 
     /**
      * {@see YearWeek::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -734,6 +734,8 @@ class ZonedDateTime implements JsonSerializable, Stringable
 
     /**
      * Serializes as a string using {@see ZonedDateTime::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function jsonSerialize(): string
     {
@@ -742,6 +744,8 @@ class ZonedDateTime implements JsonSerializable, Stringable
 
     /**
      * Returns the ISO 8601 representation of this zoned date time.
+     *
+     * @psalm-return non-empty-string
      */
     public function toISOString(): string
     {
@@ -756,6 +760,8 @@ class ZonedDateTime implements JsonSerializable, Stringable
 
     /**
      * {@see ZonedDateTime::toISOString()}.
+     *
+     * @psalm-return non-empty-string
      */
     public function __toString(): string
     {

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -611,6 +611,8 @@ class ZonedDateTime implements JsonSerializable, Stringable
      * The comparison is performed on the instant.
      *
      * @return int [-1,0,1] If this zoned date-time is before, on, or after the given one.
+     *
+     * @psalm-return -1|0|1
      */
     public function compareTo(ZonedDateTime $that): int
     {


### PR DESCRIPTION
Below are the two types improvements I've noticed were missing when we've integrated the library in our application. I've not read every code signature to make sure everything was as precise as it could be though, so maybe other type improvements will come in the future.

### TODO
- [x] `@return non-empty-string` on `toString` methods (and alike)
- [x] `@return -1|0|1` on `compareTo` methods