### PR TITLE
Add a helper TimeZone::fromDefaultTimeZone static constructor

### DIFF
--- a/src/TimeZone.php
+++ b/src/TimeZone.php
@@ -9,6 +9,8 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Stringable;
 
+use function date_default_timezone_get;
+
 use const PHP_VERSION_ID;
 
 /**
@@ -86,6 +88,11 @@ abstract class TimeZone implements Stringable
         }
 
         return $parsed;
+    }
+
+    public static function fromDefaultTimeZone(): TimeZone
+    {
+        return static::fromNativeDateTimeZone(new DateTimeZone(date_default_timezone_get()));
     }
 
     /**

--- a/tests/TimeZoneTest.php
+++ b/tests/TimeZoneTest.php
@@ -11,6 +11,8 @@ use Brick\DateTime\TimeZoneRegion;
 use DateTimeZone;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+use function date_default_timezone_get;
+
 use const PHP_VERSION_ID;
 
 /**
@@ -100,5 +102,15 @@ class TimeZoneTest extends AbstractTestCase
         if (PHP_VERSION_ID >= 80107) {
             yield ['-02:30:30'];
         }
+    }
+
+    public function testFromDefaultTimeZone(): void
+    {
+        $defaultTimeZone = date_default_timezone_get();
+
+        $timeZone = TimeZone::fromDefaultTimeZone();
+
+        self::assertInstanceOf(TimeZone::class, $timeZone);
+        self::assertSame($defaultTimeZone, $timeZone->getId());
     }
 }


### PR DESCRIPTION
Not sure if with false return from the function, it would't be better to throw an exception.

Also, maybe `TimeZone::fromDefault` would be a more comfortable naming?