### PR TITLE
Fix Month enum argument deprecations within the library itself.

### DIFF
--- a/src/Field/WeekOfYear.php
+++ b/src/Field/WeekOfYear.php
@@ -7,6 +7,7 @@ namespace Brick\DateTime\Field;
 use Brick\DateTime\DateTimeException;
 use Brick\DateTime\DayOfWeek;
 use Brick\DateTime\LocalDate;
+use Brick\DateTime\Month;
 
 /**
  * The week-of-year field.
@@ -51,7 +52,7 @@ final class WeekOfYear
      */
     public static function is53WeekYear(int $year): bool
     {
-        $date = LocalDate::of($year, 1, 1);
+        $date = LocalDate::of($year, Month::JANUARY, 1);
         $dayOfWeek = $date->getDayOfWeek();
 
         return $dayOfWeek === DayOfWeek::THURSDAY

--- a/src/LocalDateTime.php
+++ b/src/LocalDateTime.php
@@ -16,6 +16,10 @@ use JsonSerializable;
 use Stringable;
 
 use function intdiv;
+use function is_int;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * A date-time without a time-zone in the ISO-8601 calendar system, such as 2007-12-03T10:15:30.
@@ -32,7 +36,6 @@ final class LocalDateTime implements JsonSerializable, Stringable
 
     /**
      * @param int $year   The year, from MIN_YEAR to MAX_YEAR.
-     * @param int $month  The month-of-year, from 1 (January) to 12 (December).
      * @param int $day    The day-of-month, from 1 to 31.
      * @param int $hour   The hour-of-day, from 0 to 23.
      * @param int $minute The minute-of-hour, from 0 to 59.
@@ -41,8 +44,14 @@ final class LocalDateTime implements JsonSerializable, Stringable
      *
      * @throws DateTimeException If the date or time is not valid.
      */
-    public static function of(int $year, int $month, int $day, int $hour = 0, int $minute = 0, int $second = 0, int $nano = 0): LocalDateTime
+    public static function of(int $year, Month|int $month, int $day, int $hour = 0, int $minute = 0, int $second = 0, int $nano = 0): LocalDateTime
     {
+        if (is_int($month)) {
+            // usually we don't use trigger_error() for deprecations, but we can't rely on @deprecated for a parameter type change;
+            // maybe we should revisit using trigger_error() unconditionally for deprecations in the future.
+            trigger_error('Passing an integer to LocalDateTime::of() is deprecated, pass a Month instance instead.', E_USER_DEPRECATED);
+        }
+
         $date = LocalDate::of($year, $month, $day);
         $time = LocalTime::of($hour, $minute, $second, $nano);
 
@@ -306,8 +315,14 @@ final class LocalDateTime implements JsonSerializable, Stringable
      *
      * @throws DateTimeException If the month is invalid.
      */
-    public function withMonth(int $month): LocalDateTime
+    public function withMonth(Month|int $month): LocalDateTime
     {
+        if (is_int($month)) {
+            // usually we don't use trigger_error() for deprecations, but we can't rely on @deprecated for a parameter type change;
+            // maybe we should revisit using trigger_error() unconditionally for deprecations in the future.
+            trigger_error('Passing an integer to LocalDateTime::withMonth() is deprecated, pass a Month instance instead.', E_USER_DEPRECATED);
+        }
+
         $date = $this->date->withMonth($month);
 
         if ($date === $this->date) {

--- a/src/LocalTime.php
+++ b/src/LocalTime.php
@@ -607,7 +607,7 @@ final class LocalTime implements JsonSerializable, Stringable
      */
     public function toNativeDateTime(): DateTime
     {
-        return $this->atDate(LocalDate::of(0, 1, 1))->toNativeDateTime();
+        return $this->atDate(LocalDate::of(0, Month::JANUARY, 1))->toNativeDateTime();
     }
 
     /**

--- a/src/Year.php
+++ b/src/Year.php
@@ -252,7 +252,7 @@ final class Year implements JsonSerializable, Stringable
             $month = Month::from($month);
         }
 
-        return YearMonth::of($this->year, $month->value);
+        return YearMonth::of($this->year, $month);
     }
 
     /**
@@ -274,8 +274,8 @@ final class Year implements JsonSerializable, Stringable
     public function toLocalDateRange(): LocalDateRange
     {
         return LocalDateRange::of(
-            $this->atMonth(1)->getFirstDay(),
-            $this->atMonth(12)->getLastDay(),
+            $this->atMonth(Month::JANUARY)->getFirstDay(),
+            $this->atMonth(Month::DECEMBER)->getLastDay(),
         );
     }
 

--- a/src/YearMonth.php
+++ b/src/YearMonth.php
@@ -64,10 +64,13 @@ final class YearMonth implements JsonSerializable, Stringable
      */
     public static function from(DateTimeParseResult $result): YearMonth
     {
-        return YearMonth::of(
-            (int) $result->getField(Field\Year::NAME),
-            (int) $result->getField(Field\MonthOfYear::NAME),
-        );
+        $year = (int) $result->getField(Field\Year::NAME);
+        $month = (int) $result->getField(Field\MonthOfYear::NAME);
+
+        Field\Year::check($year);
+        Field\MonthOfYear::check($month);
+
+        return new YearMonth($year, $month);
     }
 
     /**
@@ -253,7 +256,7 @@ final class YearMonth implements JsonSerializable, Stringable
      */
     public function atDay(int $day): LocalDate
     {
-        return LocalDate::of($this->year, $this->month, $day);
+        return LocalDate::of($this->year, Month::from($this->month), $day);
     }
 
     /**

--- a/src/YearMonthRange.php
+++ b/src/YearMonthRange.php
@@ -66,7 +66,11 @@ class YearMonthRange implements IteratorAggregate, Countable, JsonSerializable, 
         if ($result->hasField(Field\Year::NAME)) {
             $end = YearMonth::from($result);
         } else {
-            $end = $start->withMonth((int) $result->getField(Field\MonthOfYear::NAME));
+            $month = (int) $result->getField(Field\MonthOfYear::NAME);
+
+            Field\MonthOfYear::check($month);
+
+            $end = $start->withMonth(Month::from($month));
         }
 
         return YearMonthRange::of($start, $end);

--- a/src/YearWeek.php
+++ b/src/YearWeek.php
@@ -206,7 +206,7 @@ final class YearWeek implements JsonSerializable, Stringable
             $dayOfWeek = DayOfWeek::from($dayOfWeek);
         }
 
-        $correction = LocalDate::of($this->year, 1, 4)->getDayOfWeek()->value + 3;
+        $correction = LocalDate::of($this->year, Month::JANUARY, 4)->getDayOfWeek()->value + 3;
         $dayOfYear = $this->week * 7 + $dayOfWeek->value - $correction;
         $maxDaysOfYear = Field\Year::isLeap($this->year) ? 366 : 365;
 

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -15,6 +15,10 @@ use JsonSerializable;
 use Stringable;
 
 use function intdiv;
+use function is_int;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * A date-time with a time-zone in the ISO-8601 calendar system.
@@ -347,8 +351,14 @@ class ZonedDateTime implements JsonSerializable, Stringable
     /**
      * Returns a copy of this ZonedDateTime with the month-of-year altered.
      */
-    public function withMonth(int $month): ZonedDateTime
+    public function withMonth(Month|int $month): ZonedDateTime
     {
+        if (is_int($month)) {
+            // usually we don't use trigger_error() for deprecations, but we can't rely on @deprecated for a parameter type change;
+            // maybe we should revisit using trigger_error() unconditionally for deprecations in the future.
+            trigger_error('Passing an integer to ZonedDateTime::withMonth() is deprecated, pass a Month instance instead.', E_USER_DEPRECATED);
+        }
+
         return ZonedDateTime::of($this->localDateTime->withMonth($month), $this->timeZone);
     }
 

--- a/tests/LocalDateTest.php
+++ b/tests/LocalDateTest.php
@@ -10,6 +10,7 @@ use Brick\DateTime\DayOfWeek;
 use Brick\DateTime\Instant;
 use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalTime;
+use Brick\DateTime\Month;
 use Brick\DateTime\Period;
 use Brick\DateTime\TimeZone;
 use Brick\DateTime\Year;
@@ -540,8 +541,8 @@ class LocalDateTest extends AbstractTestCase
      */
     public function testWithMonth(int $year, int $month, int $day, int $newMonth, int $expectedDay): void
     {
-        $localDate = LocalDate::of($year, $month, $day)->withMonth($newMonth);
-        self::assertLocalDateIs($year, $newMonth, $expectedDay, $localDate);
+        self::assertLocalDateIs($year, $newMonth, $expectedDay, LocalDate::of($year, $month, $day)->withMonth($newMonth));
+        self::assertLocalDateIs($year, $newMonth, $expectedDay, LocalDate::of($year, $month, $day)->withMonth(Month::from($newMonth)));
     }
 
     public static function providerWithMonth(): array

--- a/tests/LocalDateTimeTest.php
+++ b/tests/LocalDateTimeTest.php
@@ -13,6 +13,7 @@ use Brick\DateTime\Instant;
 use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalDateTime;
 use Brick\DateTime\LocalTime;
+use Brick\DateTime\Month;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Period;
 use Brick\DateTime\TimeZone;
@@ -361,10 +362,13 @@ class LocalDateTimeTest extends AbstractTestCase
      */
     public function testWithMonth(int $year, int $month, int $day, int $newMonth, int $expectedDay): void
     {
-        $date = LocalDate::of($year, $month, $day);
         $time = LocalTime::of(1, 2, 3, 123456789);
-        $localDateTime = $date->atTime($time)->withMonth($newMonth);
-        self::assertLocalDateTimeIs($year, $newMonth, $expectedDay, 1, 2, 3, 123456789, $localDateTime);
+
+        $date = LocalDate::of($year, $month, $day);
+        self::assertLocalDateTimeIs($year, $newMonth, $expectedDay, 1, 2, 3, 123456789, $date->atTime($time)->withMonth($newMonth));
+
+        $date = LocalDate::of($year, Month::from($month), $day);
+        self::assertLocalDateTimeIs($year, $newMonth, $expectedDay, 1, 2, 3, 123456789, $date->atTime($time)->withMonth($newMonth));
     }
 
     public static function providerWithMonth(): array

--- a/tests/MonthDayTest.php
+++ b/tests/MonthDayTest.php
@@ -7,6 +7,7 @@ namespace Brick\DateTime\Tests;
 use Brick\DateTime\Clock\FixedClock;
 use Brick\DateTime\DateTimeException;
 use Brick\DateTime\Instant;
+use Brick\DateTime\Month;
 use Brick\DateTime\MonthDay;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\TimeZone;
@@ -293,10 +294,10 @@ class MonthDayTest extends AbstractTestCase
     public function testWithMonth(int $month, int $day, int $newMonth, int $expectedDay): void
     {
         $monthDay = MonthDay::of($month, $day);
-        $newMonthDay = $monthDay->withMonth($newMonth);
-
         self::assertMonthDayIs($month, $day, $monthDay);
-        self::assertMonthDayIs($newMonth, $expectedDay, $newMonthDay);
+
+        self::assertMonthDayIs($newMonth, $expectedDay, $monthDay->withMonth($newMonth));
+        self::assertMonthDayIs($newMonth, $expectedDay, $monthDay->withMonth(Month::from($newMonth)));
     }
 
     public static function providerWithMonth(): array

--- a/tests/ZonedDateTimeTest.php
+++ b/tests/ZonedDateTimeTest.php
@@ -12,6 +12,7 @@ use Brick\DateTime\Instant;
 use Brick\DateTime\LocalDate;
 use Brick\DateTime\LocalDateTime;
 use Brick\DateTime\LocalTime;
+use Brick\DateTime\Month;
 use Brick\DateTime\Parser\DateTimeParseException;
 use Brick\DateTime\Period;
 use Brick\DateTime\TimeZone;
@@ -591,6 +592,7 @@ class ZonedDateTimeTest extends AbstractTestCase
     public function testWithMonth(): void
     {
         self::assertIs(ZonedDateTime::class, '2000-07-20T12:34:56.123456789-07:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withMonth(7));
+        self::assertIs(ZonedDateTime::class, '2000-07-20T12:34:56.123456789-07:00[America/Los_Angeles]', $this->getTestZonedDateTime()->withMonth(Month::JULY));
     }
 
     public function testWithDay(): void


### PR DESCRIPTION
Hello @BenMorel ,

I tried upgrading to 0.6.1 in our project, but it [broke our Behat test suite](https://stackoverflow.com/a/31059663) because the library in itself is now triggering tons of deprecations via `trigger_error()`. Anyway, I tried to "finish the job" of using `Month` wherever there is a month concerned within the library itself, while leaving the usages of the `|int` alternative in the tests to make sure it still works.

I also had to use the `Field\MonthOfYear::check($month);` line *before* creating the Enum to keep the currently throwned `DateTimeException`, otherwise it would throw a PHP `ValueError` when given invalid values to `BackendEnum::from()`.

Let me know what you think. I had to rush it quite a bit, so there's probably room for improvements. I'm not a fan of how the code looks right now, because of this compatibility layer, and even more because we don't store the Month instance internally, forcing to recreate it in a lot of places. But I'm also glad we don't change that, as already discussed. :sweat_smile: 