### PR TITLE
Ignore mac .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor
 /composer.lock
 /.phpunit.cache
+.DS_Store
 
 # https://stackoverflow.com/a/16318111
 /tools/*


### PR DESCRIPTION
@BenMorel .DS_Store files usually added automatically by MacOS X. It's pretty usual to ignore them.