### PR TITLE
Stopwatch Lap Duration

### DIFF
--- a/src/Stopwatch.php
+++ b/src/Stopwatch.php
@@ -49,14 +49,14 @@ final class Stopwatch
     }
 
     /**
-     * Stops the timer.
+     * Stops the timer and returns the lap duration.
      *
-     * If the timer is already stopped, this method does nothing.
+     * If the timer is already stopped, this method does nothing, and returns a zero duration.
      */
-    public function stop(): void
+    public function stop(): Duration
     {
         if ($this->startTime === null) {
-            return;
+            return Duration::zero();
         }
 
         $endTime = $this->clock->getTime();
@@ -64,6 +64,8 @@ final class Stopwatch
 
         $this->duration = $this->duration->plus($duration);
         $this->startTime = null;
+
+        return $duration;
     }
 
     /**

--- a/tests/StopwatchTest.php
+++ b/tests/StopwatchTest.php
@@ -73,8 +73,10 @@ class StopwatchTest extends AbstractTestCase
     public function testStopWithNullStartTime(): void
     {
         $stopwatch = new Stopwatch();
-        $stopwatch->stop();
 
+        $duration = $stopwatch->stop();
+
+        self::assertDurationIs(0, 0, $duration);
         self::assertNull($stopwatch->getStartTime());
         self::assertFalse($stopwatch->isRunning());
         self::assertDurationIs(0, 0, $stopwatch->getElapsedTime());
@@ -87,8 +89,9 @@ class StopwatchTest extends AbstractTestCase
     {
         self::setClockTime(3000, 2);
 
-        $stopwatch->stop();
+        $duration = $stopwatch->stop();
 
+        self::assertDurationIs(2000, 1, $duration);
         self::assertNull($stopwatch->getStartTime());
         self::assertFalse($stopwatch->isRunning());
         self::assertDurationIs(2000, 1, $stopwatch->getElapsedTime());
@@ -147,8 +150,9 @@ class StopwatchTest extends AbstractTestCase
     {
         self::setClockTime(5002, 20);
 
-        $stopwatch->stop();
+        $duration = $stopwatch->stop();
 
+        self::assertDurationIs(2, 11, $duration);
         self::assertNull($stopwatch->getStartTime());
         self::assertFalse($stopwatch->isRunning());
         self::assertDurationIs(2002, 12, $stopwatch->getElapsedTime());


### PR DESCRIPTION
Return the lap duration when stopping the `Stopwatch`, which will be the duration since the last start.

If the stopwatch is not started, then the duration will be zero.

Use case - using a stopwatch to perform multiple duration timings, and then fetch the total elapsed time at the end (I can't see this is possible now, please direct me if I've just overlooked it though).

**Note:** CI failure does not seem related to my changes, as above though let me know if I missed something.