### PR TITLE
Install Rector and apply ClassPropertyAssignToConstructorPromotionRector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 /tools/ecs/*
 !/tools/ecs/composer.json
 !/tools/ecs/ecs.php
+!/tools/rector
+/tools/rector/*
+!/tools/rector/composer.json
+!/tools/rector/rector.php

--- a/src/Clock/FixedClock.php
+++ b/src/Clock/FixedClock.php
@@ -16,8 +16,9 @@ final class FixedClock implements Clock
     /**
      * @param Instant $instant The time to set the clock at.
      */
-    public function __construct(private Instant $instant)
-    {
+    public function __construct(
+        private Instant $instant
+    ) {
     }
 
     public function getTime(): Instant

--- a/src/Clock/FixedClock.php
+++ b/src/Clock/FixedClock.php
@@ -17,7 +17,7 @@ final class FixedClock implements Clock
      * @param Instant $instant The time to set the clock at.
      */
     public function __construct(
-        private Instant $instant
+        private Instant $instant,
     ) {
     }
 

--- a/src/Clock/FixedClock.php
+++ b/src/Clock/FixedClock.php
@@ -13,14 +13,11 @@ use Brick\DateTime\Instant;
  */
 final class FixedClock implements Clock
 {
-    private Instant $instant;
-
     /**
      * @param Instant $instant The time to set the clock at.
      */
-    public function __construct(Instant $instant)
+    public function __construct(private Instant $instant)
     {
-        $this->instant = $instant;
     }
 
     public function getTime(): Instant

--- a/src/Clock/OffsetClock.php
+++ b/src/Clock/OffsetClock.php
@@ -19,7 +19,7 @@ final class OffsetClock implements Clock
      */
     public function __construct(
         private readonly Clock $referenceClock,
-        private readonly Duration $offset
+        private readonly Duration $offset,
     ) {
     }
 

--- a/src/Clock/OffsetClock.php
+++ b/src/Clock/OffsetClock.php
@@ -14,23 +14,13 @@ use Brick\DateTime\Instant;
 final class OffsetClock implements Clock
 {
     /**
-     * The reference clock.
-     */
-    private readonly Clock $referenceClock;
-
-    /**
-     * The offset to apply to the clock.
-     */
-    private readonly Duration $offset;
-
-    /**
      * @param Clock    $referenceClock The reference clock.
      * @param Duration $offset         The offset to apply to the clock.
      */
-    public function __construct(Clock $referenceClock, Duration $offset)
-    {
-        $this->referenceClock = $referenceClock;
-        $this->offset = $offset;
+    public function __construct(
+        private readonly Clock $referenceClock,
+        private readonly Duration $offset
+    ) {
     }
 
     public function getTime(): Instant

--- a/src/Clock/ScaleClock.php
+++ b/src/Clock/ScaleClock.php
@@ -14,19 +14,9 @@ use Brick\DateTime\Instant;
 final class ScaleClock implements Clock
 {
     /**
-     * The reference clock.
-     */
-    private readonly Clock $referenceClock;
-
-    /**
      * The start time.
      */
     private readonly Instant $startTime;
-
-    /**
-     * The time scale.
-     */
-    private readonly int $timeScale;
 
     /**
      * - a scale > 1 makes the time move at an accelerated pace;
@@ -37,11 +27,11 @@ final class ScaleClock implements Clock
      * @param Clock $referenceClock The reference clock.
      * @param int   $timeScale      The time scale.
      */
-    public function __construct(Clock $referenceClock, int $timeScale)
-    {
-        $this->referenceClock = $referenceClock;
-        $this->startTime = $referenceClock->getTime();
-        $this->timeScale = $timeScale;
+    public function __construct(
+        private readonly Clock $referenceClock,
+        private readonly int $timeScale
+    ) {
+        $this->startTime = $this->referenceClock->getTime();
     }
 
     public function getTime(): Instant

--- a/src/Clock/ScaleClock.php
+++ b/src/Clock/ScaleClock.php
@@ -29,7 +29,7 @@ final class ScaleClock implements Clock
      */
     public function __construct(
         private readonly Clock $referenceClock,
-        private readonly int $timeScale
+        private readonly int $timeScale,
     ) {
         $this->startTime = $this->referenceClock->getTime();
     }

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -35,7 +35,7 @@ final class Duration implements JsonSerializable, Stringable
      */
     private function __construct(
         private readonly int $seconds,
-        private readonly int $nanos = 0
+        private readonly int $nanos = 0,
     ) {
     }
 

--- a/src/Duration.php
+++ b/src/Duration.php
@@ -27,27 +27,16 @@ use const STR_PAD_RIGHT;
 final class Duration implements JsonSerializable, Stringable
 {
     /**
-     * The duration in seconds.
-     */
-    private readonly int $seconds;
-
-    /**
-     * The nanoseconds adjustment to the duration, in the range 0 to 999,999,999.
-     *
-     * A duration of -1 nanoseconds is stored as -1 seconds plus 999,999,999 nanoseconds.
-     */
-    private readonly int $nanos;
-
-    /**
      * Private constructor. Use one of the factory methods to obtain a Duration.
      *
      * @param int $seconds The duration in seconds.
-     * @param int $nanos   The nanoseconds adjustment, validated in the range 0 to 999,999,999.
+     * @param int $nanos   The nanoseconds adjustment to the duration, validated in the range 0 to 999,999,999.
+     *                     A duration of -1 nanoseconds is stored as -1 seconds plus 999,999,999 nanoseconds.
      */
-    private function __construct(int $seconds, int $nanos = 0)
-    {
-        $this->seconds = $seconds;
-        $this->nanos = $nanos;
+    private function __construct(
+        private readonly int $seconds,
+        private readonly int $nanos = 0
+    ) {
     }
 
     /**

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -26,25 +26,15 @@ use const STR_PAD_LEFT;
 final class Instant implements JsonSerializable, Stringable
 {
     /**
-     * The number of seconds since the epoch of 1970-01-01T00:00:00Z.
-     */
-    private readonly int $epochSecond;
-
-    /**
-     * The nanoseconds adjustment to the epoch second, in the range 0 to 999,999,999.
-     */
-    private readonly int $nano;
-
-    /**
      * Private constructor. Use of() to obtain an Instant.
      *
-     * @param int $epochSecond The epoch second.
-     * @param int $nano        The nanosecond adjustment, validated in the range 0 to 999,999,999.
+     * @param int $epochSecond The number of seconds since the epoch of 1970-01-01T00:00:00Z.
+     * @param int $nano        The nanosecond adjustment to the epoch second, validated in the range 0 to 999,999,999.
      */
-    private function __construct(int $epochSecond, int $nano)
-    {
-        $this->epochSecond = $epochSecond;
-        $this->nano = $nano;
+    private function __construct(
+        private readonly int $epochSecond,
+        private readonly int $nano
+    ) {
     }
 
     /**

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -33,7 +33,7 @@ final class Instant implements JsonSerializable, Stringable
      */
     private function __construct(
         private readonly int $epochSecond,
-        private readonly int $nano
+        private readonly int $nano,
     ) {
     }
 

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -21,7 +21,7 @@ final class Interval implements JsonSerializable, Stringable
      */
     private function __construct(
         private readonly Instant $start,
-        private readonly Instant $end
+        private readonly Instant $end,
     ) {
     }
 

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -16,23 +16,13 @@ use Stringable;
 final class Interval implements JsonSerializable, Stringable
 {
     /**
-     * The start instant, inclusive.
+     * @param Instant $start The start instant, inclusive.
+     * @param Instant $end   The end instant, exclusive, validated as not before the start instant.
      */
-    private readonly Instant $start;
-
-    /**
-     * The end instant, exclusive.
-     */
-    private readonly Instant $end;
-
-    /**
-     * @param Instant $startInclusive The start instant, inclusive.
-     * @param Instant $endExclusive   The end instant, exclusive, validated as not before the start instant.
-     */
-    private function __construct(Instant $startInclusive, Instant $endExclusive)
-    {
-        $this->start = $startInclusive;
-        $this->end = $endExclusive;
+    private function __construct(
+        private readonly Instant $start,
+        private readonly Instant $end
+    ) {
     }
 
     /**

--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -58,7 +58,7 @@ final class LocalDate implements JsonSerializable, Stringable
     private function __construct(
         private readonly int $year,
         private readonly int $month,
-        private readonly int $day
+        private readonly int $day,
     ) {
     }
 
@@ -146,7 +146,7 @@ final class LocalDate implements JsonSerializable, Stringable
         return new LocalDate(
             (int) $dateTime->format('Y'),
             (int) $dateTime->format('n'),
-            (int) $dateTime->format('j')
+            (int) $dateTime->format('j'),
         );
     }
 

--- a/src/LocalDate.php
+++ b/src/LocalDate.php
@@ -49,32 +49,17 @@ final class LocalDate implements JsonSerializable, Stringable
     public const DAYS_PER_CYCLE = 146097;
 
     /**
-     * The year.
-     */
-    private readonly int $year;
-
-    /**
-     * The month-of-year.
-     */
-    private readonly int $month;
-
-    /**
-     * The day-of-month.
-     */
-    private readonly int $day;
-
-    /**
      * Private constructor. Use of() to obtain an instance.
      *
      * @param int $year  The year, validated from MIN_YEAR to MAX_YEAR.
      * @param int $month The month-of-year, validated from 1 to 12.
      * @param int $day   The day-of-month, validated from 1 to 31, valid for the year-month.
      */
-    private function __construct(int $year, int $month, int $day)
-    {
-        $this->year = $year;
-        $this->month = $month;
-        $this->day = $day;
+    private function __construct(
+        private readonly int $year,
+        private readonly int $month,
+        private readonly int $day
+    ) {
     }
 
     /**

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -27,23 +27,13 @@ use Stringable;
 final class LocalDateRange implements IteratorAggregate, Countable, JsonSerializable, Stringable
 {
     /**
-     * The start date, inclusive.
-     */
-    private readonly LocalDate $start;
-
-    /**
-     * The end date, inclusive.
-     */
-    private readonly LocalDate $end;
-
-    /**
      * @param LocalDate $start The start date, inclusive.
      * @param LocalDate $end   The end date, inclusive, validated as not before the start date.
      */
-    private function __construct(LocalDate $start, LocalDate $end)
-    {
-        $this->start = $start;
-        $this->end = $end;
+    private function __construct(
+        private readonly LocalDate $start,
+        private readonly LocalDate $end
+    ) {
     }
 
     /**

--- a/src/LocalDateRange.php
+++ b/src/LocalDateRange.php
@@ -32,7 +32,7 @@ final class LocalDateRange implements IteratorAggregate, Countable, JsonSerializ
      */
     private function __construct(
         private readonly LocalDate $start,
-        private readonly LocalDate $end
+        private readonly LocalDate $end,
     ) {
     }
 

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -24,14 +24,10 @@ use function intdiv;
  */
 final class LocalDateTime implements JsonSerializable, Stringable
 {
-    private readonly LocalDate $date;
-
-    private readonly LocalTime $time;
-
-    public function __construct(LocalDate $date, LocalTime $time)
-    {
-        $this->date = $date;
-        $this->time = $time;
+    public function __construct(
+        private readonly LocalDate $date,
+        private readonly LocalTime $time
+    ) {
     }
 
     /**

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -26,7 +26,7 @@ final class LocalDateTime implements JsonSerializable, Stringable
 {
     public function __construct(
         private readonly LocalDate $date,
-        private readonly LocalTime $time
+        private readonly LocalTime $time,
     ) {
     }
 
@@ -67,7 +67,7 @@ final class LocalDateTime implements JsonSerializable, Stringable
     {
         return new LocalDateTime(
             LocalDate::from($result),
-            LocalTime::from($result)
+            LocalTime::from($result),
         );
     }
 
@@ -96,7 +96,7 @@ final class LocalDateTime implements JsonSerializable, Stringable
     {
         return new LocalDateTime(
             LocalDate::fromNativeDateTime($dateTime),
-            LocalTime::fromNativeDateTime($dateTime)
+            LocalTime::fromNativeDateTime($dateTime),
         );
     }
 

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -55,7 +55,7 @@ final class LocalTime implements JsonSerializable, Stringable
         private readonly int $hour,
         private readonly int $minute,
         private readonly int $second,
-        private readonly int $nano
+        private readonly int $nano,
     ) {
     }
 
@@ -141,7 +141,7 @@ final class LocalTime implements JsonSerializable, Stringable
             (int) $dateTime->format('G'),
             (int) $dateTime->format('i'),
             (int) $dateTime->format('s'),
-            1000 * (int) $dateTime->format('u')
+            1000 * (int) $dateTime->format('u'),
         );
     }
 

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -44,26 +44,6 @@ final class LocalTime implements JsonSerializable, Stringable
     public const MILLIS_PER_SECOND = 1000;
 
     /**
-     * The hour, in the range 0 to 23.
-     */
-    private readonly int $hour;
-
-    /**
-     * The minute, in the range 0 to 59.
-     */
-    private readonly int $minute;
-
-    /**
-     * The second, in the range 0 to 59.
-     */
-    private readonly int $second;
-
-    /**
-     * The nanosecond, in the range 0 to 999,999,999.
-     */
-    private readonly int $nano;
-
-    /**
      * Private constructor. Use of() to obtain an instance.
      *
      * @param int $hour   The hour-of-day, validated in the range 0 to 23.
@@ -71,12 +51,12 @@ final class LocalTime implements JsonSerializable, Stringable
      * @param int $second The second-of-minute, validated in the range 0 to 59.
      * @param int $nano   The nano-of-second, validated in the range 0 to 999,999,999.
      */
-    private function __construct(int $hour, int $minute, int $second, int $nano)
-    {
-        $this->hour = $hour;
-        $this->minute = $minute;
-        $this->second = $second;
-        $this->nano = $nano;
+    private function __construct(
+        private readonly int $hour,
+        private readonly int $minute,
+        private readonly int $second,
+        private readonly int $nano
+    ) {
     }
 
     /**

--- a/src/MonthDay.php
+++ b/src/MonthDay.php
@@ -24,7 +24,7 @@ final class MonthDay implements JsonSerializable, Stringable
      */
     private function __construct(
         private readonly int $month,
-        private readonly int $day
+        private readonly int $day,
     ) {
     }
 
@@ -52,7 +52,7 @@ final class MonthDay implements JsonSerializable, Stringable
     {
         return MonthDay::of(
             (int) $result->getField(Field\MonthOfYear::NAME),
-            (int) $result->getField(Field\DayOfMonth::NAME)
+            (int) $result->getField(Field\DayOfMonth::NAME),
         );
     }
 

--- a/src/MonthDay.php
+++ b/src/MonthDay.php
@@ -17,25 +17,15 @@ use Stringable;
 final class MonthDay implements JsonSerializable, Stringable
 {
     /**
-     * The month-of-year, from 1 to 12.
-     */
-    private readonly int $month;
-
-    /**
-     * The day-of-month, from 1 to 31.
-     */
-    private readonly int $day;
-
-    /**
      * Private constructor. Use of() to obtain an instance.
      *
-     * @param int $month The month-of-year, validated.
-     * @param int $day   The day-of-month, validated.
+     * @param int $month The month-of-year, validated in the range of 1 to 12.
+     * @param int $day   The day-of-month, validated in the range of 1 to 31, valid for this month.
      */
-    private function __construct(int $month, int $day)
-    {
-        $this->month = $month;
-        $this->day = $day;
+    private function __construct(
+        private readonly int $month,
+        private readonly int $day
+    ) {
     }
 
     /**

--- a/src/Parser/PatternParser.php
+++ b/src/Parser/PatternParser.php
@@ -18,7 +18,7 @@ final class PatternParser implements DateTimeParser
      */
     public function __construct(
         private readonly string $pattern,
-        private readonly array $fields
+        private readonly array $fields,
     ) {
     }
 

--- a/src/Parser/PatternParser.php
+++ b/src/Parser/PatternParser.php
@@ -12,21 +12,14 @@ use function sprintf;
  */
 final class PatternParser implements DateTimeParser
 {
-    private readonly string $pattern;
-
-    /**
-     * @var string[]
-     */
-    private readonly array $fields;
-
     /**
      * @param string   $pattern The regular expression pattern.
      * @param string[] $fields  The fields constants to match.
      */
-    public function __construct(string $pattern, array $fields)
-    {
-        $this->pattern = $pattern;
-        $this->fields = $fields;
+    public function __construct(
+        private readonly string $pattern,
+        private readonly array $fields
+    ) {
     }
 
     public function getPattern(): string

--- a/src/Period.php
+++ b/src/Period.php
@@ -19,12 +19,6 @@ use function sprintf;
  */
 final class Period implements JsonSerializable, Stringable
 {
-    private readonly int $years;
-
-    private readonly int $months;
-
-    private readonly int $days;
-
     /**
      * Private constructor. Use of() to obtain an instance.
      *
@@ -32,11 +26,11 @@ final class Period implements JsonSerializable, Stringable
      * @param int $months The number of months.
      * @param int $days   The number of days.
      */
-    private function __construct(int $years, int $months, int $days)
-    {
-        $this->years = $years;
-        $this->months = $months;
-        $this->days = $days;
+    private function __construct(
+        private readonly int $years,
+        private readonly int $months,
+        private readonly int $days
+    ) {
     }
 
     /**

--- a/src/Period.php
+++ b/src/Period.php
@@ -29,7 +29,7 @@ final class Period implements JsonSerializable, Stringable
     private function __construct(
         private readonly int $years,
         private readonly int $months,
-        private readonly int $days
+        private readonly int $days,
     ) {
     }
 
@@ -297,7 +297,7 @@ final class Period implements JsonSerializable, Stringable
         return new Period(
             $this->years * $scalar,
             $this->months * $scalar,
-            $this->days * $scalar
+            $this->days * $scalar,
         );
     }
 
@@ -313,7 +313,7 @@ final class Period implements JsonSerializable, Stringable
         return new Period(
             -$this->years,
             -$this->months,
-            -$this->days
+            -$this->days,
         );
     }
 
@@ -367,7 +367,7 @@ final class Period implements JsonSerializable, Stringable
             '%d years %d months %d days',
             $this->years,
             $this->months,
-            $this->days
+            $this->days,
         ));
     }
 

--- a/src/TimeZoneOffset.php
+++ b/src/TimeZoneOffset.php
@@ -15,8 +15,6 @@ use DateTimeZone;
  */
 final class TimeZoneOffset extends TimeZone
 {
-    private readonly int $totalSeconds;
-
     /**
      * The string representation of this time-zone offset.
      *
@@ -31,9 +29,8 @@ final class TimeZoneOffset extends TimeZone
      *
      * @param int $totalSeconds The total offset in seconds, validated from -64800 to +64800.
      */
-    private function __construct(int $totalSeconds)
+    private function __construct(private readonly int $totalSeconds)
     {
-        $this->totalSeconds = $totalSeconds;
     }
 
     /**

--- a/src/TimeZoneOffset.php
+++ b/src/TimeZoneOffset.php
@@ -29,8 +29,9 @@ final class TimeZoneOffset extends TimeZone
      *
      * @param int $totalSeconds The total offset in seconds, validated from -64800 to +64800.
      */
-    private function __construct(private readonly int $totalSeconds)
-    {
+    private function __construct(
+        private readonly int $totalSeconds
+    ) {
     }
 
     /**

--- a/src/TimeZoneOffset.php
+++ b/src/TimeZoneOffset.php
@@ -30,7 +30,7 @@ final class TimeZoneOffset extends TimeZone
      * @param int $totalSeconds The total offset in seconds, validated from -64800 to +64800.
      */
     private function __construct(
-        private readonly int $totalSeconds
+        private readonly int $totalSeconds,
     ) {
     }
 

--- a/src/TimeZoneRegion.php
+++ b/src/TimeZoneRegion.php
@@ -17,14 +17,11 @@ use Exception;
  */
 final class TimeZoneRegion extends TimeZone
 {
-    private readonly DateTimeZone $zone;
-
     /**
      * Private constructor. Use a factory method to obtain an instance.
      */
-    private function __construct(DateTimeZone $zone)
+    private function __construct(private readonly DateTimeZone $zone)
     {
-        $this->zone = $zone;
     }
 
     /**

--- a/src/TimeZoneRegion.php
+++ b/src/TimeZoneRegion.php
@@ -21,7 +21,7 @@ final class TimeZoneRegion extends TimeZone
      * Private constructor. Use a factory method to obtain an instance.
      */
     private function __construct(
-        private readonly DateTimeZone $zone
+        private readonly DateTimeZone $zone,
     ) {
     }
 
@@ -67,7 +67,7 @@ final class TimeZoneRegion extends TimeZone
         return DateTimeZone::listIdentifiers(
             $includeObsolete
                 ? DateTimeZone::ALL_WITH_BC
-                : DateTimeZone::ALL
+                : DateTimeZone::ALL,
         );
     }
 

--- a/src/TimeZoneRegion.php
+++ b/src/TimeZoneRegion.php
@@ -20,8 +20,9 @@ final class TimeZoneRegion extends TimeZone
     /**
      * Private constructor. Use a factory method to obtain an instance.
      */
-    private function __construct(private readonly DateTimeZone $zone)
-    {
+    private function __construct(
+        private readonly DateTimeZone $zone
+    ) {
     }
 
     /**

--- a/src/Year.php
+++ b/src/Year.php
@@ -30,7 +30,7 @@ final class Year implements JsonSerializable, Stringable
      * @param int $year The year, validated.
      */
     private function __construct(
-        private readonly int $year
+        private readonly int $year,
     ) {
     }
 
@@ -275,7 +275,7 @@ final class Year implements JsonSerializable, Stringable
     {
         return LocalDateRange::of(
             $this->atMonth(1)->getFirstDay(),
-            $this->atMonth(12)->getLastDay()
+            $this->atMonth(12)->getLastDay(),
         );
     }
 

--- a/src/Year.php
+++ b/src/Year.php
@@ -29,8 +29,9 @@ final class Year implements JsonSerializable, Stringable
     /**
      * @param int $year The year, validated.
      */
-    private function __construct(private readonly int $year)
-    {
+    private function __construct(
+        private readonly int $year
+    ) {
     }
 
     /**

--- a/src/Year.php
+++ b/src/Year.php
@@ -27,16 +27,10 @@ final class Year implements JsonSerializable, Stringable
     public const MAX_VALUE = LocalDate::MAX_YEAR;
 
     /**
-     * The year being represented.
+     * @param int $year The year, validated.
      */
-    private readonly int $year;
-
-    /**
-     * @param int $year The year to represent, validated.
-     */
-    private function __construct(int $year)
+    private function __construct(private readonly int $year)
     {
-        $this->year = $year;
     }
 
     /**

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -25,23 +25,13 @@ use const STR_PAD_LEFT;
 final class YearMonth implements JsonSerializable, Stringable
 {
     /**
-     * The year, from MIN_YEAR to MAX_YEAR.
-     */
-    private readonly int $year;
-
-    /**
-     * The month, from 1 to 12.
-     */
-    private readonly int $month;
-
-    /**
      * @param int $year  The year, validated from MIN_YEAR to MAX_YEAR.
      * @param int $month The month, validated in the range 1 to 12.
      */
-    private function __construct(int $year, int $month)
-    {
-        $this->year = $year;
-        $this->month = $month;
+    private function __construct(
+        private readonly int $year,
+        private readonly int $month
+    ) {
     }
 
     /**

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -30,7 +30,7 @@ final class YearMonth implements JsonSerializable, Stringable
      */
     private function __construct(
         private readonly int $year,
-        private readonly int $month
+        private readonly int $month,
     ) {
     }
 
@@ -66,7 +66,7 @@ final class YearMonth implements JsonSerializable, Stringable
     {
         return YearMonth::of(
             (int) $result->getField(Field\Year::NAME),
-            (int) $result->getField(Field\MonthOfYear::NAME)
+            (int) $result->getField(Field\MonthOfYear::NAME),
         );
     }
 

--- a/src/YearMonthRange.php
+++ b/src/YearMonthRange.php
@@ -30,7 +30,7 @@ class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable, 
      */
     private function __construct(
         private readonly YearMonth $start,
-        private readonly YearMonth $end
+        private readonly YearMonth $end,
     ) {
     }
 
@@ -166,7 +166,7 @@ class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable, 
     {
         return LocalDateRange::of(
             $this->getStart()->getFirstDay(),
-            $this->getEnd()->getLastDay()
+            $this->getEnd()->getLastDay(),
         );
     }
 

--- a/src/YearMonthRange.php
+++ b/src/YearMonthRange.php
@@ -25,23 +25,13 @@ use Stringable;
 class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable, Stringable
 {
     /**
-     * The start year-month, inclusive.
-     */
-    private readonly YearMonth $start;
-
-    /**
-     * The end year-month, inclusive.
-     */
-    private readonly YearMonth $end;
-
-    /**
      * @param YearMonth $start The start year-month, inclusive.
      * @param YearMonth $end   The end year-month, inclusive, validated as not before the start year-month.
      */
-    private function __construct(YearMonth $start, YearMonth $end)
-    {
-        $this->start = $start;
-        $this->end = $end;
+    private function __construct(
+        private readonly YearMonth $start,
+        private readonly YearMonth $end
+    ) {
     }
 
     /**

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -29,7 +29,7 @@ final class YearWeek implements JsonSerializable, Stringable
      */
     private function __construct(
         private readonly int $year,
-        private readonly int $week
+        private readonly int $week,
     ) {
     }
 
@@ -57,7 +57,7 @@ final class YearWeek implements JsonSerializable, Stringable
     {
         return YearWeek::of(
             (int) $result->getField(Field\Year::NAME),
-            (int) $result->getField(Field\WeekOfYear::NAME)
+            (int) $result->getField(Field\WeekOfYear::NAME),
         );
     }
 

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -24,23 +24,13 @@ use const STR_PAD_LEFT;
 final class YearWeek implements JsonSerializable, Stringable
 {
     /**
-     * The year, from MIN_YEAR to MAX_YEAR.
-     */
-    private readonly int $year;
-
-    /**
-     * The week number, from 1 to 53. Must be valid for the year.
-     */
-    private readonly int $week;
-
-    /**
      * @param int $year The year, validated from MIN_YEAR to MAX_YEAR.
      * @param int $week The week number, validated in the range 1 to 53, and valid for the year.
      */
-    private function __construct(int $year, int $week)
-    {
-        $this->year = $year;
-        $this->week = $week;
+    private function __construct(
+        private readonly int $year,
+        private readonly int $week
+    ) {
     }
 
     /**

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -25,37 +25,21 @@ use function intdiv;
 class ZonedDateTime implements JsonSerializable, Stringable
 {
     /**
-     * The local date-time.
-     */
-    private readonly LocalDateTime $localDateTime;
-
-    /**
-     * The time-zone offset from UTC/Greenwich.
-     */
-    private readonly TimeZoneOffset $timeZoneOffset;
-
-    /**
-     * The time-zone.
-     *
-     * It is either a TimeZoneRegion if this ZonedDateTime is region-based,
-     * or the same instance as the offset if this ZonedDateTime is offset-based.
-     */
-    private readonly TimeZone $timeZone;
-
-    /**
-     * The instant represented by this ZonedDateTime.
-     */
-    private readonly Instant $instant;
-
-    /**
      * Private constructor. Use a factory method to obtain an instance.
+     *
+     * @param LocalDateTime  $localDateTime  The local date-time.
+     * @param TimeZoneOffset $timeZoneOffset The time-zone offset from UTC/Greenwich.
+     * @param TimeZone       $timeZone       The time-zone. It is either a TimeZoneRegion if this ZonedDateTime is
+     *                                       region-based, or the same instance as the offset if this ZonedDateTime
+     *                                       is offset-based.
+     * @param Instant        $instant        The instant represented by this ZonedDateTime.
      */
-    private function __construct(LocalDateTime $localDateTime, TimeZoneOffset $offset, TimeZone $zone, Instant $instant)
-    {
-        $this->localDateTime = $localDateTime;
-        $this->timeZone = $zone;
-        $this->timeZoneOffset = $offset;
-        $this->instant = $instant;
+    private function __construct(
+        private readonly LocalDateTime $localDateTime,
+        private readonly TimeZoneOffset $timeZoneOffset,
+        private readonly TimeZone $timeZone,
+        private readonly Instant $instant
+    ) {
     }
 
     /**

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -38,7 +38,7 @@ class ZonedDateTime implements JsonSerializable, Stringable
         private readonly LocalDateTime $localDateTime,
         private readonly TimeZoneOffset $timeZoneOffset,
         private readonly TimeZone $timeZone,
-        private readonly Instant $instant
+        private readonly Instant $instant,
     ) {
     }
 
@@ -148,7 +148,7 @@ class ZonedDateTime implements JsonSerializable, Stringable
 
         return ZonedDateTime::of(
             $localDateTime,
-            $timeZone
+            $timeZone,
         );
     }
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -10,7 +10,6 @@ use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalDateRange;
 use Brick\DateTime\LocalDateTime;
 use Brick\DateTime\LocalTime;
-use Brick\DateTime\Month;
 use Brick\DateTime\MonthDay;
 use Brick\DateTime\Period;
 use Brick\DateTime\TimeZone;

--- a/tests/InstantTest.php
+++ b/tests/InstantTest.php
@@ -531,7 +531,7 @@ class InstantTest extends AbstractTestCase
     {
         self::assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenInclusive(
             Instant::of(-1, -1),
-            Instant::of(1, 1)
+            Instant::of(1, 1),
         ));
     }
 
@@ -546,7 +546,7 @@ class InstantTest extends AbstractTestCase
     {
         self::assertSame($isBetween, Instant::of($seconds, $nanos)->isBetweenExclusive(
             Instant::of(-1, -1),
-            Instant::of(1, 1)
+            Instant::of(1, 1),
         ));
     }
 

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -46,7 +46,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval = Interval::of(
             Instant::of(2000000000),
-            Instant::of(2000000001)
+            Instant::of(2000000001),
         );
 
         $newInterval = $interval->withStart(Instant::of(1999999999, 999999999));
@@ -69,7 +69,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval = Interval::of(
             Instant::of(2000000000),
-            Instant::of(2000000001)
+            Instant::of(2000000001),
         );
 
         $newInterval = $interval->withEnd(Instant::of(2000000002, 222222222));
@@ -89,7 +89,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval = Interval::of(
             Instant::of(1999999999, 555555),
-            Instant::of(2000000001, 111)
+            Instant::of(2000000001, 111),
         );
 
         $duration = $interval->getDuration();
@@ -178,7 +178,7 @@ class IntervalTest extends AbstractTestCase
         int $start2,
         int $end2,
         int $expectedStart,
-        int $expectedEnd
+        int $expectedEnd,
     ): void {
         $interval1 = Interval::of(Instant::of($start1), Instant::of($end1));
         $interval2 = Interval::of(Instant::of($start2), Instant::of($end2));
@@ -267,7 +267,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval = Interval::of(
             Instant::of($epochSecondStart),
-            Instant::of($epochSecondEnd)
+            Instant::of($epochSecondEnd),
         );
 
         self::assertSame(json_encode($expectedString, JSON_THROW_ON_ERROR), json_encode($interval, JSON_THROW_ON_ERROR));
@@ -278,7 +278,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval = Interval::of(
             Instant::of($epochSecondStart),
-            Instant::of($epochSecondEnd)
+            Instant::of($epochSecondEnd),
         );
 
         self::assertSame($expectedString, $interval->toISOString());
@@ -289,7 +289,7 @@ class IntervalTest extends AbstractTestCase
     {
         $interval = Interval::of(
             Instant::of($epochSecondStart),
-            Instant::of($epochSecondEnd)
+            Instant::of($epochSecondEnd),
         );
 
         self::assertSame($expectedString, (string) $interval);

--- a/tests/LocalDateRangeTest.php
+++ b/tests/LocalDateRangeTest.php
@@ -25,7 +25,7 @@ class LocalDateRangeTest extends AbstractTestCase
     {
         self::assertLocalDateRangeIs(2001, 2, 3, 2004, 5, 6, LocalDateRange::of(
             LocalDate::of(2001, 2, 3),
-            LocalDate::of(2004, 5, 6)
+            LocalDate::of(2004, 5, 6),
         ));
     }
 
@@ -35,7 +35,7 @@ class LocalDateRangeTest extends AbstractTestCase
 
         LocalDateRange::of(
             LocalDate::of(2001, 2, 3),
-            LocalDate::of(2001, 2, 2)
+            LocalDate::of(2001, 2, 2),
         );
     }
 
@@ -101,7 +101,7 @@ class LocalDateRangeTest extends AbstractTestCase
     {
         self::assertSame($isEqual, LocalDateRange::of(
             LocalDate::of(2001, 2, 3),
-            LocalDate::of(2004, 5, 6)
+            LocalDate::of(2004, 5, 6),
         )->isEqualTo(LocalDateRange::parse($testRange)));
     }
 
@@ -199,11 +199,11 @@ class LocalDateRangeTest extends AbstractTestCase
         int $yearEnd,
         int $monthEnd,
         int $dayEnd,
-        string $expectedString
+        string $expectedString,
     ): void {
         $dateRange = LocalDateRange::of(
             LocalDate::of($yearStart, $monthStart, $dayStart),
-            LocalDate::of($yearEnd, $monthEnd, $dayEnd)
+            LocalDate::of($yearEnd, $monthEnd, $dayEnd),
         );
 
         self::assertSame(json_encode($expectedString, JSON_THROW_ON_ERROR), json_encode($dateRange, JSON_THROW_ON_ERROR));
@@ -217,11 +217,11 @@ class LocalDateRangeTest extends AbstractTestCase
         int $yearEnd,
         int $monthEnd,
         int $dayEnd,
-        string $expectedString
+        string $expectedString,
     ): void {
         $dateRange = LocalDateRange::of(
             LocalDate::of($yearStart, $monthStart, $dayStart),
-            LocalDate::of($yearEnd, $monthEnd, $dayEnd)
+            LocalDate::of($yearEnd, $monthEnd, $dayEnd),
         );
 
         self::assertSame($expectedString, $dateRange->toISOString());
@@ -235,11 +235,11 @@ class LocalDateRangeTest extends AbstractTestCase
         int $yearEnd,
         int $monthEnd,
         int $dayEnd,
-        string $expectedString
+        string $expectedString,
     ): void {
         $dateRange = LocalDateRange::of(
             LocalDate::of($yearStart, $monthStart, $dayStart),
-            LocalDate::of($yearEnd, $monthEnd, $dayEnd)
+            LocalDate::of($yearEnd, $monthEnd, $dayEnd),
         );
 
         self::assertSame($expectedString, (string) $dateRange);

--- a/tests/YearMonthRangeTest.php
+++ b/tests/YearMonthRangeTest.php
@@ -22,7 +22,7 @@ class YearMonthRangeTest extends AbstractTestCase
     {
         self::assertYearMonthRangeIs(2001, 2, 2004, 5, YearMonthRange::of(
             YearMonth::of(2001, 2),
-            YearMonth::of(2004, 5)
+            YearMonth::of(2004, 5),
         ));
     }
 
@@ -32,7 +32,7 @@ class YearMonthRangeTest extends AbstractTestCase
 
         YearMonthRange::of(
             YearMonth::of(2001, 3),
-            YearMonth::of(2001, 2)
+            YearMonth::of(2001, 2),
         );
     }
 
@@ -92,7 +92,7 @@ class YearMonthRangeTest extends AbstractTestCase
     {
         self::assertSame($isEqual, YearMonthRange::of(
             YearMonth::of(2001, 2),
-            YearMonth::of(2004, 5)
+            YearMonth::of(2004, 5),
         )->isEqualTo(YearMonthRange::parse($testRange)));
     }
 
@@ -204,7 +204,7 @@ class YearMonthRangeTest extends AbstractTestCase
     {
         $yearMonthRange = YearMonthRange::of(
             YearMonth::of($yearStart, $monthStart),
-            YearMonth::of($yearEnd, $monthEnd)
+            YearMonth::of($yearEnd, $monthEnd),
         );
 
         self::assertSame(json_encode($expectedString, JSON_THROW_ON_ERROR), json_encode($yearMonthRange, JSON_THROW_ON_ERROR));
@@ -215,7 +215,7 @@ class YearMonthRangeTest extends AbstractTestCase
     {
         $yearMonthRange = YearMonthRange::of(
             YearMonth::of($yearStart, $monthStart),
-            YearMonth::of($yearEnd, $monthEnd)
+            YearMonth::of($yearEnd, $monthEnd),
         );
 
         self::assertSame($expectedString, $yearMonthRange->toISOString());
@@ -226,7 +226,7 @@ class YearMonthRangeTest extends AbstractTestCase
     {
         $yearMonthRange = YearMonthRange::of(
             YearMonth::of($yearStart, $monthStart),
-            YearMonth::of($yearEnd, $monthEnd)
+            YearMonth::of($yearEnd, $monthEnd),
         );
 
         self::assertSame($expectedString, (string) $yearMonthRange);

--- a/tools/ecs/ecs.php
+++ b/tools/ecs/ecs.php
@@ -92,7 +92,7 @@ return static function (ECSConfig $ecsConfig): void {
             $libRootPath . '/src',
             $libRootPath . '/tests',
             __FILE__,
-        ]
+        ],
     );
 
     $ecsConfig->indentation('spaces');
@@ -193,11 +193,11 @@ return static function (ECSConfig $ecsConfig): void {
             UnaryOperatorSpacesFixer::class,
             WhitespaceAfterCommaInArrayFixer::class,
             NoTrailingCommaInSinglelineArrayFixer::class,
-            TrailingCommaInMultilineFixer::class,
             StandaloneLinePromotedPropertyFixer::class,
-        ]
+        ],
     );
 
+    $ecsConfig->ruleWithConfiguration(TrailingCommaInMultilineFixer::class, ['elements' => ['arrays', 'arguments', 'parameters']]);
     $ecsConfig->ruleWithConfiguration(ListSyntaxFixer::class, ['syntax' => 'short']);
     $ecsConfig->ruleWithConfiguration(MethodArgumentSpaceFixer::class, ['on_multiline' => 'ensure_fully_multiline']);
     $ecsConfig->ruleWithConfiguration(OrderedClassElementsFixer::class, ['order' => ['use_trait', 'case', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'phpunit', 'method_public', 'magic', 'method_protected', 'method_private', 'destruct']]);
@@ -212,7 +212,7 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->rules(
         [
             FunctionCommentSniff::class,
-        ]
+        ],
     );
 
     $ecsConfig->ruleWithConfiguration(
@@ -228,7 +228,7 @@ return static function (ECSConfig $ecsConfig): void {
                 '@return',
                 '@throws',
             ],
-        ]
+        ],
     );
 
     $ecsConfig->ruleWithConfiguration(
@@ -243,7 +243,7 @@ return static function (ECSConfig $ecsConfig): void {
             'allowFullyQualifiedNameForCollidingConstants' => true,
             'allowFullyQualifiedNameForCollidingFunctions' => true,
             'searchAnnotations' => true,
-        ]
+        ],
     );
 
     $ecsConfig->ruleWithConfiguration(
@@ -252,6 +252,6 @@ return static function (ECSConfig $ecsConfig): void {
             'linesCountAfterLastUse' => 0,
             'linesCountBetweenUseTypes' => 1,
             'linesCountBeforeFirstUse' => 0,
-        ]
+        ],
     );
 };

--- a/tools/ecs/ecs.php
+++ b/tools/ecs/ecs.php
@@ -80,6 +80,7 @@ use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UseSpacingSniff;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -193,6 +194,7 @@ return static function (ECSConfig $ecsConfig): void {
             WhitespaceAfterCommaInArrayFixer::class,
             NoTrailingCommaInSinglelineArrayFixer::class,
             TrailingCommaInMultilineFixer::class,
+            StandaloneLinePromotedPropertyFixer::class,
         ]
     );
 

--- a/tools/rector/composer.json
+++ b/tools/rector/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "rector/rector": "^1.0"
+    }
+}

--- a/tools/rector/rector.php
+++ b/tools/rector/rector.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+use Rector\Config\RectorConfig;
+
+$root = dirname(__DIR__, 2);
+
+return RectorConfig::configure()
+    ->withPaths([
+        $root . '/src',
+        $root . '/tests',
+        $root . '/tools',
+    ])
+    ->withSkip([
+        $root . '/tools/ecs/vendor',
+        $root . '/tools/rector/vendor',
+
+        // This one does not really match with the project's code style
+        SimplifyUselessVariableRector::class,
+    ])
+    ->withPhpSets()
+    ->withImportNames(importNames: false, removeUnusedImports: true);


### PR DESCRIPTION
Hello there! I've noticed that the project was not using promoted properties, even though its minimum PHP version supports them. Yet it's using readonly properties already. So I thought it would be a good idea to add Rector in the project to allow doing automated refactorings to keep the codebase up-to-date.

With the current config file, if you bump the minimum PHP version in `composer.json`, it will apply the refactorings that can be done in the new PHP version, making sure the code is always the latest and brightest.

cf. https://getrector.com/documentation/integration-to-new-project

Let me know what you think.

### TODO
- [x] Install Rector in `tools/` (to be run with `tools/rector/vendor/bin/rector process -c tools/rector/rector.php`)
- [x] PHP 5.3 - 5.6 (nothing changed)
- [x] PHP 7.0 - 7.4 (nothing changed)
- [x] PHP 8.0 :
  - [x] `ClassPropertyAssignToConstructorPromotionRector` applied (I made my best to keep the most complete comments around)
- [x] PHP 8.1 (nothing changed)
- [x] Add type coverage at maximum level
- [x] Add dead code at maximum level
  - [x] ~`SimplifyUselessVariableRector`~ skipped
- [x] ECS: apply `TrailingCommaInMultilineFixer` for everything